### PR TITLE
Adjust documentation, import paths and codegen to avoid case-insensitive import collision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 install:
   - dep ensure
 
-go_import_path: github.com/GoogleCloudPlatform/spark-on-k8s-operator
+go_import_path: github.com/googlecloudplatform/spark-on-k8s-operator
 
 script:
   - go test -v ./...

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,6 @@
 
 
 [[projects]]
-  digest = "1:9702dc153c9bb6ee7ee0587c248b7024700e89e4a7be284faaeeab9da32e1c6b"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
@@ -10,62 +9,23 @@
     "internal",
     "internal/optional",
     "internal/version",
-    "storage",
+    "storage"
   ]
-  pruneopts = ""
   revision = "767c40d6a2e058483c25fa193e963a22da17236d"
   version = "v0.18.0"
 
 [[projects]]
-  digest = "1:f1f464dded149767f5ceb579e73628139ee1a63d9022602109d439862b18f708"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
     "autorest/adal",
     "autorest/azure",
-    "autorest/date",
+    "autorest/date"
   ]
-  pruneopts = ""
   revision = "fc3b03a2d2d1f43fad3007038bd16f044f870722"
   version = "v9.10.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:a01ad406efc79e2cdf827baa8836eb7a0ceb84bcec7f389a163076748076d4ab"
-  name = "github.com/GoogleCloudPlatform/spark-on-k8s-operator"
-  packages = [
-    "pkg/apis/sparkoperator.k8s.io",
-    "pkg/apis/sparkoperator.k8s.io/v1alpha1",
-    "pkg/apis/sparkoperator.k8s.io/v1beta1",
-    "pkg/client/clientset/versioned",
-    "pkg/client/clientset/versioned/fake",
-    "pkg/client/clientset/versioned/scheme",
-    "pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1",
-    "pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake",
-    "pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1",
-    "pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake",
-    "pkg/client/informers/externalversions",
-    "pkg/client/informers/externalversions/internalinterfaces",
-    "pkg/client/informers/externalversions/sparkoperator.k8s.io",
-    "pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1",
-    "pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1",
-    "pkg/client/listers/sparkoperator.k8s.io/v1alpha1",
-    "pkg/client/listers/sparkoperator.k8s.io/v1beta1",
-    "pkg/config",
-    "pkg/controller/scheduledsparkapplication",
-    "pkg/controller/sparkapplication",
-    "pkg/crd",
-    "pkg/crd/scheduledsparkapplication",
-    "pkg/crd/sparkapplication",
-    "pkg/util",
-    "pkg/webhook",
-    "sparkctl/cmd",
-  ]
-  pruneopts = ""
-  revision = "c43465e832dea23675f33a66698e680d900c5ddb"
-
-[[projects]]
-  digest = "1:dbab841ea152563f54241d32eed59754b50fb46241f5b07b629f4bf2411b7474"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -99,100 +59,78 @@
     "service/s3",
     "service/s3/s3iface",
     "service/s3/s3manager",
-    "service/sts",
+    "service/sts"
   ]
-  pruneopts = ""
   revision = "92c96c4f5ad419f2a72401c2f606d51e010cc110"
   version = "v1.14.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6c48291ff15f3c3b263ed6f7356acea45da69e7fca8d0d76d2c021a075fbd52a"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy",
+    "spdy"
   ]
-  pruneopts = ""
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
-  digest = "1:dcefbadf4534c5ecac8573698fba6e6e601157bfa8f96aafe29df31ae582ef2a"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
-  pruneopts = ""
   revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
   version = "v3.0.0"
 
 [[projects]]
-  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:617b3e0f5989d4ff866a1820480990c65dfc9257eb080da749a45e2d76681b02"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  pruneopts = ""
   revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
   version = "v1.37.0"
 
 [[projects]]
-  digest = "1:0a3f6a0c68ab8f3d455f8892295503b179e571b7fefe47cc6c556405d1f83411"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = ""
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
-  digest = "1:1d8a57fce1f68298ce54967c0752a2ab54bf55dff261d245b8f3440a217700cb"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
-  pruneopts = ""
   revision = "24b0969c4cb722950103eed87108c8d291a8df00"
 
 [[projects]]
