### PR TITLE
Added optional field MemoryOverhead

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -81,6 +81,7 @@ A `SparkPodSpec` defines common attributes of a driver or executor pod, summariz
 | `Cores` | `spark.driver.cores` or `spark.executor.cores` | Number of CPU cores for the driver or executor pod. |
 | `CoreLimit` | `spark.kubernetes.driver.limit.cores` or `spark.kubernetes.executor.limit.cores` | Hard limit on the number of CPU cores for the driver or executor pod. |
 | `Memory` | `spark.driver.memory` or `spark.executor.memory` | Amount of memory to request for the driver or executor pod. |
+| `MemoryOverhead` | `spark.driver.memoryOverhead` or `spark.executor.memoryOverhead` | Amount of off-heap memory to allocate for the driver or executor pod in cluster mode, in `MiB` unless otherwise specified. |
 | `Image` | `spark.kubernetes.driver.container.image` or `spark.kubernetes.executor.container.image` | Custom container image for the driver or executor. |
 | `ConfigMaps` | N/A | A map of Kubernetes ConfigMaps to mount into the driver or executor pod. Keys are ConfigMap names and values are mount paths. |
 | `Secrets` | `spark.kubernetes.driver.secrets.[SecretName]` or `spark.kubernetes.executor.secrets.[SecretName]` | A map of Kubernetes secrets to mount into the driver or executor pod. Keys are secret names and values specify the mount paths and secret types. |

--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
@@ -309,6 +309,9 @@ type SparkPodSpec struct {
 	// Memory is the amount of memory to request for the pod.
 	// Optional.
 	Memory *string `json:"memory,omitempty"`
+	// MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.
+	// Optional.
+	MemoryOverhead *string `json:"memoryOverhead,omitempty"`
 	// Image is the container image to use. Overrides Spec.Image if set.
 	// Optional.
 	Image *string `json:"image,omitempty"`

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -246,6 +246,10 @@ func addDriverConfOptions(app *v1alpha1.SparkApplication) ([]string, error) {
 		driverConfOptions = append(driverConfOptions,
 			fmt.Sprintf("spark.driver.memory=%s", *app.Spec.Driver.Memory))
 	}
+	if app.Spec.Driver.MemoryOverhead != nil {
+		driverConfOptions = append(driverConfOptions,
+			fmt.Sprintf("spark.driver.memoryOverhead=%s", *app.Spec.Driver.MemoryOverhead))
+	}
 
 	if app.Spec.Driver.ServiceAccount != nil {
 		driverConfOptions = append(driverConfOptions,
@@ -316,16 +320,20 @@ func addExecutorConfOptions(app *v1alpha1.SparkApplication) ([]string, error) {
 	}
 	if app.Spec.Executor.Cores != nil {
 		// Property "spark.executor.cores" does not allow float values.
-		conf := fmt.Sprintf("spark.executor.cores=%d", int32(*app.Spec.Executor.Cores))
-		executorConfOptions = append(executorConfOptions, conf)
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("spark.executor.cores=%d", int32(*app.Spec.Executor.Cores)))
 	}
 	if app.Spec.Executor.CoreLimit != nil {
-		conf := fmt.Sprintf("%s=%s", config.SparkExecutorCoreLimitKey, *app.Spec.Executor.CoreLimit)
-		executorConfOptions = append(executorConfOptions, conf)
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("%s=%s", config.SparkExecutorCoreLimitKey, *app.Spec.Executor.CoreLimit))
 	}
 	if app.Spec.Executor.Memory != nil {
-		conf := fmt.Sprintf("spark.executor.memory=%s", *app.Spec.Executor.Memory)
-		executorConfOptions = append(executorConfOptions, conf)
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("spark.executor.memory=%s", *app.Spec.Executor.Memory))
+	}
+	if app.Spec.Executor.MemoryOverhead != nil {
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("spark.executor.memoryOverhead=%s", *app.Spec.Executor.MemoryOverhead))
 	}
 
 	for key, value := range app.Spec.Executor.Labels {


### PR DESCRIPTION
To cover `spark.driver.memoryOverhead` and `spark.executor.memoryOverhead`.