### PR TITLE
Fixed the name of a Spark config key

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ A `SparkApplicationSpec` has the following top-level fields:
 | Field | Spark configuration property or `spark-submit` option | Note |
 | ------------- | ------------- | ------------- |
 | `Type`  | N/A  | The type of the Spark application. Valid values are `Java`, `Scala`, `Python`, and `R`. |
-| `PythonVersion`  | `spark.kubernetes.pyspark.pythonversion`  | This sets the major Python version of the docker image used to run the driver and executor containers. Can either be 2 or 3, default 2. |
+| `PythonVersion`  | `spark.kubernetes.pyspark.pythonVersion`  | This sets the major Python version of the docker image used to run the driver and executor containers. Can either be 2 or 3, default 2. |
 | `Mode`  | `--mode` | Spark deployment mode. Valid values are `cluster` and `client`. |
 | `Image` | `spark.kubernetes.container.image` | Unified container image for the driver, executor, and init-container. |
 | `InitContainerImage` | `spark.kubernetes.initContainer.image` | Custom init-container image. |

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -136,7 +136,7 @@ const (
 	// SparkWaitAppCompletion is the Spark configuration key for specifying whether to wait for application to complete.
 	SparkWaitAppCompletion = "spark.kubernetes.submission.waitAppCompletion"
 	// SparkPythonVersion is the Spark configuration key for specifying python version used.
-	SparkPythonVersion = "spark.kubernetes.pyspark.pythonversion"
+	SparkPythonVersion = "spark.kubernetes.pyspark.pythonVersion"
 	// SparkPythonVersion is the Spark configuration key for specifying memory overhead factor used for Non-JVM memory.
 	SparkMemoryOverheadFactor = "spark.kubernetes.memoryOverheadFactor"
 	// SparkDriverJavaOptions is the Spark configuration key for a string of extra JVM options to pass to driver.


### PR DESCRIPTION
`spark.kubernetes.pyspark.pythonversion` has been fixed and changed to `spark.kubernetes.pyspark.pythonVersion` in Spark.