### PR TITLE
Add an entrypoint to spark-operator for handling non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ RUN go generate && go build -o /usr/bin/spark-operator
 
 FROM gcr.io/ynli-k8s/spark:v2.3.0
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
-ENTRYPOINT ["/usr/bin/spark-operator"]
+COPY ./entrypoint /entrypoint
+ENTRYPOINT ["/entrypoint"]

--- a/entrypoint
+++ b/entrypoint
@@ -34,4 +34,4 @@ if [ -z "$uidentry" ] ; then
         echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID"
     fi
 fi
-exec /usr/bin/spark-operator "$@"
+exec "$@"

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# echo commands to the terminal output
+set -ex
+
+# Check whether there is a passwd entry for the container UID
+myuid=$(id -u)
+mygid=$(id -g)
+set +e
+uidentry=$(getent passwd $myuid)
+set -e
+
+# If there is no passwd entry for the container UID, attempt to create one
+if [ -z "$uidentry" ] ; then
+    if [ -w /etc/passwd ] ; then
+        echo "$myuid:x:$myuid:$mygid:anonymous uid:$SPARK_HOME:/bin/false" >> /etc/passwd
+    else
+        echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID"
+    fi
+fi
+exec /usr/bin/spark-operator "$@"

--- a/manifest/spark-operator.yaml
+++ b/manifest/spark-operator.yaml
@@ -43,7 +43,6 @@ spec:
       - name: sparkoperator
         image: gcr.io/spark-operator/spark-operator:v2.3.0-v1alpha1-latest
         imagePullPolicy: Always
-        command: ["/usr/bin/spark-operator"]
         args:
         - -logtostderr
         - -enable-initializer=false

--- a/manifest/spark-operator.yaml
+++ b/manifest/spark-operator.yaml
@@ -43,6 +43,8 @@ spec:
       - name: sparkoperator
         image: gcr.io/spark-operator/spark-operator:v2.3.0-v1alpha1-latest
         imagePullPolicy: Always
+        command: ["/entrypoint"]
         args:
+        - /usr/bin/spark-operator
         - -logtostderr
         - -enable-initializer=false


### PR DESCRIPTION
In order to use the spark-on-k8s-operator on a platform where a user
is assigned based on a security context (OpenShift), the /etc/passwd
file needs to be modified in an entrypoint like it is in the standard
Apache Spark 2.3 image to support an assigned user (note that it
won't be changed for a root user). Change the spark-operator.yaml to
call the entrypoint and pass /usr/bin/spark-operator as the first argument.