-  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -200,14 +138,12 @@
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = ""
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:3f95eb48889ea2863cd451b1e8066c725f64772fa06d69e675722dc5c95fd07f"
   name = "github.com/google/go-cloud"
   packages = [
     "blob",
@@ -215,43 +151,35 @@
     "blob/gcsblob",
     "blob/s3blob",
     "gcp",
-    "wire",
+    "wire"
   ]
-  pruneopts = ""
   revision = "354ed1d60b1bb1e190b483a8e8ce88053f83e904"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = ""
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:e097a364f4e8d8d91b9b9eeafb992d3796a41fde3eb548c1a87eb9d9f60725cf"
   name = "github.com/googleapis/gax-go"
   packages = ["."]
-  pruneopts = ""
   revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = ""
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4301e05db7d213e68f2ea25e53809136218c7efb2ebfff4efed949b91adc7a2a"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -260,186 +188,144 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/utils",
-    "pagination",
+    "pagination"
   ]
-  pruneopts = ""
   revision = "6cd928389e7eefe1715e188b97fdd07b09a55e62"
 
 [[projects]]
   branch = "master"
-  digest = "1:9c776d7d9c54b7ed89f119e449983c3f24c0023e75001d6092442412ebca6b94"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = ""
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
-  digest = "1:f81c8d7354cc0c6340f2f7a48724ee6c2b3db3e918ecd441c985b4d2d97dd3e7"
   name = "github.com/howeyc/gopass"
   packages = ["."]
-  pruneopts = ""
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
-  digest = "1:302c6eb8e669c997bec516a138b8fc496018faa1ece4c13e445a2749fbe079bb"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = ""
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
-  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
-  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:9eab2325abbed0ebcee9d44bb3660a69d5d10e42d5ac4a0e77f7a6ea22bfce88"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = ""
   revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
   version = "1.1.3"
 
 [[projects]]
-  digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
-  pruneopts = ""
   revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
   version = "v0.0.2"
 
 [[projects]]
-  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = ""
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:420f9231f816eeca3ff5aab070caac3ed7f27e4d37ded96ce9de3d7a7a2e31ad"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = ""
   revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
   version = "1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:816e800c7b5689e114c0dc6acf494553d1e7a52575764c5d6de67fb32bd8bbb2"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
-  pruneopts = ""
   revision = "d4647c9c7a84d847478d890b816b7d8b62b0b279"
 
 [[projects]]
-  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3148d6840726c78a90ca3e712870c43eebfd723af101a4917adab87bc3da3441"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp",
+    "prometheus/promhttp"
   ]
-  pruneopts = ""
   revision = "ee1c9d7e23df7f011bdf6f12a5c9e7f0ae10a1fe"
 
 [[projects]]
   branch = "master"
-  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = ""
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
-  digest = "1:bfbc121ef802d245ef67421cff206615357d9202337a3d492b8f668906b485a8"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model",
+    "model"
   ]
-  pruneopts = ""
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
-  digest = "1:b694a6bdecdace488f507cff872b30f6f490fdaf988abd74d87ea56406b23b6e"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs",
+    "xfs"
   ]
-  pruneopts = ""
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
-  digest = "1:4fc12a4611ba6e3db7dd567580579cb23fbe59ac77e7233dc8defa7cb0c62001"
   name = "github.com/robfig/cron"
   packages = ["."]
-  pruneopts = ""
   revision = "df38d32658d8788cd446ba74db4bb5375c4b0cb3"
 
 [[projects]]
-  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:8e243c568f36b09031ec18dff5f7d2769dcf5ca4d624ea511c8e3197dc3d352d"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = ""
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:7ae9ab20a379344cd296d7cd041180d547ba5489b8fd6e8919e0de24a94991b2"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -454,23 +340,19 @@
     "tag",
     "trace",
     "trace/internal",
-    "trace/propagation",
+    "trace/propagation"
   ]
-  pruneopts = ""
   revision = "6edeb78af2d9e4f169abb223feaef35da2e45d06"
   version = "v0.13.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9790f02de4149564057296b2698e3632acb48ec5471eb5cc89bf93364ee5f2ea"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = ""
   revision = "a8fb68e7206f8c78be19b432c58eb52a6aa34462"
 
 [[projects]]
   branch = "master"
