### PR TITLE
add the KUBECONFIG check

### DIFF
--- a/sparkctl/cmd/root.go
+++ b/sparkctl/cmd/root.go
@@ -23,7 +23,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var defaultKubeConfig = os.Getenv("HOME") + "/.kube/config"
+func getKubeConfigPath() string {
+	var kubeConfigEnv = os.Getenv("KUBECONFIG")
+	if len(kubeConfigEnv) == 0 {
+		return os.Getenv("HOME") + "/.kube/config"
+	}
+	return kubeConfigEnv
+}
+
+var defaultKubeConfig = getKubeConfigPath()
 
 var Namespace string
 var KubeConfig string


### PR DESCRIPTION
I left the possibility to override it using the `k` flag. The logic to select the `KubeConfig` flag is in this file, so that in `cmd/client.go` `KubeConfig` is already set at its final value (as it is now)