### PR TITLE
Added support for SparkApplication updates

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
@@ -158,15 +158,15 @@ const (
 type SparkApplicationStatus struct {
 	// AppId is the application ID that's also added as a label to the SparkApplication object
 	// and driver and executor Pods, and is used to group the objects for the same application.
-	AppID string `json:"appId"`
+	AppID string `json:"appId,omitempty"`
 	// SubmissionTime is the time when the application is submitted.
-	SubmissionTime metav1.Time `json:"submissionTime"`
+	SubmissionTime metav1.Time `json:"submissionTime,omitempty"`
 	// CompletionTime is the time when the application runs to completion if it does.
-	CompletionTime metav1.Time `json:"completionTime"`
+	CompletionTime metav1.Time `json:"completionTime,omitempty"`
 	// DriverInfo has information about the driver.
 	DriverInfo DriverInfo `json:"driverInfo"`
 	// AppState tells the overall application state.
-	AppState ApplicationState `json:"applicationState"`
+	AppState ApplicationState `json:"applicationState,omitempty"`
 	// ExecutorState records the state of executors by executor Pod names.
 	ExecutorState map[string]ExecutorState `json:"executorState,omitempty"`
 	// SubmissionRetries is the number of retries attempted for a failed submission.
@@ -282,10 +282,10 @@ const (
 
 // DriverInfo captures information about the driver.
 type DriverInfo struct {
-	WebUIServiceName string `json:"webUIServiceName"`
-	WebUIPort        int32  `json:"webUIPort"`
-	WebUIAddress     string `json:"webUIAddress"`
-	PodName          string `json:"podName"`
+	WebUIServiceName string `json:"webUIServiceName,omitempty"`
+	WebUIPort        int32  `json:"webUIPort,omitempty"`
+	WebUIAddress     string `json:"webUIAddress,omitempty"`
+	PodName          string `json:"podName,omitempty"`
 }
 
 // SecretInfo captures information of a secret.

--- a/pkg/controller/spark_pod_monitor.go
+++ b/pkg/controller/spark_pod_monitor.go
@@ -50,6 +50,7 @@ type sparkPodMonitor struct {
 type driverStateUpdate struct {
 	appNamespace   string         // Namespace in which the application and driver pod run.
 	appName        string         // Name of the application.
+	appID          string         // Application ID.
 	podName        string         // Name of the driver pod.
 	nodeName       string         // Name of the node the driver pod runs on.
 	podPhase       apiv1.PodPhase // Driver pod phase.
@@ -60,6 +61,7 @@ type driverStateUpdate struct {
 type executorStateUpdate struct {
 	appNamespace string                 // Namespace in which the application and executor pods run.
 	appName      string                 // Name of the application.
+	appID        string                 // Application ID.
 	podName      string                 // Name of the executor pod.
 	executorID   string                 // Spark executor ID.
 	state        v1alpha1.ExecutorState // Executor state.
@@ -173,6 +175,7 @@ func (s *sparkPodMonitor) updateDriverState(pod *apiv1.Pod) {
 		update := driverStateUpdate{
 			appNamespace: pod.Namespace,
 			appName:      appName,
+			appID:        getAppID(pod),
 			podName:      pod.Name,
 			nodeName:     pod.Spec.NodeName,
 			podPhase:     pod.Status.Phase,
@@ -190,6 +193,7 @@ func (s *sparkPodMonitor) updateExecutorState(pod *apiv1.Pod) {
 		s.podStateReportingChan <- &executorStateUpdate{
 			appNamespace: pod.Namespace,
 			appName:      appName,
+			appID:        getAppID(pod),
 			podName:      pod.Name,
 			executorID:   getExecutorID(pod),
 			state:        podPhaseToExecutorState(pod.Status.Phase),
@@ -200,6 +204,10 @@ func (s *sparkPodMonitor) updateExecutorState(pod *apiv1.Pod) {
 func getAppName(pod *apiv1.Pod) (string, bool) {
 	appName, ok := pod.Labels[config.SparkAppNameLabel]
 	return appName, ok
+}
+
+func getAppID(pod *apiv1.Pod) string {
+	return pod.Labels[config.SparkAppIDLabel]
 }
 
 func isDriverPod(pod *apiv1.Pod) bool {


### PR DESCRIPTION
When an upate to a SparkApplication object is received, the controller checks if the update was to the specification, and if so, kills the old run of the application by deleting the driver pod of the old run and submits the new run.

Ref #83 .