### PR TITLE
Changed subcommand events to event for sparkctl

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -588,6 +588,7 @@
     "pkg/util/cache",
     "pkg/util/clock",
     "pkg/util/diff",
+    "pkg/util/duration",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/httpstream",
@@ -754,9 +755,15 @@
   packages = ["pkg/util/proto"]
   revision = "bf40560368791a7dddfeea9b3cfcf89b34139f44"
 
+[[projects]]
+  name = "k8s.io/kubernetes"
+  packages = ["pkg/util/interrupt"]
+  revision = "bb9ffb1654d4a729bb4cec18ff088eacc153c239"
+  version = "v1.11.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9b7963ba9e67b29c9399a2c397b014720db36b9d0f8f03e13091c8274607f808"
+  inputs-digest = "a6b3389ce59992ab7fa5c82b0dc47146142d0df41c7295526c39bacc4de07289"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/sparkctl/cmd/event.go
+++ b/sparkctl/cmd/event.go
@@ -18,11 +18,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/cobra"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +35,8 @@ import (
 
 var FollowEvents bool
 
-var eventsCommand = &cobra.Command{
-	Use:   "events <name>",
+var eventCommand = &cobra.Command{
+	Use:   "event <name>",
 	Short: "Shows SparkApplication events",
 	Long:  `Shows events associated with SparkApplication of a given name`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -63,7 +64,7 @@ var eventsCommand = &cobra.Command{
 }
 
 func init() {
-	eventsCommand.Flags().BoolVarP(&FollowEvents, "follow", "f", false,
+	eventCommand.Flags().BoolVarP(&FollowEvents, "follow", "f", false,
 		"whether to stream the events for the specified SparkApplication name")
 }
 

--- a/sparkctl/cmd/root.go
+++ b/sparkctl/cmd/root.go
@@ -40,7 +40,7 @@ func init() {
 		"The namespace in which the SparkApplication is to be created")
 	rootCmd.PersistentFlags().StringVarP(&KubeConfig, "kubeconfig", "k", defaultKubeConfig,
 		"The path to the local Kubernetes configuration file")
-	rootCmd.AddCommand(createCmd, deleteCmd, eventsCommand, statusCmd, logCommand, listCmd, forwardCmd)
+	rootCmd.AddCommand(createCmd, deleteCmd, eventCommand, statusCmd, logCommand, listCmd, forwardCmd)
 }
 
 func Execute() {


### PR DESCRIPTION
This is to be consistent with naming of the other subcommands.

@mrow4a 