### PR TITLE
Check condition for submission in onAdd

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/defaults.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
+// SetSparkApplicationDefaults sets default values for certain fields of a SparkApplication.
 func SetSparkApplicationDefaults(app *SparkApplication) {
 	if app == nil {
 		return
@@ -27,16 +28,6 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 
 	if app.Spec.RestartPolicy == "" {
 		app.Spec.RestartPolicy = Never
-	}
-
-	if app.Spec.MaxSubmissionRetries == nil {
-		app.Spec.MaxSubmissionRetries = new(int32)
-		*app.Spec.MaxSubmissionRetries = 3
-	}
-
-	if app.Spec.SubmissionRetryInterval == nil {
-		app.Spec.SubmissionRetryInterval = new(int64)
-		*app.Spec.SubmissionRetryInterval = 300
 	}
 
 	setDriverSpecDefaults(app.Spec.Driver)


### PR DESCRIPTION
Instead of blindly submitting an application to run when `onAdd` is called, the controller checks if it should submit by testing if any of the following submission conditions is satisfied.  
* The application has not been submitted to run, i.e., its state is empty or `NEW`.
* The application has terminated and is subject to restart based on the observed application state and restart policy.
* The application has failed submission and is subject to submission retry based on the observed application state and submission failure tracking information. 

This is necessary for #90.