### PR TITLE
Removed check on the presence of kube-dns

### DIFF
--- a/manifest/spark-operator-rbac.yaml
+++ b/manifest/spark-operator-rbac.yaml
@@ -37,7 +37,7 @@ rules:
   resources: ["services", "configmaps"]
   verbs: ["create", "get", "delete"]
 - apiGroups: [""]
-  resources: ["nodes", "endpoints"]
+  resources: ["nodes"]
   verbs: ["get"]
 - apiGroups: [""]
   resources: ["events"]


### PR DESCRIPTION
Core DNS reached GA in Kubernetes 1.11. We cannot assume that users will always use the kube-dns add-on so the check no longer makes sense.