-  digest = "1:5dc6753986b9eeba4abdf05dedc5ba06bb52dad43cc8aad35ffb42bb7adfa68f"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -480,38 +362,32 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace",
+    "trace"
   ]
-  pruneopts = ""
   revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
 
 [[projects]]
   branch = "master"
-  digest = "1:823e7b6793b3f80b5d01da97211790dc89601937e4b70825fdcb5637ac60f04f"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt",
+    "jwt"
   ]
-  pruneopts = ""
   revision = "1e0a3fa8ba9a5c9eb35c271780101fdaf1b205d7"
 
 [[projects]]
   branch = "master"
-  digest = "1:14ef7df419735d494ee96b2cbc653f4209bd6634125bb66a63c4bcf5f5ab6bf3"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = ""
   revision = "8883426083c04a2627e6e59d84d5f6fb63d16c91"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -527,35 +403,29 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:55a681cb66f28755765fa5fa5104cbd8dc85c55c02d206f9f89566451e3fe1aa"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = ""
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
-  digest = "1:b3e50d2cb7f622d4c647006c4ea5a3245383f3050c31bc246df8c31034f129fe"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk",
+    "internal/fastwalk"
   ]
-  pruneopts = ""
   revision = "c6269430a55499efa2e293ae66926175dc3af30e"
 
 [[projects]]
   branch = "master"
-  digest = "1:7d15746ff4df12481c89fd953a28122fa75368fb1fb1bb1fed918a78647b3c3a"
   name = "google.golang.org/api"
   packages = [
     "gensupport",
@@ -566,13 +436,11 @@
     "iterator",
     "option",
     "storage/v1",
-    "transport/http",
+    "transport/http"
   ]
-  pruneopts = ""
   revision = "2eea9ba0a3d94f6ab46508083e299a00bbbc65f6"
 
 [[projects]]
-  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -584,26 +452,22 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = ""
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d88c2eb6750028f5707971ed1340a02407d5f0967af85bf6ac70c031533f6c15"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
     "googleapis/iam/v1",
-    "googleapis/rpc/status",
+    "googleapis/rpc/status"
   ]
-  pruneopts = ""
   revision = "32ee49c4dd805befd833990acba36cb75042378c"
 
 [[projects]]
-  digest = "1:dda79c5192c1c59f3f60bbc109a6c710f37e3ebef4d1e7527f586e11ec9ba2af"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -629,31 +493,25 @@
     "stats",
     "status",
     "tap",
-    "transport",
+    "transport"
   ]
-  pruneopts = ""
   revision = "7a6a684ca69eb4cae85ad0a484f2e531598c047b"
   version = "v1.12.2"
 
 [[projects]]
-  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = ""
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:5beb32094452970c0d73a2bdacd79aa9cfaa4947a774d521c1bed4b4c2705f15"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -684,14 +542,12 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = ""
   revision = "8b7507fac302640dd5f1efbf9643199952cc58db"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:66d1421ecff35bc48ee0b11a3f891f3af6f775ed6bb1d3e0deeaba221bf42490"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -700,14 +556,12 @@
     "pkg/client/clientset/clientset/fake",
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
-    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake"
   ]
-  pruneopts = ""
   revision = "8e7f43002fec5394a8d96ebca781aa9d4b37aaef"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:ddf1cbe17938e59f1f5d7caa57c03382a450fdc5c91e5852ff89802c8b27b459"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -754,14 +608,12 @@
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = ""
   revision = "17529ec7eadb8de8e7dc835201455f53571f655a"
 
 [[projects]]
   branch = "release-7.0"
-  digest = "1:3a45889089f89cc371fb45b3f8a478248b755e4af17a8cf592e49bdf3481a0b3"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -858,14 +710,12 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue",
+    "util/workqueue"
   ]
-  pruneopts = ""
   revision = "26a26f55b28aa1b338fbaf6fbbe0bcd76aed05e0"
 
 [[projects]]
   branch = "master"
