### PR TITLE
Add mutating admission webhook

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,6 +47,12 @@
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
+  version = "v3.0.0"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -397,6 +403,7 @@
   branch = "release-1.10"
   name = "k8s.io/api"
   packages = [
+    "admission/v1beta1",
     "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
@@ -639,6 +646,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "28658d55a72e1c5e3f8f277ac9fc114067f74f5cb0a681fbc8c6375fe0d80317"
+  inputs-digest = "f21002511798e7e4396ccc14e7762e00556f425771101da81efeaaa5b26cea1a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,3 +92,7 @@ required = [
 [[constraint]]
   branch = "master"
   name = "k8s.io/code-generator"
+
+[[constraint]]
+  name = "github.com/evanphx/json-patch"
+  version = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -5,31 +5,31 @@
 
 ## Community
 
-* [Slack](https://kubernetes.slack.com/messages/CALBDHMTL) channel
+* [Slack](https://kubernetes.slack.com/messages/CALBDHMTL) channel.
 
 ## Project Status
 
 **Project status:** *alpha* 
 
-Spark Operator is still under active development and has not been extensively tested in production environment yet. Backward compatibility of the APIs is not guaranteed for alpha releases.
+Spark Operator is still under active development. Backward compatibility of the APIs is not guaranteed for alpha releases.
 
-Customization of Spark pods, e.g., mounting ConfigMaps and PersistentVolumes is currently experimental and implemented using a Kubernetes
-[Initializer](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers), which is a Kubernetes **alpha** feature and 
-requires a Kubernetes cluster with alpha features enabled. The Initializer can be disabled if there's no need for pod customization or
- if running on an alpha cluster is not desirable. Check out the [Quick Start Guide](docs/quick-start-guide.md#configuration) on how to disable
- the Initializer.
+Customization of Spark pods, e.g., mounting arbitrary volumes and setting pod affinity, is currently experimental and implemented using a Kubernetes
+[Mutating Admission Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/), which became beta in Kubernetes 1.9. 
+The mutating admission webhook is disabled by default but can be enabled if there are needs for pod customization. Check out the [Quick Start Guide](docs/quick-start-guide.md#using-the-mutating-admission-webhook) 
+on how to enable the webhook.
 
 ## Prerequisites
 
 * Version >= 1.8 of Kubernetes.
+* Version >= 1.9 of Kubernetes if **using the mutating admission webhook for Spark pod customization**.
 
-Spark Operator relies on [garbage collection](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) support for 
-custom resources and **optionally** the [Initializers](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers) which are in Kubernetes 1.8+.
+Spark Operator relies on [garbage collection](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) support for custom resources that is available in Kubernetes 1.8+ 
+and **optionally** the [Mutating Admission Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) which is available in Kubernetes 1.9+.
 
 **Due to this [bug](https://github.com/kubernetes/kubernetes/issues/56018) in Kubernetes 1.9 and earlier, CRD objects with
 escaped quotes (e.g., `spark.ui.port\"`) in map keys can cause serialization problems in the API server. So please pay
 extra attention to make sure no offending escaping is in your `SparkAppliction` CRD objects, particularly if you use 
-Kubernetes prior to 1.10.**   
+Kubernetes prior to 1.10.**
 
 ## Get Started
 
@@ -42,39 +42,22 @@ For more information, check the [Design](docs/design.md), [API Specification](do
 ## Overview
 
 Spark Operator aims to make specifying and running [Spark](https://github.com/apache/spark) 
-applications as easy and idiomatic as running other workloads on Kubernetes. It uses a 
-[CustomResourceDefinition (CRD)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/) of 
-`SparkApplication` objects for specifying, running, and surfacing status of Spark applications. For a complete reference 
-of the API definition of the `SparkApplication` CRD, please refer to [API Definition](docs/api.md). For details on its design, 
-please refer to the [design doc](docs/design.md). It requires Spark 2.3 and above that supports Kubernetes as a native scheduler 
-backend. Below are some example things that the Spark Operator is able to automate (some are to be implemented):
-* Submitting applications on behalf of users so they don't need to deal with the submission process and the `spark-submit` command.
-* Mounting user-specified ConfigMaps and volumes into the driver and executor Pods.
-* Mounting ConfigMaps carrying Spark or Hadoop configuration files that are to be put into a directory referred to by the 
-environment variable `SPARK_CONF_DIR` or `HADOOP_CONF_DIR` into the driver and executor Pods. Example use cases include 
-shipping a `log4j.properties` file for configuring logging and a `core-site.xml` file for configuring Hadoop and/or HDFS 
-access.
-* Creating a `NodePort` service for the Spark UI running on the driver so the UI can be accessed from outside the Kubernetes 
-cluster, without needing to use API server proxy or port forwarding.
-
-To make such automation possible, Spark Operator uses the `SparkApplication` CRD and a corresponding CRD controller as well as an 
-[initializer](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers). The CRD controller setups the 
-environment for an application and submits the application to run on behalf of the user, whereas the initializer handles customization 
-of the Spark Pods. It also supports running Spark applications on standard [cron](https://en.wikipedia.org/wiki/Cron) schedules using 
-the `ScheduledSparkApplication` CRD and the corresponding CRD controller.
-
-## Features
+applications as easy and idiomatic as running other workloads on Kubernetes. It uses 
+[Kubernetes custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) 
+for specifying, running, and surfacing status of Spark applications. For a complete reference of the custom resource definitions, 
+please refer to the [API Definition](docs/api.md). For details on its design, please refer to the [design doc](docs/design.md). 
+It requires Spark 2.3 and above that supports Kubernetes as a native scheduler backend.
 
 Spark Operator currently supports the following list of features:
 
 * Supports Spark 2.3 and up.
-* Enables declarative application specification and management of applications by manipulating `SparkApplication` resources. 
+* Enables declarative application specification and management of applications through custom resources. 
 * Automatically runs `spark-submit` on behalf of users for each `SparkApplication` eligible for submission.
 * Provides native [cron](https://en.wikipedia.org/wiki/Cron) support for running scheduled applications.
+* Supports customization of Spark pods beyond what Spark natively is able to do through the mutating admission webhook, e.g., mounting ConfigMaps and volumes, and setting pod affinity/anti-affinity.
 * Supports automatic application re-submission for updated `SparkAppliation` objects with updated specification.
 * Supports automatic application restart with a configurable restart policy.
 * Supports automatic retries of failed submissions with optional linear back-off.
-* Supports mounting user-specified ConfigMaps and volumes (currently through the Initializer).
 * Supports mounting local Hadoop configuration as a Kubernetes ConfigMap automatically via `sparkctl`.
 * Supports automatically staging local application dependencies to Google Cloud Storage (GCS) via `sparkctl`.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -6,8 +6,8 @@
 * [The CRD Controller](#the-crd-controller)
 * [Handling Application Restart](#handling-application-restart)
 * [Handling Retries of Failed Submissions](#handling-retries-of-failed-submissions)
-* [Spark Pod Initializer](#spark-pod-initializer)
-* [Command-line Tool: Sparkctl](#command-line-tool-sparkctl)
+* [Mutating Admission Webhook](#mutating-admission-webhook)
+* [Command-line Tool: Sparkctl](#command-line-tool:-sparkctl)
 
 ## Introduction
 
@@ -57,17 +57,9 @@ When the operator decides to restart an application, it cleans up the Kubernetes
 
 The submission of an application may fail for various reasons. Sometimes a submission may fail due to transient errors and a retry may succeed. The Spark Operator supports retries of failed submissions through a combination of the `MaxSubmissionRetries` field of `SparkApplicationSpec` and the `SubmissionRetries` field of `SparkApplicationStatus` (see the [API Definition](api.md) for more details). When the operator decides to retry a failed submission, it simply enqueues the `SparkApplication` object of the application into the internal work queue, from which it gets picked up by a worker who will handle the submission.   
 
-## Spark Pod Initializer
+## Mutating Admission Webhook
 
-NOTE: it is planned to migrate from using an Initializer to instead using an [external admission webhook](https://kubernetes.io/docs/admin/extensible-admission-controllers/#external-admission-webhooks).
-
-The Spark pod initializer is responsible for configuring pods of Spark applications based on certain annotations on the pods added by the CRD controller. All Spark pod customization needs except for those natively support by Spark on Kubernetes are handled by the initializer. The following annotations for pod customization are supported:
-
-|Annotation|Value|Note|
-| ------------- | ------------- | ------------- |
-|`sparkoperator.k8s.io/sparkConfigMap`|Name of the Kubernetes ConfigMap storing Spark configuration files (to which `SPARK_CONF_DIR` applies)|Environment variable `SPARK_CONF_DIR` is set to point to the mount path.|
-|`sparkoperator.k8s.io/hadoopConfigMap`|Name of the Kubernetes ConfigMap storing Hadoop configuration files (to which `HADOOP_CONF_DIR` applies)|Environment variable `HADOOP_CONF_DIR` is set to point to the mount path.|
-|`sparkoperator.k8s.io/configMap.[ConfigMapName]`|Mount path of the ConfigMap named `ConfigMapName`|N/A|
+The Spark Operator comes with an optional mutating admission webhook for customizing Spark driver and executor pods based on certain annotations on the pods added by the CRD controller. The annotations are set by the operator based on the application specifications. All Spark pod customization needs except for those natively support by Spark on Kubernetes are handled by the mutating admission webhook.
 
 ## Command-line Tool: Sparkctl 
 

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generates a CA certificate, a server key, and a server certificate signed by the CA.
+
+set -e
+
+CN_BASE="spark-webhook"
+TMP_DIR="/tmp/spark-pod-webhook-certs"
+
+echo "Generating certs for the Spark pod admission webhook in ${TMP_DIR}."
+mkdir -p ${TMP_DIR}
+cat > ${TMP_DIR}/server.conf << EOF
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, serverAuth
+EOF
+
+# Create a certificate authority.
+openssl genrsa -out ${TMP_DIR}/ca-key.pem 2048
+openssl req -x509 -new -nodes -key ${TMP_DIR}/ca-key.pem -days 100000 -out ${TMP_DIR}/ca-cert.pem -subj "/CN=${CN_BASE}_ca"
+
+# Create a server certificate.
+openssl genrsa -out ${TMP_DIR}/server-key.pem 2048
+# Note the CN is the DNS name of the service of the webhook.
+openssl req -new -key ${TMP_DIR}/server-key.pem -out ${TMP_DIR}/server.csr -subj "/CN=spark-webhook.sparkoperator.svc" -config ${TMP_DIR}/server.conf
+openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/ca-cert.pem -CAkey ${TMP_DIR}/ca-key.pem -CAcreateserial -out ${TMP_DIR}/server-cert.pem -days 100000 -extensions v3_req -extfile ${TMP_DIR}/server.conf
+
+echo "Creating a secret for the certificate and keys"
+kubectl create secret --namespace=sparkoperator generic spark-webhook-certs --from-file=${TMP_DIR}/ca-key.pem --from-file=${TMP_DIR}/ca-cert.pem --from-file=${TMP_DIR}/server-key.pem --from-file=${TMP_DIR}/server-cert.pem
+
+# Clean up after we're done.
+echo "Deleting ${TMP_DIR}."
+rm -rf ${TMP_DIR}

--- a/manifest/spark-operator-rbac.yaml
+++ b/manifest/spark-operator-rbac.yaml
@@ -46,7 +46,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["create", "get", "update", "delete"]
 - apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["initializerconfigurations"]
+  resources: ["mutatingwebhookconfigurations"]
   verbs: ["create", "get", "update", "delete"]
 - apiGroups: ["sparkoperator.k8s.io"]
   resources: ["sparkapplications", "scheduledsparkapplications"]

--- a/manifest/spark-operator-with-webhook.yaml
+++ b/manifest/spark-operator-with-webhook.yaml
@@ -1,0 +1,70 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: sparkoperator
+  namespace: sparkoperator
+  labels:
+    app.kubernetes.io/name: sparkoperator
+    app.kubernetes.io/version: v2.3.0-v1alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sparkoperator
+      app.kubernetes.io/version: v2.3.0-v1alpha1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sparkoperator
+        app.kubernetes.io/version: v2.3.0-v1alpha1
+      initializers:
+        pending: []
+    spec:
+      serviceAccountName: sparkoperator
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: spark-webhook-certs
+      containers:
+      - name: sparkoperator
+        image: gcr.io/spark-operator/spark-operator:v2.3.0-v1alpha1-webhook-latest
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: webhook-certs
+            mountPath: /etc/webhook-certs
+        command: ["/usr/bin/spark-operator"]
+        args:
+        - -logtostderr
+        - -enable-webhook=true
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: spark-webhook
+  namespace: sparkoperator
+spec:
+  ports:
+    - port: 443
+      targetPort: 8080
+      name: webhook
+  selector:
+    app.kubernetes.io/name: sparkoperator
+    app.kubernetes.io/version: v2.3.0-v1alpha1

--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
@@ -333,6 +333,9 @@ type SparkPodSpec struct {
 	// VolumeMounts specifies the volumes listed in ".spec.volumes" to mount into the main container's filesystem.
 	// Optional.
 	VolumeMounts []apiv1.VolumeMount `json:"volumeMounts,omitempty"`
+	// Affinity specifies the affinity/anti-affinity settings for the pod.
+	// Optional.
+	Affinity *apiv1.Affinity `json:"affinity,omitempty"`
 }
 
 // DriverSpec is specification of the driver.

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -59,6 +59,9 @@ const (
 	// OwnerReferenceAnnotation is the name of the annotation added to the driver and executor Pods
 	// that specifies the OwnerReference of the owning SparkApplication.
 	OwnerReferenceAnnotation = LabelAnnotationPrefix + "ownerreference"
+	// AffinityAnnotation is the name of the annotation added to the driver and executor Pods that
+	// specifies the value of the Pod Affinity.
+	AffinityAnnotation = LabelAnnotationPrefix + "affinity"
 	// SparkAppIDLabel is the name of the label used to group API objects, e.g., Spark UI service, Pods,
 	// ConfigMaps, etc., belonging to the same Spark application.
 	SparkAppIDLabel = LabelAnnotationPrefix + "app-id"

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -267,6 +267,16 @@ func addDriverConfOptions(app *v1alpha1.SparkApplication) ([]string, error) {
 			fmt.Sprintf("%s%s=%s:%s", config.SparkDriverSecretKeyRefKeyPrefix, key, value.Name, value.Key))
 	}
 
+	if app.Spec.Driver.Affinity != nil {
+		affinityString, err := util.MarshalAffinity(app.Spec.Driver.Affinity)
+		if err != nil {
+			return nil, err
+		}
+		driverConfOptions = append(driverConfOptions,
+			fmt.Sprintf("%s%s=%s", config.SparkDriverAnnotationKeyPrefix, config.AffinityAnnotation,
+				affinityString))
+	}
+
 	driverConfOptions = append(driverConfOptions, config.GetDriverSecretConfOptions(app)...)
 	driverConfOptions = append(driverConfOptions, config.GetDriverConfigMapConfOptions(app)...)
 	driverConfOptions = append(driverConfOptions, config.GetDriverEnvVarConfOptions(app)...)
@@ -331,6 +341,16 @@ func addExecutorConfOptions(app *v1alpha1.SparkApplication) ([]string, error) {
 	for key, value := range app.Spec.Executor.EnvSecretKeyRefs {
 		executorConfOptions = append(executorConfOptions,
 			fmt.Sprintf("%s%s=%s:%s", config.SparkExecutorSecretKeyRefKeyPrefix, key, value.Name, value.Key))
+	}
+
+	if app.Spec.Executor.Affinity != nil {
+		affinityString, err := util.MarshalAffinity(app.Spec.Executor.Affinity)
+		if err != nil {
+			return nil, err
+		}
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("%s%s=%s", config.SparkExecutorAnnotationKeyPrefix, config.AffinityAnnotation,
+				affinityString))
 	}
 
 	executorConfOptions = append(executorConfOptions, config.GetExecutorSecretConfOptions(app)...)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,3 +103,25 @@ func UnmarshalOwnerReference(ownerReferenceStr string) (*metav1.OwnerReference, 
 	}
 	return ownerReference, nil
 }
+
+// MarshalAffinity encodes the given Affinity into a string.
+func MarshalAffinity(affinity *apiv1.Affinity) (string, error) {
+	affinityData, err := affinity.Marshal()
+	if err != nil {
+		return "", err
+	}
+	return encodeToString(affinityData), nil
+}
+
+// UnmarshalAffinity decodes a Affinity from the given string.
+func UnmarshalAffinity(affinityStr string) (*apiv1.Affinity, error) {
+	affinity := &apiv1.Affinity{}
+	decoded, err := decodeString(affinityStr)
+	if err != nil {
+		return nil, err
+	}
+	if err = affinity.Unmarshal(decoded); err != nil {
+		return nil, err
+	}
+	return affinity, nil
+}

--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+)
+
+// certBundle is a container of a X509 certificate file and a corresponding key file for the
+// webhook server, and a CA certificate file for the API server to verify the server certificate.
+type certBundle struct {
+	serverCertFile string
+	serverKeyFile  string
+	caCertFile     string
+}
+
+// configServerTLS configures TLS for the admission webhook server.
+func configServerTLS(certBundle *certBundle) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certBundle.serverCertFile, certBundle.serverKeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
+}
+
+func readCertFile(certFile string) ([]byte, error) {
+	return ioutil.ReadFile(certFile)
+}

--- a/pkg/webhook/doc.go
+++ b/pkg/webhook/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+// Package webhook implements a mutating admission webhook for patching Spark driver and executor pods.
+// The webhook supports mutations that are not supported by Spark on Kubernetes itself, e.g., adding an
+// OwnerReference to the driver pod for the owning SparkApplications or setting the SecurityContext.

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/spark-on-k8s-operator/pkg/config"
+	"k8s.io/spark-on-k8s-operator/pkg/util"
+)
+
+const (
+	sparkDriverContainerName   = "spark-kubernetes-driver"
+	sparkExecutorContainerName = "executor"
+)
+
+// patchOperation represents a RFC6902 JSON patch operation.
+type patchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func patchSparkPod(pod *corev1.Pod) ([]*patchOperation, error) {
+	var patchOps []*patchOperation
+
+	op, err := addOwnerReference(pod)
+	if err != nil {
+		return nil, err
+	}
+	if op != nil {
+		patchOps = append(patchOps, op)
+	}
+
+	ops, err := addVolumes(pod)
+	if err != nil {
+		return nil, err
+	}
+	patchOps = append(patchOps, ops...)
+
+	op, err = addAffinity(pod)
+	if err != nil {
+		return nil, err
+	}
+	if op != nil {
+		patchOps = append(patchOps, op)
+	}
+
+	return patchOps, nil
+}
+
+func addOwnerReference(pod *corev1.Pod) (*patchOperation, error) {
+	ownerReferenceStr, ok := pod.Annotations[config.OwnerReferenceAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	ownerReference, err := util.UnmarshalOwnerReference(ownerReferenceStr)
+	if err != nil {
+		return nil, err
+	}
+
+	path := "/metadata/ownerReferences"
+	var value interface{}
+	if len(pod.OwnerReferences) == 0 {
+		value = []metav1.OwnerReference{*ownerReference}
+	} else {
+		path += "/-"
+		value = *ownerReference
+	}
+
+	return &patchOperation{Op: "add", Path: path, Value: value}, nil
+}
+
+func addVolumes(pod *corev1.Pod) ([]*patchOperation, error) {
+	volumes, err := config.FindVolumes(pod.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	volumeMounts, err := config.FindVolumeMounts(pod.Annotations)
+	if err != nil {
+		return nil, err
+	}
+
+	var ops []*patchOperation
+	for name := range volumeMounts {
+		if volume, ok := volumes[name]; ok {
+			ops = append(ops, addVolume(pod, volume))
+			ops = append(ops, addVolumeMount(pod, volumeMounts[name]))
+		}
+	}
+
+	return ops, nil
+}
+
+func addVolume(pod *corev1.Pod, volume *corev1.Volume) *patchOperation {
+	path := "/spec/volumes"
+	var value interface{}
+	if len(pod.Spec.Volumes) == 0 {
+		value = []corev1.Volume{*volume}
+	} else {
+		path += "/-"
+		value = *volume
+	}
+
+	return &patchOperation{Op: "add", Path: path, Value: value}
+}
+
+func addVolumeMount(pod *corev1.Pod, mount *corev1.VolumeMount) *patchOperation {
+	i := 0
+	// Find the driver or executor container in the pod.
+	for ; i < len(pod.Spec.Containers); i++ {
+		if pod.Spec.Containers[i].Name == sparkDriverContainerName ||
+			pod.Spec.Containers[i].Name == sparkExecutorContainerName {
+			break
+		}
+	}
+
+	path := fmt.Sprintf("/spec/containers/%d/volumeMounts", i)
+	var value interface{}
+	if len(pod.Spec.Containers[i].VolumeMounts) == 0 {
+		value = []corev1.VolumeMount{*mount}
+	} else {
+		path += "/-"
+		value = *mount
+	}
+
+	return &patchOperation{Op: "add", Path: path, Value: value}
+}
+
+func addAffinity(pod *corev1.Pod) (*patchOperation, error) {
+	affinityStr, ok := pod.Annotations[config.AffinityAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	affinity, err := util.UnmarshalAffinity(affinityStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &patchOperation{Op: "add", Path: "/spec/affinity", Value: *affinity}, nil
+}

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/evanphx/json-patch"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"k8s.io/spark-on-k8s-operator/pkg/config"
+	"k8s.io/spark-on-k8s-operator/pkg/util"
+)
+
+func TestPatchSparkPod(t *testing.T) {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		Kind:       reflect.TypeOf(v1alpha1.SparkApplication{}).Name(),
+		Name:       "spark-test",
+		UID:        "spark-test-1",
+	}
+	referenceStr, err := util.MarshalOwnerReference(&ownerReference)
+	if err != nil {
+		t.Error(err)
+	}
+
+	volume := &corev1.Volume{
+		Name: "spark",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/spark",
+			},
+		},
+	}
+	volumeStr, err := util.MarshalVolume(volume)
+	if err != nil {
+		t.Error(err)
+	}
+	volumeMount := &corev1.VolumeMount{
+		Name:      "spark",
+		MountPath: "/mnt/spark",
+	}
+	volumeMountStr, err := util.MarshalVolumeMount(volumeMount)
+	if err != nil {
+		t.Error(err)
+	}
+
+	volumeAnnotation := fmt.Sprintf("%s%s", config.VolumesAnnotationPrefix, volume.Name)
+	volumeMountAnnotation := fmt.Sprintf("%s%s", config.VolumeMountsAnnotationPrefix, volumeMount.Name)
+	// Test patching a pod without existing OwnerReference and Volume.
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "spark-driver",
+			Labels: map[string]string{sparkRoleLabel: sparkDriverRole},
+			Annotations: map[string]string{
+				config.OwnerReferenceAnnotation: referenceStr,
+				volumeAnnotation:                volumeStr,
+				volumeMountAnnotation:           volumeMountStr},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  sparkDriverContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	patchOps, err := patchSparkPod(pod1)
+	if err != nil {
+		t.Error(err)
+	}
+	patchBytes, err := json.Marshal(patchOps)
+	if err != nil {
+		t.Error(err)
+	}
+	patch, err := jsonpatch.DecodePatch(patchBytes)
+	if err != nil {
+		t.Error(err)
+	}
+
+	original, err := json.Marshal(pod1)
+	if err != nil {
+		t.Error(err)
+	}
+	modified, err := patch.Apply(original)
+	if err != nil {
+		t.Error(err)
+	}
+	modifiedPod := &corev1.Pod{}
+	if err := json.Unmarshal(modified, modifiedPod); err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, 1, len(modifiedPod.OwnerReferences))
+	assert.Equal(t, ownerReference, modifiedPod.OwnerReferences[0])
+	assert.Equal(t, 1, len(modifiedPod.Spec.Volumes))
+	assert.Equal(t, *volume, modifiedPod.Spec.Volumes[0])
+	assert.Equal(t, 1, len(modifiedPod.Spec.Containers[0].VolumeMounts))
+	assert.Equal(t, *volumeMount, modifiedPod.Spec.Containers[0].VolumeMounts[0])
+
+	// Test patching a pod with existing OwnerReference and Volume.
+	pod2 := pod1.DeepCopy()
+	pod2.OwnerReferences = append(pod2.OwnerReferences, metav1.OwnerReference{Name: "owner-reference1"})
+	pod2.Spec.Volumes = append(pod2.Spec.Volumes, corev1.Volume{Name: "volume1"})
+	pod2.Spec.Containers[0].VolumeMounts = append(pod2.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name: "volume1",
+	})
+
+	patchOps, err = patchSparkPod(pod2)
+	if err != nil {
+		t.Error(err)
+	}
+	patchBytes, err = json.Marshal(patchOps)
+	if err != nil {
+		t.Error(err)
+	}
+	patch, err = jsonpatch.DecodePatch(patchBytes)
+	if err != nil {
+		t.Error(err)
+	}
+
+	original, err = json.Marshal(pod2)
+	if err != nil {
+		t.Error(err)
+	}
+	modified, err = patch.Apply(original)
+	if err != nil {
+		t.Error(err)
+	}
+	modifiedPod = &corev1.Pod{}
+	if err := json.Unmarshal(modified, modifiedPod); err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, 2, len(modifiedPod.OwnerReferences))
+	assert.Equal(t, ownerReference, modifiedPod.OwnerReferences[1])
+	assert.Equal(t, 2, len(modifiedPod.Spec.Volumes))
+	assert.Equal(t, *volume, modifiedPod.Spec.Volumes[1])
+	assert.Equal(t, 2, len(modifiedPod.Spec.Containers[0].VolumeMounts))
+	assert.Equal(t, *volumeMount, modifiedPod.Spec.Containers[0].VolumeMounts[1])
+
+	// Test patching a pod with a pod Affinity.
+	affinity := &corev1.Affinity{
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{sparkRoleLabel: sparkDriverRole},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+	affinityStr, err := util.MarshalAffinity(affinity)
+	if err != nil {
+		t.Error(err)
+	}
+	pod3 := pod1.DeepCopy()
+	pod3.Annotations[config.AffinityAnnotation] = affinityStr
+
+	patchOps, err = patchSparkPod(pod3)
+	if err != nil {
+		t.Error(err)
+	}
+	patchBytes, err = json.Marshal(patchOps)
+	if err != nil {
+		t.Error(err)
+	}
+	patch, err = jsonpatch.DecodePatch(patchBytes)
+	if err != nil {
+		t.Error(err)
+	}
+
+	original, err = json.Marshal(pod3)
+	if err != nil {
+		t.Error(err)
+	}
+	modified, err = patch.Apply(original)
+	if err != nil {
+		t.Error(err)
+	}
+	modifiedPod = &corev1.Pod{}
+	if err := json.Unmarshal(modified, modifiedPod); err != nil {
+		t.Error(err)
+	}
+
+	assert.True(t, modifiedPod.Spec.Affinity != nil)
+	assert.Equal(t, 1,
+		len(modifiedPod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	assert.Equal(t, "kubernetes.io/hostname",
+		modifiedPod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].TopologyKey)
+}

--- a/pkg/webhook/scheme.go
+++ b/pkg/webhook/scheme.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	addToScheme(scheme)
+}
+
+func addToScheme(scheme *runtime.Scheme) {
+	corev1.AddToScheme(scheme)
+	admissionv1beta1.AddToScheme(scheme)
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/golang/glog"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/spark-on-k8s-operator/pkg/config"
+)
+
+const (
+	webhookConfigName = "spark-webhook-config"
+	webhookName       = "webhook.sparkoperator.k8s.io"
+	sparkRoleLabel    = "spark-role"
+	sparkDriverRole   = "driver"
+	sparkExecutorRole = "executor"
+	serverCertFile    = "server-cert.pem"
+	serverKeyFile     = "server-key.pem"
+	caCertFile        = "ca-cert.pem"
+)
+
+type WebHook struct {
+	clientset  kubernetes.Interface
+	server     *http.Server
+	cert       *certBundle
+	serviceRef *v1beta1.ServiceReference
+}
+
+func New(
+	clientset kubernetes.Interface,
+	certDir string,
+	webhookServiceNamespace string,
+	webhookServiceName string,
+	webhookPort int) (*WebHook, error) {
+	cert := &certBundle{
+		serverCertFile: filepath.Join(certDir, serverCertFile),
+		serverKeyFile:  filepath.Join(certDir, serverKeyFile),
+		caCertFile:     filepath.Join(certDir, caCertFile),
+	}
+	path := "/webhook"
+	serviceRef := &v1beta1.ServiceReference{
+		Namespace: webhookServiceNamespace,
+		Name:      webhookServiceName,
+		Path:      &path,
+	}
+	hook := &WebHook{clientset: clientset, cert: cert, serviceRef: serviceRef}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, hook.serve)
+	tlsConfig, err := configServerTLS(cert)
+	if err != nil {
+		return nil, err
+	}
+	hook.server = &http.Server{
+		Addr:      fmt.Sprintf(":%d", webhookPort),
+		Handler:   mux,
+		TLSConfig: tlsConfig,
+	}
+
+	return hook, nil
+}
+
+// Start starts the admission webhook server and registers itself to the API server.
+func (wh *WebHook) Start() error {
+	go func() {
+		glog.Info("Starting the Spark pod admission webhook server")
+		if err := wh.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			glog.Errorf("error while serving the Spark pod admission webhook: %v\n", err)
+		}
+	}()
+
+	return wh.selfRegistration()
+}
+
+// Stop deregisters itself with the API server and stops the admission webhook server.
+func (wh *WebHook) Stop() error {
+	if err := wh.selfDeregistration(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	glog.Info("Stopping the Spark pod admission webhook server")
+	return wh.server.Shutdown(ctx)
+}
+
+func (wh *WebHook) serve(w http.ResponseWriter, r *http.Request) {
+	var body []byte
+	if r.Body != nil {
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			glog.Errorf("failed to read the request body")
+			http.Error(w, "failed to read the request body", http.StatusInternalServerError)
+			return
+		}
+		body = data
+	}
+
+	if len(body) == 0 {
+		glog.Errorf("empty request body")
+		http.Error(w, "empty request body", http.StatusBadRequest)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		glog.Errorf("Content-Type=%s, expected application/json", contentType)
+		http.Error(w, "invalid Content-Type, expected `application/json`", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var reviewResponse *admissionv1beta1.AdmissionResponse
+	review := &admissionv1beta1.AdmissionReview{}
+	deserializer := codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(body, nil, review); err != nil {
+		glog.Error(err)
+		reviewResponse = toAdmissionResponse(err)
+	} else {
+		reviewResponse = mutatePods(review)
+	}
+
+	response := admissionv1beta1.AdmissionReview{}
+	if reviewResponse != nil {
+		response.Response = reviewResponse
+		if review.Request != nil {
+			response.Response.UID = review.Request.UID
+		}
+	}
+
+	resp, err := json.Marshal(response)
+	if err != nil {
+		glog.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(resp); err != nil {
+		glog.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (wh *WebHook) selfRegistration() error {
+	client := wh.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
+	existing, getErr := client.Get(webhookConfigName, metav1.GetOptions{})
+	if getErr != nil && !errors.IsNotFound(getErr) {
+		return getErr
+	}
+
+	ignorePolicy := v1beta1.Ignore
+	caCert, err := readCertFile(wh.cert.caCertFile)
+	if err != nil {
+		return err
+	}
+	webhook := v1beta1.Webhook{
+		Name: webhookName,
+		Rules: []v1beta1.RuleWithOperations{
+			{
+				Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+				Rule: v1beta1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"pods"},
+				},
+			},
+		},
+		ClientConfig: v1beta1.WebhookClientConfig{
+			Service:  wh.serviceRef,
+			CABundle: caCert,
+		},
+		FailurePolicy: &ignorePolicy,
+	}
+	webhooks := []v1beta1.Webhook{webhook}
+
+	if getErr == nil && existing != nil {
+		// Update case.
+		glog.Info("Updating existing MutatingWebhookConfiguration for the Spark pod admission webhook")
+		if !reflect.DeepEqual(webhooks, existing.Webhooks) {
+			existing.Webhooks = webhooks
+			if _, err := client.Update(existing); err != nil {
+				return err
+			}
+		}
+	} else {
+		// Create case.
+		glog.Info("Creating a MutatingWebhookConfiguration for the Spark pod admission webhook")
+		webhookConfig := &v1beta1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: webhookConfigName,
+			},
+			Webhooks: webhooks,
+		}
+		if _, err := client.Create(webhookConfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (wh *WebHook) selfDeregistration() error {
+	client := wh.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
+	return client.Delete(webhookConfigName, metav1.NewDeleteOptions(0))
+}
+
+func mutatePods(review *admissionv1beta1.AdmissionReview) *admissionv1beta1.AdmissionResponse {
+	podResource := metav1.GroupVersionResource{
+		Group:    corev1.SchemeGroupVersion.Group,
+		Version:  corev1.SchemeGroupVersion.Version,
+		Resource: "pods",
+	}
+	if review.Request.Resource != podResource {
+		glog.Errorf("expected resource to be %s, got %s", podResource, review.Request.Resource)
+		return nil
+	}
+
+	raw := review.Request.Object.Raw
+	pod := &corev1.Pod{}
+	if err := json.Unmarshal(raw, pod); err != nil {
+		glog.Error(err)
+		return toAdmissionResponse(err)
+	}
+
+	response := &admissionv1beta1.AdmissionResponse{Allowed: true}
+
+	if !isSparkPod(pod) {
+		return response
+	}
+
+	patchOps, err := patchSparkPod(pod)
+	if err != nil {
+		glog.Error(err)
+		return toAdmissionResponse(err)
+	}
+
+	if len(patchOps) > 0 {
+		patchType := admissionv1beta1.PatchTypeJSONPatch
+		response.PatchType = &patchType
+		patchBytes, err := json.Marshal(patchOps)
+		if err != nil {
+			glog.Error(err)
+			return toAdmissionResponse(err)
+		}
+		response.Patch = patchBytes
+	}
+
+	return response
+}
+
+func toAdmissionResponse(err error) *admissionv1beta1.AdmissionResponse {
+	return &admissionv1beta1.AdmissionResponse{
+		Result: &metav1.Status{
+			Message: err.Error(),
+			Code:    http.StatusInternalServerError,
+		},
+	}
+}
+
+func isSparkPod(pod *corev1.Pod) bool {
+	launchedBySparkOperator, ok := pod.Labels[config.LaunchedBySparkOperatorLabel]
+	if !ok {
+		return false
+	}
+
+	sparkRole, ok := pod.Labels[sparkRoleLabel]
+	if !ok {
+		return false
+	}
+
+	return launchedBySparkOperator == "true" && (sparkRole == sparkDriverRole || sparkRole == sparkExecutorRole)
+}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"k8s.io/spark-on-k8s-operator/pkg/config"
+	"k8s.io/spark-on-k8s-operator/pkg/util"
+)
+
+func TestMutatePod(t *testing.T) {
+	// Testing processing non-Spark pod.
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-driver",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  sparkDriverContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	podBytes, err := serializePod(pod1)
+	if err != nil {
+		t.Error(err)
+	}
+	review := &v1beta1.AdmissionReview{
+		Request: &v1beta1.AdmissionRequest{
+			Resource: metav1.GroupVersionResource{
+				Group:    corev1.SchemeGroupVersion.Group,
+				Version:  corev1.SchemeGroupVersion.Version,
+				Resource: "pods",
+			},
+			Object: runtime.RawExtension{
+				Raw: podBytes,
+			},
+		},
+	}
+	response := mutatePods(review)
+	assert.True(t, response.Allowed)
+
+	// Test processing Spark pod without any patch.
+	pod1.Labels = map[string]string{
+		sparkRoleLabel:                      sparkDriverRole,
+		config.LaunchedBySparkOperatorLabel: "true",
+	}
+
+	podBytes, err = serializePod(pod1)
+	if err != nil {
+		t.Error(err)
+	}
+	review.Request.Object.Raw = podBytes
+	assert.True(t, response.Allowed)
+	assert.True(t, response.PatchType == nil)
+	assert.True(t, response.Patch == nil)
+
+	// Test processing Spark pod with patches.
+	ownerReference := metav1.OwnerReference{
+		APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		Kind:       reflect.TypeOf(v1alpha1.SparkApplication{}).Name(),
+		Name:       "spark-test",
+		UID:        "spark-test-1",
+	}
+	referenceStr, err := util.MarshalOwnerReference(&ownerReference)
+	if err != nil {
+		t.Error(err)
+	}
+
+	volume := &corev1.Volume{
+		Name: "spark",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/spark",
+			},
+		},
+	}
+	volumeStr, err := util.MarshalVolume(volume)
+	if err != nil {
+		t.Error(err)
+	}
+	volumeMount := &corev1.VolumeMount{
+		Name:      "spark",
+		MountPath: "/mnt/spark",
+	}
+	volumeMountStr, err := util.MarshalVolumeMount(volumeMount)
+	if err != nil {
+		t.Error(err)
+	}
+
+	affinity := &corev1.Affinity{
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{sparkRoleLabel: sparkDriverRole},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+	affinityStr, err := util.MarshalAffinity(affinity)
+	if err != nil {
+		t.Error(err)
+	}
+
+	volumeAnnotation := fmt.Sprintf("%s%s", config.VolumesAnnotationPrefix, volume.Name)
+	volumeMountAnnotation := fmt.Sprintf("%s%s", config.VolumeMountsAnnotationPrefix, volumeMount.Name)
+	pod1.Annotations = map[string]string{
+		config.OwnerReferenceAnnotation: referenceStr,
+		volumeAnnotation:                volumeStr,
+		volumeMountAnnotation:           volumeMountStr,
+		config.AffinityAnnotation:       affinityStr,
+	}
+
+	podBytes, err = serializePod(pod1)
+	if err != nil {
+		t.Error(err)
+	}
+	review.Request.Object.Raw = podBytes
+	response = mutatePods(review)
+	assert.True(t, response.Allowed)
+	assert.Equal(t, v1beta1.PatchTypeJSONPatch, *response.PatchType)
+	assert.True(t, len(response.Patch) > 0)
+	var patchOps []*patchOperation
+	json.Unmarshal(response.Patch, &patchOps)
+	assert.Equal(t, 4, len(patchOps))
+}
+
+func serializePod(pod *corev1.Pod) ([]byte, error) {
+	return json.Marshal(pod)
+}


### PR DESCRIPTION
This PR includes an initial commit for adding the mutating admission webhook that will replace the existing initializer for Spark pod customization. It also includes support for pod affinity/anti-affinity.