### PR TITLE
Delete the CRD definition when the operator is stopped

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -136,10 +136,10 @@ func newSparkApplicationController(
 func (s *SparkApplicationController) Start(workers int, stopCh <-chan struct{}) error {
 	glog.Info("Starting the SparkApplication controller")
 
-	glog.Infof("Creating the CustomResourceDefinition %s", crd.FullName)
+	glog.Infof("Creating CustomResourceDefinition %s", crd.FullName)
 	err := crd.CreateCRD(s.extensionsClient)
 	if err != nil {
-		return fmt.Errorf("failed to create the CustomResourceDefinition %s: %v", crd.FullName, err)
+		return fmt.Errorf("failed to create CustomResourceDefinition %s: %v", crd.FullName, err)
 	}
 
 	glog.Info("Starting the SparkApplication informer")
@@ -169,6 +169,10 @@ func (s *SparkApplicationController) Start(workers int, stopCh <-chan struct{}) 
 func (s *SparkApplicationController) Stop() {
 	glog.Info("Stopping the SparkApplication controller")
 	s.queue.ShutDown()
+	glog.Infof("Deleting CustomResourceDefinition %s", crd.FullName)
+	if err := crd.DeleteCRD(s.extensionsClient); err != nil {
+		glog.Errorf("failed to delete CustomResourceDefinition %s: %v", crd.FullName, err)
+	}
 }
 
 // Callback function called when a new SparkApplication object gets created.

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -87,6 +87,17 @@ func CreateCRD(clientset apiextensionsclient.Interface) error {
 	return nil
 }
 
+func DeleteCRD(clientset apiextensionsclient.Interface) error {
+	var zero int64 = 0
+	err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(FullName,
+		&metav1.DeleteOptions{GracePeriodSeconds: &zero})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
 func getCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	return clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(FullName, metav1.GetOptions{})
 }

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -210,9 +210,10 @@ func (ic *SparkPodInitializer) addInitializationConfig() error {
 
 func (ic *SparkPodInitializer) deleteInitializationConfig() error {
 	glog.Infof("Deleting the InitializerConfiguration %s", sparkPodInitializerConfigName)
+	var zero int64 = 0
 	err := ic.kubeClient.AdmissionregistrationV1alpha1().InitializerConfigurations().Delete(
 		sparkPodInitializerConfigName,
-		&metav1.DeleteOptions{})
+		&metav1.DeleteOptions{GracePeriodSeconds: &zero})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete InitializerConfiguration: %v", err)
 	}


### PR DESCRIPTION
When the operator is stopped and started, the CRD definition stays the same. There is a problem with this: changes to the CRD definition won't take effect if the definition is not updated to the API server. Deleting the definition when the operator stops and recreating it when the operator starts effectively updates the definition.