### PR TITLE
Modified gencerts.sh script to be used in Helm chart automatic secret creation. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN dep ensure -vendor-only
 COPY . ./
 RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
-
 FROM gcr.io/spark-operator/spark:v2.3.1
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
 RUN apk add --update openssl && rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY . ./
 RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 
-FROM gcr.io/ynli-k8s/spark:v2.3.0
+FROM gcr.io/spark-operator/spark:v2.3.1
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
+RUN apk add --update openssl && rm -rf /var/cache/apk/*
+RUN apk add --update curl && rm -rf /var/cache/apk/*
+COPY hack/gencerts.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/spark-operator"]

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -43,7 +43,7 @@ function parse_arguments {
       shift 2
       continue
       ;;
-      -p|--pod-container) # Whether the script is running inside a pod container or invoked manually
+      -p|--in-pod)
       export IN_POD=true
       shift 1
       continue

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -25,7 +25,7 @@ function usage {
   Options:
   -h | --help               	   Display help information.
   -n | --namespace <namespace>   The namespace where the Spark operator is installed.			
-  -p | --pod-container           whether the script is running inside a pod container or manually invoked.
+  -p | --in-pod                  Whether the script is running inside a pod or not.
 EOF
 }
 

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -23,9 +23,9 @@ function usage {
   cat<< EOF
   Usage: $SCRIPT
   Options:
-  -h | --help               	   This help info.
+  -h | --help               	   Display help information.
   -n | --namespace <namespace>   The namespace where the Spark operator is installed.			
-  -p | --pod-container           whether the script is running inside a pod container or manually invoked
+  -p | --pod-container           whether the script is running inside a pod container or manually invoked.
 EOF
 }
 

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -23,7 +23,7 @@ function usage {
   cat<< EOF
   Usage: $SCRIPT
   Options:
-  -h | --help               	 This help info.
+  -h | --help               	   This help info.
   -n | --namespace <namespace>   The namespace where the Spark operator is installed.			
   -p | --pod-container           whether the script is running inside a pod container or manually invoked
 EOF


### PR DESCRIPTION
Modified gencert.sh so that it can be run inside a pod container when running as a k8s Job. It can still be manually run the same way as before. This PR is to be reviewed together with this [commit](https://github.com/helm/charts/pull/6239/commits/de8d491d000edebc3bff1fc2c9c0b974d958b439).