-  digest = "1:5f8a121f3d6f52aa450f560b20096b9d622fead09b0d318d31343af7bc8dbf44"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -880,14 +730,12 @@
     "cmd/deepcopy-gen/args",
     "cmd/defaulter-gen",
     "cmd/defaulter-gen/args",
-    "pkg/util",
+    "pkg/util"
   ]
-  pruneopts = ""
   revision = "4c99649af8fee16989100e4cc3e6a75143530b28"
 
 [[projects]]
   branch = "master"
-  digest = "1:0a35c959fd117efeda39643d60ce6a0530cd6649ad9ebaf1e56c02baed367a80"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -897,117 +745,25 @@
     "generator",
     "namer",
     "parser",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 
 [[projects]]
   branch = "master"
-  digest = "1:324305490fa0113cac244a48e648bf8a566f0a6e5e25c498e8c033a0b4e23c96"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  pruneopts = ""
   revision = "bf40560368791a7dddfeea9b3cfcf89b34139f44"
 
 [[projects]]
-  digest = "1:13614139aef760b502fe057a8d34e9c4257d1581fb85498b0053267596e0514c"
   name = "k8s.io/kubernetes"
   packages = ["pkg/util/interrupt"]
-  pruneopts = ""
   revision = "bb9ffb1654d4a729bb4cec18ff088eacc153c239"
   version = "v1.11.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "cloud.google.com/go/storage",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/fake",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1beta1",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/controller/scheduledsparkapplication",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/controller/sparkapplication",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/crd",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/crd/scheduledsparkapplication",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/crd/sparkapplication",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/webhook",
-    "github.com/GoogleCloudPlatform/spark-on-k8s-operator/sparkctl/cmd",
-    "github.com/aws/aws-sdk-go/aws",
-    "github.com/aws/aws-sdk-go/aws/session",
-    "github.com/aws/aws-sdk-go/service/s3",
-    "github.com/evanphx/json-patch",
-    "github.com/golang/glog",
-    "github.com/google/go-cloud/blob",
-    "github.com/google/go-cloud/blob/gcsblob",
-    "github.com/google/go-cloud/blob/s3blob",
-    "github.com/google/go-cloud/gcp",
-    "github.com/olekukonko/tablewriter",
-    "github.com/prometheus/client_golang/prometheus",
-    "github.com/prometheus/client_golang/prometheus/promhttp",
-    "github.com/prometheus/client_model/go",
-    "github.com/robfig/cron",
-    "github.com/spf13/cobra",
-    "github.com/stretchr/testify/assert",
-    "golang.org/x/net/context",
-    "k8s.io/api/admission/v1beta1",
-    "k8s.io/api/admissionregistration/v1beta1",
-    "k8s.io/api/core/v1",
-    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
-    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
-    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
-    "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/labels",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
-    "k8s.io/apimachinery/pkg/types",
-    "k8s.io/apimachinery/pkg/util/clock",
-    "k8s.io/apimachinery/pkg/util/duration",
-    "k8s.io/apimachinery/pkg/util/errors",
-    "k8s.io/apimachinery/pkg/util/runtime",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/apimachinery/pkg/util/yaml",
-    "k8s.io/apimachinery/pkg/watch",
-    "k8s.io/client-go/discovery",
-    "k8s.io/client-go/discovery/fake",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/kubernetes/fake",
-    "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/plugin/pkg/client/auth",
-    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
-    "k8s.io/client-go/rest",
-    "k8s.io/client-go/testing",
-    "k8s.io/client-go/tools/cache",
-    "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/client-go/tools/portforward",
-    "k8s.io/client-go/tools/record",
-    "k8s.io/client-go/transport/spdy",
-    "k8s.io/client-go/util/flowcontrol",
-    "k8s.io/client-go/util/retry",
-    "k8s.io/client-go/util/workqueue",
-    "k8s.io/code-generator/cmd/client-gen",
-    "k8s.io/code-generator/cmd/deepcopy-gen",
-    "k8s.io/code-generator/cmd/defaulter-gen",
-    "k8s.io/kubernetes/pkg/util/interrupt",
-  ]
+  inputs-digest = "a6b3389ce59992ab7fa5c82b0dc47146142d0df41c7295526c39bacc4de07289"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -214,8 +214,8 @@ $ docker build --build-arg SPARK_IMAGE=<your Spark image> -t <image-tag> .
 If you'd like to build/test the spark-operator locally, follow the instructions below:
 
 ```bash
-$ mkdir -p $GOPATH/src/k8s.io
-$ cd $GOPATH/src/k8s.io
+$ mkdir -p $GOPATH/src/github.com/googlecloudplatform
+$ cd $GOPATH/src/github.com/googlecloudplatform
 $ git clone git@github.com:GoogleCloudPlatform/spark-on-k8s-operator.git
 ```
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -26,7 +26,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-ge
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
 ${CODEGEN_PKG}/generate-groups.sh "all" \
