### PR TITLE
Add PySpark support to sparkctl and Spark Operator. 

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@ A `SparkApplicationSpec` has the following top-level fields:
 | Field | Spark configuration property or `spark-submit` option | Note |
 | ------------- | ------------- | ------------- |
 | `Type`  | N/A  | The type of the Spark application. Valid values are `Java`, `Scala`, `Python`, and `R`. |
+| `PythonVersion`  | `spark.kubernetes.pyspark.pythonversion`  | This sets the major Python version of the docker image used to run the driver and executor containers. Can either be 2 or 3, default 2. |
 | `Mode`  | `--mode` | Spark deployment mode. Valid values are `cluster` and `client`. |
 | `Image` | `spark.kubernetes.container.image` | Unified container image for the driver, executor, and init-container. |
 | `InitContainerImage` | `spark.kubernetes.initContainer.image` | Custom init-container image. |
@@ -53,6 +54,7 @@ A `SparkApplicationSpec` has the following top-level fields:
 | `NodeSelector` | `spark.kubernetes.node.selector.[labelKey]` | Node selector of the driver pod and executor pods, with key `labelKey` and value as the label's value. |
 | `MaxSubmissionRetries` | N/A | The maximum number of times to retry a failed submission. |
 | `SubmissionRetryInterval` | N/A | The unit of intervals in seconds between submission retries. Depending on the implementation, the actual interval between two submission retries may be a multiple of `SubmissionRetryInterval`, e.g., if linear or exponential backoff is used. |
+| `MemoryOverheadFactor` | `spark.kubernetes.memoryOverheadFactor` | This sets the Memory Overhead Factor that will allocate memory to non-JVM memory. For JVM-based jobs this value will default to 0.10, for non-JVM jobs 0.40. Value of this field will be overridden by `Spec.Driver.MemoryOverhead` and `Spec.Executor.MemoryOverhead` if they are set. |
 
 #### `DriverSpec`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -50,7 +50,7 @@ For general information about working with manifests, see
 A `SparkApplication` also needs a 
 [`.spec` section](https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status). This section
 contains fields for specifying various aspects of an application including its type (`Scala`, `Java`, `Python`, or `R`), 
-deployment mode (`clsuter` or `client`), main application resource URI (e.g., the URI of the application jar), 
+deployment mode (`cluster` or `client`), main application resource URI (e.g., the URI of the application jar), 
 main class, arguments, etc. Node selectors are also supported via the optional field `.spec.nodeSelector`.
 
 It also has fields for specifying the unified container image (to use for both the driver and executors) and the image 
