### PR TITLE
 Extend sparkctl to stream SparkApplication events

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -675,19 +675,35 @@ func (c *Controller) getNodeExternalIP(nodeName string) string {
 
 func (c *Controller) recordDriverEvent(
 	app *v1alpha1.SparkApplication, phase apiv1.PodPhase, name string) {
-	if phase == apiv1.PodSucceeded {
+
+	switch phase {
+	case apiv1.PodSucceeded:
 		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkDriverCompleted", "Driver %s completed", name)
-	} else if phase == apiv1.PodFailed {
+	case apiv1.PodPending:
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkDriverPending", "Driver %s is pending", name)
+	case apiv1.PodRunning:
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkDriverRunning", "Driver %s is running", name)
+	case apiv1.PodFailed:
 		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkDriverFailed", "Driver %s failed", name)
+	case apiv1.PodUnknown:
+		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkDriverUnknownState", "Driver %s in unknown state", name)
 	}
 }
 
 func (c *Controller) recordExecutorEvent(
 	app *v1alpha1.SparkApplication, state v1alpha1.ExecutorState, name string) {
-	if state == v1alpha1.ExecutorCompletedState {
+		
+	switch state {
+	case v1alpha1.ExecutorCompletedState:
 		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorCompleted", "Executor %s completed", name)
-	} else if state == v1alpha1.ExecutorFailedState {
+	case v1alpha1.ExecutorPendingState:
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorPending", "Executor %s is pending", name)
+	case v1alpha1.ExecutorRunningState:
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorRunning", "Executor %s is running", name)
+	case v1alpha1.ExecutorFailedState:
 		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkExecutorFailed", "Executor %s failed", name)
+	case v1alpha1.ExecutorUnknownState:
+		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkExecutorUnknownState", "Executor %s in unknown state", name)
 	}
 }
 

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -692,7 +692,7 @@ func (c *Controller) recordDriverEvent(
 
 func (c *Controller) recordExecutorEvent(
 	app *v1alpha1.SparkApplication, state v1alpha1.ExecutorState, name string) {
-		
+
 	switch state {
 	case v1alpha1.ExecutorCompletedState:
 		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorCompleted", "Executor %s completed", name)

--- a/sparkctl/README.md
+++ b/sparkctl/README.md
@@ -101,6 +101,20 @@ Usage:
 $ sparkctl status <SparkApplication name>
 ```
 
+### Events
+
+`events` is a sub command of `sparkctl` for listing `SparkApplication` events in the namespace 
+specified by `--namespace`. 
+
+The `events` command also supports streaming the events with the `--follow` or `-f` flag. 
+The command will display events since last creation of the `SparkApplication`
+for the specific `name`, and continues to stream events even if `ResourceVersion` changes.
+
+Usage:
+```bash
+$ sparkctl events <SparkApplication name> [-f]
+```
+
 ### Log
 
 `log` is a sub command of `sparkctl` for fetching the logs of a pod of `SparkApplication` with the given name in the 

--- a/sparkctl/cmd/events.go
+++ b/sparkctl/cmd/events.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/util/interrupt"
+	crdclientset "k8s.io/spark-on-k8s-operator/pkg/client/clientset/versioned"
+)
+
+var FollowEvents bool
+
+var eventsCommand = &cobra.Command{
+	Use:   "events <name>",
+	Short: "Shows SparkApplication events",
+	Long:  `Shows events associated with SparkApplication of a given name`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, "must specify a SparkApplication name")
+			return
+		}
+
+		crdClientset, err := getSparkApplicationClient()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to get SparkApplication client: %v\n", err)
+			return
+		}
+
+		kubeClientset, err := getKubeClient()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to get KubeClient: %v\n", err)
+			return
+		}
+
+		if err := doShowEvents(args[0], crdClientset, kubeClientset); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to check events of SparkApplication %s: %v\n", args[0], err)
+		}
+	},
+}
+
+func init() {
+	eventsCommand.Flags().BoolVarP(&FollowEvents, "follow", "f", false,
+		"whether to stream the events for the specified SparkApplication name")
+}
+
+func doShowEvents(name string, crdClientset crdclientset.Interface, kubeClientset kubernetes.Interface) error {
+	app, err := getSparkApplication(name, crdClientset)
+	if err != nil {
+		return fmt.Errorf("failed to get SparkApplication %s: %v", name, err)
+	}
+	app.Kind = "SparkApplication"
+
+	eventsInterface := kubeClientset.CoreV1().Events(Namespace)
+	if FollowEvents {
+		// watch for all events for this specific SparkApplication name
+		selector := eventsInterface.GetFieldSelector(&app.Name, &app.Namespace, &app.Kind, nil)
+		options := metav1.ListOptions{FieldSelector: selector.String(), Watch: true}
+		events, err := eventsInterface.Watch(options)
+		if err != nil {
+			return err
+		}
+		if err := streamEvents(events, app.CreationTimestamp.Unix()); err != nil {
+			return err
+		}
+	} else {
+		// print only events for current SparkApplication UID
+		stringUID := string(app.UID)
+		selector := eventsInterface.GetFieldSelector(&app.Name, &app.Namespace, &app.Kind, &stringUID)
+		options := metav1.ListOptions{FieldSelector: selector.String()}
+		events, err := eventsInterface.List(options)
+		if err != nil {
+			return err
+		}
+		if err := printEvents(events); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func prepareNewTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetColMinWidth(0, 10)
+	table.SetColMinWidth(1, 6)
+	table.SetColMinWidth(2, 50)
+
+	return table
+}
+
+func prepareEventsHeader(table *tablewriter.Table) *tablewriter.Table {
+	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
+	table.SetHeader([]string{"Type", "Age", "Message"})
+	table.SetHeaderLine(true)
+	return table
+}
+
+func printEvents(events *v1.EventList) error {
+	// Render all event rows
+	table := prepareNewTable()
+	table = prepareEventsHeader(table)
+	for _, event := range events.Items {
+		table.Append([]string{
+			event.Type,
+			getSinceTime(event.LastTimestamp),
+			strings.TrimSpace(event.Message),
+		})
+	}
+
+	table.Render()
+	return nil
+}
+
+func streamEvents(events watch.Interface, streamSince int64) error {
+	// Render just table header, without a additional header line as we stream
+	table := prepareNewTable()
+	table = prepareEventsHeader(table)
+	table.SetHeaderLine(false)
+	table.Render()
+
+	// Set 10 minutes inactivity timeout
+	watchExpire := time.Duration(10 * time.Minute)
+	intr := interrupt.New(nil, events.Stop)
+	return intr.Run(func() error {
+		// Start rendering contents of the table without table header as it is already printed
+		table = prepareNewTable()
+		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+		_, err := watch.Until(watchExpire, events, func(ev watch.Event) (bool, error) {
+			if event, isEvent := ev.Object.(*v1.Event); isEvent {
+				// Ensure to display events which are newer than last creation time of SparkApplication
+				// for this specific application name
+				if streamSince <= event.CreationTimestamp.Unix() {
+					// Render each row separately
+					table.ClearRows()
+					table.Append([]string{
+						event.Type,
+						getSinceTime(event.LastTimestamp),
+						strings.TrimSpace(event.Message),
+					})
+					table.Render()
+				}
+			} else {
+				fmt.Printf("info: %v", ev.Object)
+			}
+
+			return false, nil
+		})
+
+		return err
+	})
+}

--- a/sparkctl/cmd/log.go
+++ b/sparkctl/cmd/log.go
@@ -32,7 +32,7 @@ import (
 )
 
 var ExecutorId int32
-var Follow bool
+var FollowLogs bool
 
 var logCommand = &cobra.Command{
 	Use:   "log <name>",
@@ -65,7 +65,7 @@ var logCommand = &cobra.Command{
 func init() {
 	logCommand.Flags().Int32VarP(&ExecutorId, "executor", "e", -1,
 		"id of the executor to fetch logs for")
-	logCommand.Flags().BoolVarP(&Follow, "follow", "f", false, "whether to stream the logs")
+	logCommand.Flags().BoolVarP(&FollowLogs, "follow", "f", false, "whether to stream the logs")
 }
 
 func doLog(name string, kubeClientset clientset.Interface, crdClientset crdclientset.Interface) error {
@@ -87,7 +87,7 @@ func doLog(name string, kubeClientset clientset.Interface, crdClientset crdclien
 	}
 
 	out := os.Stdout
-	if Follow {
+	if FollowLogs {
 		if err := streamLogs(out, kubeClientset, podName); err != nil {
 			return err
 		}

--- a/sparkctl/cmd/root.go
+++ b/sparkctl/cmd/root.go
@@ -40,7 +40,7 @@ func init() {
 		"The namespace in which the SparkApplication is to be created")
 	rootCmd.PersistentFlags().StringVarP(&KubeConfig, "kubeconfig", "k", defaultKubeConfig,
 		"The path to the local Kubernetes configuration file")
-	rootCmd.AddCommand(createCmd, deleteCmd, statusCmd, logCommand, listCmd, forwardCmd)
+	rootCmd.AddCommand(createCmd, deleteCmd, eventsCommand, statusCmd, logCommand, listCmd, forwardCmd)
 }
 
 func Execute() {

--- a/sparkctl/cmd/utils.go
+++ b/sparkctl/cmd/utils.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+func getSinceTime(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "N.A."
+	}
+
+	return duration.ShortHumanDuration(time.Since(timestamp.Time))
+}
+
+func formatNotAvailable(info string) string {
+	if info == "" {
+		return "N.A."
+	}
+	return info
+}


### PR DESCRIPTION
SparkOperator will additionally 
trigger events on driver/executor `pending`, `running` and `unknown`.

- [x] Add documentation when logic approved

Now `$ sparkctl events <name>` will trigger `watch` and display:
```
Events: Type	Reason	Age	Message
Normal	SparkApplicationAdded	1h	SparkApplication spark-pi was added, enqueued it for submission
Normal	SparkApplicationTerminated	1h	SparkApplication spark-pi terminated with state: COMPLETED
Normal	SparkDriverCompleted	1h	Driver spark-pi-1533304888525-driver completed


Normal	SparkExecutorCompleted	1h	Executor spark-pi-1533304888525-exec-1 completed
```

It is also good in early catching early mistakes
```
Normal	SparkApplicationDeleted	6s	SparkApplication spark-pi was deleted
Normal	SparkApplicationAdded	6s	SparkApplication spark-pi was added, enqueued it for submission
Warning	SparkApplicationSubmissionFailed	6s	SparkApplication spark-pi failed submission: Error: Cannot load main class from JAR https://storage.googleapis.com/spark-on-k8s-cluster/spark-app-dependencies/default/spark-pi/spark-service-examples_2.11-0.3.0.jar with URI https. Please specify a class through --class.
```

Additionaly, `$ sparkctl status spark-pi` will pre-format to a bit different status:
```
application state:
+-----------+---------------+---------------+-------------------------------+-----------+---------+
|   STATE   | SUBMITTED AGE | COMPLETED AGE |          DRIVER POD           | DRIVER UI | RETRIES |
+-----------+---------------+---------------+-------------------------------+-----------+---------+
| COMPLETED | 10m           | 10m           | spark-pi-1533309141745-driver | N.A.      |       0 |
+-----------+---------------+---------------+-------------------------------+-----------+---------+
executor state:
+-------------------------------+-----------+
|         EXECUTOR POD          |   STATE   |
+-------------------------------+-----------+
| spark-pi-1533309141745-exec-1 | COMPLETED |
+-------------------------------+-----------+
```

@liyinan926 