-  github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis \
+  github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis \
   sparkoperator.k8s.io:v1alpha1,v1beta1 \
   --go-header-file "$(dirname ${BASH_SOURCE})/custom-boilerplate.go.txt" \
   --output-base "$(dirname ${BASH_SOURCE})/../../../.."

--- a/main.go
+++ b/main.go
@@ -35,15 +35,15 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	crdinformers "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/controller/scheduledsparkapplication"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/controller/sparkapplication"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/crd"
-	ssacrd "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/crd/scheduledsparkapplication"
-	sacrd "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/crd/sparkapplication"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/webhook"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdinformers "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/controller/scheduledsparkapplication"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/controller/sparkapplication"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/crd"
+	ssacrd "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/crd/scheduledsparkapplication"
+	sacrd "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/crd/sparkapplication"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/webhook"
 )
 
 var (

--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/register.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/register.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
 )
 
 const Version = "v1alpha1"

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/register.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/register.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
 )
 
 const Version = "v1beta1"

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -21,8 +21,8 @@ limitations under the License.
 package versioned
 
 import (
-	sparkoperatorv1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1"
-	sparkoperatorv1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1"
+	sparkoperatorv1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1"
+	sparkoperatorv1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -21,11 +21,11 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	sparkoperatorv1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1"
-	fakesparkoperatorv1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake"
-	sparkoperatorv1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1"
-	fakesparkoperatorv1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake"
+	clientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	sparkoperatorv1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1"
+	fakesparkoperatorv1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake"
+	sparkoperatorv1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1"
+	fakesparkoperatorv1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -21,8 +21,8 @@ limitations under the License.
 package fake
 
 import (
-	sparkoperatorv1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	sparkoperatorv1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	sparkoperatorv1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	sparkoperatorv1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -21,8 +21,8 @@ limitations under the License.
 package scheme
 
 import (
-	sparkoperatorv1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	sparkoperatorv1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	sparkoperatorv1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	sparkoperatorv1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake/fake_scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake/fake_scheduledsparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake/fake_sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake/fake_sparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake/fake_sparkoperator.k8s.io_client.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/fake/fake_sparkoperator.k8s.io_client.go
@@ -21,7 +21,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/scheduledsparkapplication.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	scheme "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	scheme "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/sparkapplication.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	scheme "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	scheme "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/sparkoperator.k8s.io_client.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1alpha1/sparkoperator.k8s.io_client.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_scheduledsparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_sparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_sparkoperator.k8s.io_client.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_sparkoperator.k8s.io_client.go
@@ -21,7 +21,7 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
-	scheme "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	scheme "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/sparkapplication.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
-	scheme "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	scheme "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/sparkoperator.k8s.io_client.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/sparkoperator.k8s.io_client.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -25,9 +25,9 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
-	sparkoperator_k8s_io "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io"
+	versioned "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	sparkoperator_k8s_io "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -23,8 +23,8 @@ package externalversions
 import (
 	"fmt"
 
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -23,7 +23,7 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	versioned "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/interface.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/interface.go
@@ -21,9 +21,9 @@ limitations under the License.
 package sparkoperator
 
 import (
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1"
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1/interface.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1/scheduledsparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1/scheduledsparkapplication.go
@@ -23,10 +23,10 @@ package v1alpha1
 import (
 	time "time"
 
-	sparkoperator_k8s_io_v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	versioned "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
+	sparkoperator_k8s_io_v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	versioned "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1/sparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1alpha1/sparkapplication.go
@@ -23,10 +23,10 @@ package v1alpha1
 import (
 	time "time"
 
-	sparkoperator_k8s_io_v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	versioned "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
+	sparkoperator_k8s_io_v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	versioned "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/interface.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/interface.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
@@ -23,10 +23,10 @@ package v1beta1
 import (
 	time "time"
 
-	sparkoperator_k8s_io_v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
-	versioned "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1beta1"
+	sparkoperator_k8s_io_v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	versioned "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/sparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/sparkapplication.go
@@ -23,10 +23,10 @@ package v1beta1
 import (
 	time "time"
 
-	sparkoperator_k8s_io_v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
-	versioned "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1beta1"
+	sparkoperator_k8s_io_v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	versioned "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions/internalinterfaces"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/listers/sparkoperator.k8s.io/v1alpha1/scheduledsparkapplication.go
+++ b/pkg/client/listers/sparkoperator.k8s.io/v1alpha1/scheduledsparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/sparkoperator.k8s.io/v1alpha1/sparkapplication.go
+++ b/pkg/client/listers/sparkoperator.k8s.io/v1alpha1/sparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	v1alpha1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
+++ b/pkg/client/listers/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/sparkoperator.k8s.io/v1beta1/sparkapplication.go
+++ b/pkg/client/listers/sparkoperator.k8s.io/v1beta1/sparkapplication.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+	v1beta1 "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 // GetDriverAnnotationOption returns a spark-submit option for a driver annotation of the given key and value.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 func TestGetDriverEnvVarConfOptions(t *testing.T) {

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 // FindGeneralConfigMaps finds the annotations for specifying general secrets and returns

--- a/pkg/config/configmap_test.go
+++ b/pkg/config/configmap_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 func TestFindGeneralConfigMaps(t *testing.T) {

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 // GetDriverSecretConfOptions returns a list of spark-submit options for mounting driver secrets.

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 func TestGetDriverSecretConfOptions(t *testing.T) {

--- a/pkg/config/volume.go
+++ b/pkg/config/volume.go
@@ -22,8 +22,8 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 func getVolumeAnnotationsForMounts(volumes []apiv1.Volume, mounts []apiv1.VolumeMount) (map[string]string, error) {

--- a/pkg/config/volume_test.go
+++ b/pkg/config/volume_test.go
@@ -25,8 +25,8 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 func TestFindVolumes(t *testing.T) {

--- a/pkg/controller/scheduledsparkapplication/controller.go
+++ b/pkg/controller/scheduledsparkapplication/controller.go
@@ -36,11 +36,11 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	crdscheme "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
-	crdinformers "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
-	crdlisters "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdscheme "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	crdinformers "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
+	crdlisters "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
 )
 
 var (

--- a/pkg/controller/scheduledsparkapplication/controller_test.go
+++ b/pkg/controller/scheduledsparkapplication/controller_test.go
@@ -31,9 +31,9 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientfake "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/fake"
-	crdinformers "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientfake "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/fake"
+	crdinformers "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
 )
 
 func TestSyncScheduledSparkApplication_Allow(t *testing.T) {

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -37,12 +37,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	crdscheme "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
-	crdinformers "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
-	crdlisters "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdscheme "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/scheme"
+	crdinformers "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
+	crdlisters "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/listers/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 const (

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -34,10 +34,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientfake "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/fake"
-	crdinformers "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientfake "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned/fake"
+	crdinformers "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 func newFakeController(apps ...*v1alpha1.SparkApplication) (*Controller, *record.FakeRecorder) {

--- a/pkg/controller/sparkapplication/monitoring_config.go
+++ b/pkg/controller/sparkapplication/monitoring_config.go
@@ -23,8 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 const (

--- a/pkg/controller/sparkapplication/monitoring_config_test.go
+++ b/pkg/controller/sparkapplication/monitoring_config_test.go
@@ -23,8 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 func TestConfigPrometheusMonitoring(t *testing.T) {

--- a/pkg/controller/sparkapplication/spark_pod_monitor.go
+++ b/pkg/controller/sparkapplication/spark_pod_monitor.go
@@ -30,8 +30,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 // sparkPodMonitor monitors Spark executor pods and update the SparkApplication objects accordingly.

--- a/pkg/controller/sparkapplication/spark_pod_monitor_test.go
+++ b/pkg/controller/sparkapplication/spark_pod_monitor_test.go
@@ -25,8 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 func TestOnPodAdded(t *testing.T) {

--- a/pkg/controller/sparkapplication/sparkapp_metrics.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics.go
@@ -22,8 +22,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 type sparkAppMetrics struct {

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -26,8 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 const (

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -25,8 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 func TestCreateSparkUIService(t *testing.T) {

--- a/pkg/controller/sparkapplication/state_validation.go
+++ b/pkg/controller/sparkapplication/state_validation.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 var (

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -24,9 +24,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 const (

--- a/pkg/controller/sparkapplication/submission_runner.go
+++ b/pkg/controller/sparkapplication/submission_runner.go
@@ -28,7 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 // sparkSubmitRunner is responsible for running user-specified Spark applications.

--- a/pkg/controller/sparkapplication/submission_runner_test.go
+++ b/pkg/controller/sparkapplication/submission_runner_test.go
@@ -23,7 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 func TestNewRunner(t *testing.T) {

--- a/pkg/crd/scheduledsparkapplication/crd.go
+++ b/pkg/crd/scheduledsparkapplication/crd.go
@@ -22,8 +22,8 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 // CRD metadata.

--- a/pkg/crd/sparkapplication/crd.go
+++ b/pkg/crd/sparkapplication/crd.go
@@ -22,8 +22,8 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 // CRD metadata.

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -22,8 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 const (

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -28,9 +28,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 func TestPatchSparkPod_OwnerReference(t *testing.T) {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -35,7 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
 )
 
 const (

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -29,9 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/config"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/util"
 )
 
 func TestMutatePod(t *testing.T) {

--- a/sparkctl/cmd/client.go
+++ b/sparkctl/cmd/client.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 func buildConfig(kubeConfig string) (*rest.Config, error) {

--- a/sparkctl/cmd/create.go
+++ b/sparkctl/cmd/create.go
@@ -34,8 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	clientset "k8s.io/client-go/kubernetes"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 const bufferSize = 1024

--- a/sparkctl/cmd/create_test.go
+++ b/sparkctl/cmd/create_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
 )
 
 func TestIsLocalFile(t *testing.T) {

--- a/sparkctl/cmd/delete.go
+++ b/sparkctl/cmd/delete.go
@@ -24,7 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 var deleteCmd = &cobra.Command{

--- a/sparkctl/cmd/event.go
+++ b/sparkctl/cmd/event.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/util/interrupt"
 
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 var FollowEvents bool

--- a/sparkctl/cmd/forward.go
+++ b/sparkctl/cmd/forward.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 var LocalPort int32

--- a/sparkctl/cmd/list.go
+++ b/sparkctl/cmd/list.go
@@ -25,7 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 var listCmd = &cobra.Command{

--- a/sparkctl/cmd/log.go
+++ b/sparkctl/cmd/log.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 var ExecutorId int32

--- a/sparkctl/cmd/status.go
+++ b/sparkctl/cmd/status.go
@@ -23,8 +23,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
-	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1alpha1"
+	crdclientset "github.com/googlecloudplatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 )
 
 var statusCmd = &cobra.Command{

--- a/sparkctl/main.go
+++ b/sparkctl/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/sparkctl/cmd"
+	"github.com/googlecloudplatform/spark-on-k8s-operator/sparkctl/cmd"
 )
 
 func main() {


### PR DESCRIPTION
When following the steps from https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/docs/quick-start-guide.md#build and calling `go generate` and then `go test ./...` there were errors as 

`
../../googlecloudplatform/spark-on-k8s-operator/vendor/k8s.io/apimachinery/pkg/watch/until.go:23:2: case-insensitive import collision: "github.com/googlecloudplatform/spark-on-k8s-operator/vendor/k8s.io/apimachinery/pkg/util/wait" and "github.com/GoogleCloudPlatform/spark-on-k8s-operator/vendor/k8s.io/apimachinery/pkg/util/wait"
`

CC @liyinan926