@@ -361,6 +361,42 @@ spec:
 
 Note that the mutating admission webhook is needed to use this feature. Please refer to the 
 [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.
+
+### Python Support
+
+Python support can be enabled by setting `.spec.mainApplicationFile` with path to your python application.
+Optionaly, `.spec.pythonVersion` parameter can be used to set the major Python version of the docker image used 
+to run the driver and executor containers. Below is an example showing part of a `SparkApplication` specification:
+
+```yaml
+spec:
+  type: Python
+  pythonVersion: 2
+  mainApplicationFile: local:///opt/spark/examples/src/main/python/pyfiles.py
+```
+
+Some PySpark applications need additional Python packages to run. 
+Such dependencies are specified using the optional field `.spec.deps.pyFiles` , which translates to the --py-files 
+option of the spark-submit command.
+
+```yaml
+spec:
+  deps:
+    pyfiles:
+       - local:///opt/spark/examples/src/main/python/py_container_checks.py
+       - gs://spark-data/python-dep.zip
+``` 
+
+In order to use the dependencies that are hosted remotely, the following PySpark code
+can be used in Spark 2.4.
+  
+```
+python_dep_file_path = SparkFiles.get("python-dep.zip")
+spark.sparkContext.addPyFile(dep_file_path)
+``` 
+
+Note that Python binding for PySpark will be available in Apache Spark 2.4, 
+and currently requires building a custom Docker image from the Spark master branch.
 
 ## Working with SparkApplications
 

--- a/examples/spark-pyfiles.yaml
+++ b/examples/spark-pyfiles.yaml
@@ -1,0 +1,49 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Support for Python is experimental, and requires building SNAPSHOT image of Apache Spark,
+# with `imagePullPolicy` set to Always
+
+apiVersion: "sparkoperator.k8s.io/v1alpha1"
+kind: SparkApplication
+metadata:
+  name: pyfiles
+  namespace: default
+spec:
+  type: Python
+  pythonVersion: "2"
+  mode: cluster
+  image: "gcr.io/ynli-k8s/spark:v2.4.0-SNAPSHOT"
+  imagePullPolicy: Always
+  mainApplicationFile: local:///opt/spark/examples/src/main/python/pyfiles.py
+  arguments:
+    - python2.7
+  deps:
+    pyfiles:
+       - local:///opt/spark/examples/src/main/python/py_container_checks.py
+  driver:
+    cores: 0.1
+    coreLimit: "200m"
+    memory: "512m"
+    labels:
+      version: 2.4.0
+    serviceAccount: spark
+  executor:
+    cores: 1
+    instances: 1
+    memory: "512m"
+    labels:
+      version: 2.4.0
+  restartPolicy: Never

--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
@@ -212,6 +212,15 @@ type SparkApplicationSpec struct {
 	// SubmissionRetryInterval is the unit of intervals in seconds between submission retries.
 	// Optional.
 	SubmissionRetryInterval *int64 `json:"submissionRetryInterval,omitempty"`
+	// This sets the major Python version of the docker
+	// image used to run the driver and executor containers. Can either be 2 or 3, default 2.
+	// Optional.
+	PythonVersion *string `json:"pythonVersion,omitempty"`
+	// This sets the Memory Overhead Factor that will allocate memory to non-JVM memory.
+	// For JVM-based jobs this value will default to 0.10, for non-JVM jobs 0.40. Value of this field will
+	// be overridden by `Spec.Driver.MemoryOverhead` and `Spec.Executor.MemoryOverhead` if they are set.
+	// Optional.
+	MemoryOverheadFactor *string `json:"memoryOverheadFactor,omitempty"`
 }
 
 // ApplicationStateType represents the type of the current state of an application.

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -135,6 +135,10 @@ const (
 	SparkMaxSimultaneousDownloads = "spark.kubernetes.mountDependencies.maxSimultaneousDownloads"
 	// SparkWaitAppCompletion is the Spark configuration key for specifying whether to wait for application to complete.
 	SparkWaitAppCompletion = "spark.kubernetes.submission.waitAppCompletion"
+	// SparkPythonVersion is the Spark configuration key for specifying python version used.
+	SparkPythonVersion = "spark.kubernetes.pyspark.pythonversion"
+	// SparkPythonVersion is the Spark configuration key for specifying memory overhead factor used for Non-JVM memory.
+	SparkMemoryOverheadFactor = "spark.kubernetes.memoryOverheadFactor"
 )
 
 const (

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -84,6 +84,14 @@ func buildSubmissionCommandArgs(app *v1alpha1.SparkApplication) ([]string, error
 		secretNames := strings.Join(app.Spec.ImagePullSecrets, ",")
 		args = append(args, "--conf", fmt.Sprintf("%s=%s", config.SparkImagePullSecretKey, secretNames))
 	}
+	if app.Spec.PythonVersion != nil {
+		args = append(args, "--conf",
+			fmt.Sprintf("%s=%s", config.SparkPythonVersion, *app.Spec.PythonVersion))
+	}
+	if app.Spec.MemoryOverheadFactor != nil {
+		args = append(args, "--conf",
+			fmt.Sprintf("%s=%s", config.SparkMemoryOverheadFactor, *app.Spec.MemoryOverheadFactor))
+	}
 
 	if app.Spec.SparkConf == nil {
 		app.Spec.SparkConf = make(map[string]string)

--- a/sparkctl/cmd/create.go
+++ b/sparkctl/cmd/create.go
@@ -190,6 +190,19 @@ func handleLocalDependencies(app *v1alpha1.SparkApplication) error {
 		app.Spec.Deps.Files = uploadedFiles
 	}
 
+	localPyFiles, err := filterLocalFiles(app.Spec.Deps.PyFiles)
+	if err != nil {
+		return fmt.Errorf("failed to filter local pyfiles: %v", err)
+	}
+
+	if len(localPyFiles) > 0 {
+		uploadedPyFiles, err := uploadLocalDependencies(app, localPyFiles)
+		if err != nil {
+			return fmt.Errorf("failed to upload local pyfiles: %v", err)
+		}
+		app.Spec.Deps.PyFiles = uploadedPyFiles
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description
This PR add a support for PySpark, and thus closes https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/181

@liyinan926
CC @prasanthkothuri