### PR TITLE
Fix reader closing issue when err is not nil

### DIFF
--- a/sparkctl/cmd/create.go
+++ b/sparkctl/cmd/create.go
@@ -289,9 +289,12 @@ type uploadHandler struct {
 func (uh uploadHandler) uploadToBucket(uploadPath, localFilePath string) (string, error) {
 	fileName := filepath.Base(localFilePath)
 	uploadFilePath := filepath.Join(uploadPath, fileName)
+
 	// Check if exists by trying to fetch metadata
 	reader, err := uh.b.NewRangeReader(uh.ctx, uploadFilePath, 0, 0)
-	reader.Close()
+	if err == nil {
+		reader.Close()
+	}
 	if (blob.IsNotExist(err)) || (err == nil && Override) {
 		fmt.Printf("uploading local file: %s\n", fileName)
 


### PR DESCRIPTION
As in the title @liyinan926 - I was getting:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1add8f9]

goroutine 1 [running]:
k8s.io/spark-on-k8s-operator/vendor/github.com/google/go-cloud/blob.(*Reader).Close(0xc4205c2460, 0x2211a00, 0xc420040090)
	/Users/pmrowczy/Projects/go/src/k8s.io/spark-on-k8s-operator/vendor/github.com/google/go-cloud/blob/blob.go:42 +0x29
k8s.io/spark-on-k8s-operator/sparkctl/cmd.uploadHandler.uploadToBucket(0x21f7780, 0xc42027e2d0, 0x7ffeefbffac3, 0x14, 0x7ffeefbffadb, 0x1e, 0x20a5025, 0x2, 0x2211a00, 0xc420040090, ...)
```