### PR TITLE
Explicitly delete the driver pod and UI service when a SparkApp gets deleted

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -244,6 +244,11 @@ func (c *Controller) onDelete(obj interface{}) {
 			"SparkApplicationDeleted",
 			"SparkApplication %s was deleted",
 			app.Name)
+
+		if err := c.deleteDriverAndUIService(app, false); err != nil {
+			glog.Errorf("failed to delete the driver pod and UI service for deleted SparkApplication %s: $v",
+				app.Name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #167.

@scotthew1