### PR TITLE
Shorten the suffix appended to the name of the driver UI service

### DIFF
--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -45,9 +45,15 @@ func createSparkUIService(
 		return "", -1, fmt.Errorf("invalid Spark UI port: %s", portStr)
 	}
 
+	serviceName := app.Name + "-ui-svc"
+	if _, err = kubeClient.CoreV1().Services(app.Namespace).Get(serviceName, metav1.GetOptions{}); err == nil {
+		// Delete the service if it already exists.
+		kubeClient.CoreV1().Services(app.Namespace).Delete(serviceName, metav1.NewDeleteOptions(0))
+	}
+
 	service := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      appID + "-ui-svc",
+			Name:      serviceName,
 			Namespace: app.Namespace,
 			Labels: map[string]string{
 				config.SparkAppNameLabel: app.Name,

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -38,8 +38,9 @@ func TestCreateSparkUIService(t *testing.T) {
 		expectedSelector    map[string]string
 		expectError         bool
 	}
+
+	fakeClient := fake.NewSimpleClientset()
 	testFn := func(test testcase, t *testing.T) {
-		fakeClient := fake.NewSimpleClientset()
 		uiServiceName, uiServicePort, err := createSparkUIService(test.app, test.app.Status.AppID, fakeClient)
 		if err != nil {
 			if test.expectError {
@@ -130,7 +131,7 @@ func TestCreateSparkUIService(t *testing.T) {
 		{
 			name:                "service with custom port",
 			app:                 app1,
-			expectedServiceName: app1.Status.AppID + "-ui-svc",
+			expectedServiceName: app1.Name + "-ui-svc",
 			expectedServicePort: 4041,
 			expectedSelector: map[string]string{
 				config.SparkAppNameLabel: "foo",
@@ -142,7 +143,7 @@ func TestCreateSparkUIService(t *testing.T) {
 		{
 			name:                "service with default port",
 			app:                 app2,
-			expectedServiceName: app2.Status.AppID + "-ui-svc",
+			expectedServiceName: app2.Name + "-ui-svc",
 			expectedServicePort: int32(defaultPort),
 			expectedSelector: map[string]string{
 				config.SparkAppNameLabel: "foo",


### PR DESCRIPTION
Fixes #201. By shortening the suffix appended to the name of the driver UI service, we give user more room to use longer application name. Particularly, the service name is changed from `appId-ui-svc` to `appName-ui-svc` instead as `appIs` is derived as `appName-hash`.