### PR TITLE
Add s3 support for staging local dependencies in sparkctl #144

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -65,6 +65,12 @@
   version = "v1.14.6"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -136,6 +142,19 @@
   ]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/google/go-cloud"
+  packages = [
+    "blob",
+    "blob/driver",
+    "blob/gcsblob",
+    "blob/s3blob",
+    "gcp",
+    "wire"
+  ]
+  revision = "354ed1d60b1bb1e190b483a8e8ce88053f83e904"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
@@ -738,6 +757,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5233e038fedfc1ab3f03e8752a5a58e7749bc05b96ab4a924ce0c3781666771b"
+  inputs-digest = "9b7963ba9e67b29c9399a2c397b014720db36b9d0f8f03e13091c8274607f808"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,10 +26,43 @@
   version = "v9.10.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/beorn7/perks"
-  packages = ["quantile"]
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/sts"
+  ]
+  revision = "92c96c4f5ad419f2a72401c2f606d51e010cc110"
+  version = "v1.14.6"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -63,6 +96,12 @@
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
+  version = "v1.37.0"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
@@ -160,6 +199,11 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/json-iterator/go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,6 +50,10 @@ required = [
   version = "0.18.0"
 
 [[constraint]]
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.14.6"
+
+[[constraint]]
   branch = "master"
   name = "github.com/golang/glog"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,6 +46,10 @@ required = [
   name = "github.com/prometheus/client_golang"
 
 [[constraint]]
+  name = "github.com/google/go-cloud"
+  version = "0.1.0"
+
+[[constraint]]
   name = "cloud.google.com/go"
   version = "0.18.0"
 

--- a/sparkctl/README.md
+++ b/sparkctl/README.md
@@ -40,7 +40,7 @@ environment variable `HADOOP_CONF_DIR` is also set in the driver and executor co
 
 The `create` command also supports staging local application dependencies, though currently only uploading to a Google 
 Cloud Storage (GCS) bucket is supported. The way it works is as follows. It checks if there is any local dependencies 
-in `spec.mainApplicationFile`, `spec.deps.jars`, `spec.deps.files`, etc. in the parsed `SaprkApplication` object. If so, 
+in `spec.mainApplicationFile`, `spec.deps.jars`, `spec.deps.files`, etc. in the parsed `SparkApplication` object. If so, 
 it tries to upload the local dependencies to the remote location specified by `--upload-to`. The command fails if local
 dependencies are used but `--upload-to` is not specified. By default, a local file that already exists remotely, i.e., 
 there exists a file with the same name and upload path remotely, will be ignored. If the remote file should be overridden
@@ -54,16 +54,17 @@ otherwise. The local dependencies will be uploaded to the path
 file path of each local dependency with the URI of the remote copy in the parsed `SaprkApplication` object if uploading
 is successful. 
 
-Usage:
-```bash
-$ sparkctl create <path to YAML file> --upload-to gs://<bucket> --project <GCP project the GCS bucket is associated to>
-```
-
 Note that uploading to GCS requires a GCP service account with the necessary IAM permission to use the GCP project 
-specified by `--project` (`serviceusage.services.use`) and the permission to create GCS objects (`storage.object.create`). 
+specified by service account JSON key file (`serviceusage.services.use`) and the permission to create GCS objects (`storage.object.create`). 
 The service account JSON key file must be locally available and be pointed to by the environment variable 
 `GOOGLE_APPLICATION_CREDENTIALS`. For more information on IAM authentication, please check 
 [Getting Started with Authentication](https://cloud.google.com/docs/authentication/getting-started).
+
+Usage:
+```bash
+$ export GOOGLE_APPLICATION_CREDENTIALS="[PATH]/[FILE_NAME].json"
+$ sparkctl create <path to YAML file> --upload-to gs://<bucket>
+```
 
 By default, the uploaded dependencies are not made publicly accessible and are referenced using URIs in the form of 
 `gs://bucket/path/to/file`. Such dependencies are referenced through URIs of the form `gs://bucket/path/to/file`. To 
@@ -76,10 +77,74 @@ If you want to make uploaded dependencies publicly available so they can be down
 simply add `--public` to the `create` command, as the following example shows:
 
 ```bash
-$ sparkctl create <path to YAML file> --upload-to gs://<bucket> --project <GCP project the GCS bucket is associated to> --public
+$ sparkctl create <path to YAML file> --upload-to gs://<bucket> --public
 ``` 
 
 Publicly available files are referenced through URIs of the form `https://storage.googleapis.com/bucket/path/to/file`.
+
+##### Uploading to S3
+
+For uploading to S3, the value should be in the form of `s3://<bucket>`. The bucket must exist and uploading fails if
+otherwise. The local dependencies will be uploaded to the path
+`spark-app-dependencies/<SparkApplication namespace>/<SparkApplication name>` in the given bucket. It replaces the
+file path of each local dependency with the URI of the remote copy in the parsed `SparkApplication` object if uploading
+is successful.
+
+Note that uploading to S3 with [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) 
+requires credentials to be specified. For GCP, the S3 Interoperability credentials can be retrieved as 
+described [here](https://cloud.google.com/storage/docs/migrating#keys).
+SDK uses the default credential provider chain to find AWS credentials. 
+The SDK uses the first provider in the chain that returns credentials without an error.
+The default provider chain looks for credentials in the following order:
+
+- Environment variables
+    ```
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    ```
+- Shared credentials file (.aws/credentials)
+
+For more information about AWS SDK authentication, please check
+[Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
+
+Usage:
+```bash
+$ export AWS_ACCESS_KEY_ID=[KEY]
+$ export AWS_SECRET_ACCESS_KEY=[SECRET]
+$ sparkctl create <path to YAML file> --upload-to s3://<bucket>
+```
+
+By default, the uploaded dependencies are not made publicly accessible and are referenced using URIs in the form of
+`s3a://bucket/path/to/file`. To download the dependencies from S3, a custom-built Spark Docker image with the required
+jars for `S3A Connector` (`hadoop-aws-2.7.6.jar`, `aws-java-sdk-1.7.6.jar` for Spark build with Hadoop2.7 profile, or `hadoop-aws-3.1.0.jar`, `aws-java-sdk-bundle-1.11.271.jar` for Hadoop3.1) need to be available in the classpath,
+and `spark-default.conf` with the AWS keys and the S3A FileSystemClass needs to be set (you can also use `spec.hadoopConf` in the SparkApplication YAML):
+
+```
+spark.hadoop.fs.s3a.endpoint https://storage.googleapis.com
+spark.hadoop.fs.s3a.access.key [KEY]
+spark.hadoop.fs.s3a.secret.key [SECRET]
+spark.hadoop.fs.s3a.impl org.apache.hadoop.fs.s3a.S3AFileSystem
+```
+
+NOTE: In Spark 2.3 init-containers are used for downloading remote application dependencies. In future versions, init-containers are removed. 
+It is recommended to use Apache Spark 2.4 for staging local dependencies with `s3`, 
+which currently requires building a custom Docker image from the Spark master branch. Additionaly, since Spark 2.4.0 
+there are two available build profiles, Hadoop2.7 and Hadoop3.1. For use of Spark with `S3A Connector`, Hadoop3.1 profile
+is recommended as this allows to use newer version of `aws-java-sdk-bundle`.
+
+If you want to use custom S3 endpoint or region, add `--upload-to-endpoint` and `--upload-to-region`: 
+
+```bash
+$ sparkctl create <path to YAML file> --upload-to-endpoint https://<endpoint-url> --upload-to-region <endpoint-region> --upload-to s3://<bucket>
+```
+
+If you want to make uploaded dependencies publicly available, add `--public` to the `create` command, as the following example shows:
+
+```bash
+$ sparkctl create <path to YAML file> --upload-to s3://<bucket> --public
+```
+
+Publicly available files are referenced through URIs in the default form `https://<endpoint-url>/bucket/path/to/file`.
 
 ### List
 

--- a/sparkctl/cmd/gcs.go
+++ b/sparkctl/cmd/gcs.go
@@ -18,119 +18,63 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/go-cloud/blob/gcsblob"
+	"github.com/google/go-cloud/gcp"
 	"golang.org/x/net/context"
 )
 
-const rootPath = "spark-app-dependencies"
-
-type gcsUploader struct {
-	client *storage.Client
-	handle *storage.BucketHandle
-	endpointURL string
-	bucket string
-	path   string
+type blobGCS struct {
+	projectId string
+	endpoint  string
+	region    string
 }
 
-func (g *gcsUploader) upload(ctx context.Context, localFile string, public bool, override bool) (string, error) {
-	file, err := os.Open(localFile)
-	if err != nil {
-		return "", fmt.Errorf("failed to open file %s: %v", localFile, err)
-	}
-	defer file.Close()
-
-	object := g.handle.Object(filepath.Join(g.path, filepath.Base(localFile)))
-	// Check if a file with the same name already exists remotely.
-	objectAttrs, err := object.Attrs(ctx)
-	if err == nil && !override {
-		fmt.Printf("not uploading file %s as it already exists remotely\n", filepath.Base(localFile))
-		return g.getRemoteFileUrl(objectAttrs.Name, public), nil
-	}
-
-	fmt.Printf("uploading local file: %s\n", localFile)
-	writer := object.NewWriter(ctx)
-	if _, err = io.Copy(writer, file); err != nil {
-		return "", fmt.Errorf("failed to copy file %s to GCS: %v", localFile, err)
-	}
-	if err = writer.Close(); err != nil {
-		return "", err
-	}
-
-	objectAttrs, err = object.Attrs(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	if public {
-		if err = object.ACL().Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
-			return "", fmt.Errorf("failed to set ACL on GCS object %s: %v", objectAttrs.Name, err)
-		}
-	}
-
-	return g.getRemoteFileUrl(objectAttrs.Name, public), nil
-}
-
-func (g *gcsUploader) getRemoteFileUrl(name string, public bool) string {
-	if public {
-		return fmt.Sprintf("%s/%s/%s", g.endpointURL, g.bucket, name)
-	}
-	return fmt.Sprintf("gs://%s/%s", g.bucket, name)
-}
-
-func newGcsUploader(
+func (blob blobGCS) setPublicACL(
+	ctx context.Context,
 	bucket string,
-	path string,
-	projectID string,
-	endpointURL string,
-	ctx context.Context) (*gcsUploader, error) {
+	filePath string) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	defer client.Close()
 
-	handle := client.Bucket(bucket)
-	// Check if the bucket exists.
-	if _, err := handle.Attrs(ctx); err != nil {
-		return nil, err
+	handle := client.Bucket(bucket).UserProject(blob.projectId)
+	if err = handle.Object(filePath).ACL().Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
+		return fmt.Errorf("failed to set ACL on GCS object %s: %v", filePath, err)
 	}
-	uploader := &gcsUploader{
-		client: client,
-		handle: handle.UserProject(projectID),
-		endpointURL: endpointURL,
-		bucket: bucket,
-		path:   path}
-
-	return uploader, nil
+	return nil
 }
 
-func uploadToGCS(
+func newGCSBlob(
+	ctx context.Context,
 	bucket string,
-	appNamespace string,
-	appName string,
-	endpointURL string,
-	projectID string,
-	files []string,
-	public bool,
-	override bool) ([]string, error) {
-	ctx := context.Background()
-	uploader, err := newGcsUploader(bucket, filepath.Join(rootPath, appNamespace, appName), projectID, endpointURL, ctx)
+	endpoint string,
+	region string) (*uploadHandler, error) {
+	creds, err := gcp.DefaultCredentials(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer uploader.client.Close()
 
-	var uploadedFiles []string
-	for _, file := range files {
-		remoteFile, err := uploader.upload(ctx, file, public, override)
-		if err != nil {
-			return nil, err
-		}
-		uploadedFiles = append(uploadedFiles, remoteFile)
+	projectId, err := gcp.DefaultProjectID(creds)
+	if err != nil {
+		return nil, err
 	}
 
-	return uploadedFiles, nil
+	c, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := gcsblob.OpenBucket(ctx, bucket, c)
+	return &uploadHandler{
+		blob:             blobGCS{endpoint: endpoint, region: region, projectId: string(projectId)},
+		ctx:              ctx,
+		b:                b,
+		blobUploadBucket: bucket,
+		blobEndpoint:     endpoint,
+		hdpScheme:        "gs",
+	}, err
 }

--- a/sparkctl/cmd/s3.go
+++ b/sparkctl/cmd/s3.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"net/url"
+)
+
+type s3Uploader struct {
+	client *s3manager.Uploader
+	endpointURL string
+	region string
+	bucket string
+	path   string
+}
+
+func (s *s3Uploader) upload(localFile string, public bool, override bool) (string, error) {
+	file, err := os.Open(localFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file %s: %v", localFile, err)
+	}
+	defer file.Close()
+
+	bucket := s.bucket
+	key := filepath.Join(s.path, filepath.Base(localFile))
+	_, err = s.client.S3.HeadObject(&s3.HeadObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+
+	if err == nil && !override {
+		fmt.Printf("not uploading file %s as it already exists remotely\n", filepath.Base(localFile))
+		return s.getRemoteFileUrl(key, public), nil
+	}
+
+	acl := "private"
+	if public {
+		acl = "public-read"
+	}
+
+	fmt.Printf("uploading local file: %s\n", localFile)
+	_, err = s.client.Upload(&s3manager.UploadInput{
+		Bucket: &bucket,
+		Key: &key,
+		Body: file,
+		ACL: &acl,
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to copy file %s to S3: %v", localFile, err)
+	}
+
+	return s.getRemoteFileUrl(key, public), nil
+}
+
+func (s *s3Uploader) getRemoteFileUrl(name string, public bool) string {
+	if public {
+		uploadLocationUrl, err := url.Parse(s.endpointURL)
+		if err != nil {
+			return ""
+		}
+
+		return fmt.Sprintf("%s://%s.%s/%s",
+			uploadLocationUrl.Scheme,
+			s.bucket,
+			uploadLocationUrl.Host,
+			name)
+	}
+	return fmt.Sprintf("s3a://%s/%s", s.bucket, name)
+}
+
+func newS3Uploader(endpointURL string, region string, bucket string, path string) (*s3Uploader, error) {
+	// AWS SDK does require specifying regions, thus set it to default GCS region
+	if region == "" {
+		region = "us-east1"
+	}
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+		Endpoint: aws.String(endpointURL),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	uploader := &s3Uploader{
+		client: s3manager.NewUploader(sess),
+		endpointURL: endpointURL,
+		region: region,
+		bucket: bucket,
+		path:   path,
+	}
+	return uploader, nil
+}
+
+func uploadToS3(
+	bucket string,
+	appNamespace string,
+	appName string,
+	endpointURL string,
+	region string,
+	files []string,
+	public bool,
+	override bool) ([]string, error) {
+	uploader, err := newS3Uploader(endpointURL, region, bucket, filepath.Join(rootPath, appNamespace, appName))
+	if err != nil {
+		return nil, err
+	}
+
+	var uploadedFiles []string
+	for _, file := range files {
+		remoteFile, err := uploader.upload(file, public, override)
+		if err != nil {
+			return nil, err
+		}
+		uploadedFiles = append(uploadedFiles, remoteFile)
+	}
+
+	return uploadedFiles, nil
+}

--- a/sparkctl/cmd/s3.go
+++ b/sparkctl/cmd/s3.go
@@ -17,127 +17,54 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"net/url"
+	"github.com/google/go-cloud/blob/s3blob"
 )
 
-type s3Uploader struct {
-	client *s3manager.Uploader
-	endpointURL string
-	region string
-	bucket string
-	path   string
+type blobS3 struct {
+	s *session.Session
 }
 
-func (s *s3Uploader) upload(localFile string, public bool, override bool) (string, error) {
-	file, err := os.Open(localFile)
-	if err != nil {
-		return "", fmt.Errorf("failed to open file %s: %v", localFile, err)
-	}
-	defer file.Close()
+func (blob blobS3) setPublicACL(
+	ctx context.Context,
+	bucket string,
+	filePath string) error {
+	acl := "public-read"
+	svc := s3.New(blob.s)
 
-	bucket := s.bucket
-	key := filepath.Join(s.path, filepath.Base(localFile))
-	_, err = s.client.S3.HeadObject(&s3.HeadObjectInput{
-		Bucket: &bucket,
-		Key:    &key,
-	})
-
-	if err == nil && !override {
-		fmt.Printf("not uploading file %s as it already exists remotely\n", filepath.Base(localFile))
-		return s.getRemoteFileUrl(key, public), nil
+	if _, err := svc.PutObjectAcl(&s3.PutObjectAclInput{Bucket: &bucket, Key: &filePath, ACL: &acl}); err != nil {
+		return fmt.Errorf("failed to set ACL on S3 object %s: %v", filePath, err)
 	}
 
-	acl := "private"
-	if public {
-		acl = "public-read"
-	}
-
-	fmt.Printf("uploading local file: %s\n", localFile)
-	_, err = s.client.Upload(&s3manager.UploadInput{
-		Bucket: &bucket,
-		Key: &key,
-		Body: file,
-		ACL: &acl,
-	})
-
-	if err != nil {
-		return "", fmt.Errorf("failed to copy file %s to S3: %v", localFile, err)
-	}
-
-	return s.getRemoteFileUrl(key, public), nil
+	return nil
 }
 
-func (s *s3Uploader) getRemoteFileUrl(name string, public bool) string {
-	if public {
-		uploadLocationUrl, err := url.Parse(s.endpointURL)
-		if err != nil {
-			return ""
-		}
-
-		return fmt.Sprintf("%s://%s.%s/%s",
-			uploadLocationUrl.Scheme,
-			s.bucket,
-			uploadLocationUrl.Host,
-			name)
-	}
-	return fmt.Sprintf("s3a://%s/%s", s.bucket, name)
-}
-
-func newS3Uploader(endpointURL string, region string, bucket string, path string) (*s3Uploader, error) {
+func newS3Blob(
+	ctx context.Context,
+	bucket string,
+	endpoint string,
+	region string) (*uploadHandler, error) {
 	// AWS SDK does require specifying regions, thus set it to default GCS region
 	if region == "" {
 		region = "us-east1"
 	}
-
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(region),
-		Endpoint: aws.String(endpointURL),
-	})
-
-	if err != nil {
-		return nil, err
+	c := &aws.Config{
+		Region:   aws.String(region),
+		Endpoint: aws.String(endpoint),
 	}
-
-	uploader := &s3Uploader{
-		client: s3manager.NewUploader(sess),
-		endpointURL: endpointURL,
-		region: region,
-		bucket: bucket,
-		path:   path,
-	}
-	return uploader, nil
-}
-
-func uploadToS3(
-	bucket string,
-	appNamespace string,
-	appName string,
-	endpointURL string,
-	region string,
-	files []string,
-	public bool,
-	override bool) ([]string, error) {
-	uploader, err := newS3Uploader(endpointURL, region, bucket, filepath.Join(rootPath, appNamespace, appName))
-	if err != nil {
-		return nil, err
-	}
-
-	var uploadedFiles []string
-	for _, file := range files {
-		remoteFile, err := uploader.upload(file, public, override)
-		if err != nil {
-			return nil, err
-		}
-		uploadedFiles = append(uploadedFiles, remoteFile)
-	}
-
-	return uploadedFiles, nil
+	sess := session.Must(session.NewSession(c))
+	b, err := s3blob.OpenBucket(ctx, sess, bucket)
+	return &uploadHandler{
+		blob:             blobS3{s: sess},
+		ctx:              ctx,
+		b:                b,
+		blobUploadBucket: bucket,
+		blobEndpoint:     endpoint,
+		hdpScheme:        "s3a",
+	}, err
 }


### PR DESCRIPTION
### Description

Adds support for staging local dependencies in sparkctl (solves #144 )

- Implementation follows the guidelines from Google Storage Interoperability (https://cloud.google.com/storage/docs/interoperability) and S3 CLI docs (https://docs.aws.amazon.com/cli/latest/topic/s3-config.html)
- By default, implementation uses `--upload-to-endpoint` set to `https://storage.googleapis.com` and `--upload-to-region` default empty region 

### To bo done

- [x] Implement S3 support
- [x] Adjust GCS
- [x] Update docs

### How did I test

```
export AWS_ACCESS_KEY_ID=<redacted>
export AWS_SECRET_ACCESS_KEY=<redacted>
./sparkctl create \
./jobs/spark-pi.yaml \
--upload-to s3a://<gcs-bucket>
```

```
export GOOGLE_APPLICATION_CREDENTIALS=~/<redacted>.json
./sparkctl create \
./jobs/spark-pi.yaml \
--upload-to gs://<gcs-bucket>
```
@liyinan926 @prasanthkothuri