### PR TITLE
Removed the use of the finalizer

### DIFF
--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -76,25 +76,6 @@ func podPhaseToExecutorState(podPhase apiv1.PodPhase) v1alpha1.ExecutorState {
 	}
 }
 
-func removeFinalizer(app *v1alpha1.SparkApplication, finalizerToRemove string) *v1alpha1.SparkApplication {
-	for k, elem := range app.Finalizers {
-		if elem == finalizerToRemove {
-			app.Finalizers = append(app.Finalizers[:k], app.Finalizers[k+1:]...)
-			break
-		}
-	}
-	return app
-}
-
-func addFinalizer(app *v1alpha1.SparkApplication, finalizerToAdd string) *v1alpha1.SparkApplication {
-	if app.ObjectMeta.Finalizers == nil {
-		app.ObjectMeta.Finalizers = []string{finalizerToAdd}
-	} else {
-		app.ObjectMeta.Finalizers = append(app.ObjectMeta.Finalizers, finalizerToAdd)
-	}
-	return app
-}
-
 func isExecutorTerminated(executorState v1alpha1.ExecutorState) bool {
 	return executorState == v1alpha1.ExecutorCompletedState || executorState == v1alpha1.ExecutorFailedState
 }


### PR DESCRIPTION
The operator currently adds a finalizer to a submitted `SparkApplication` object for the purpose of preventing it from being deleted before the driver pod is gone (the operator does try to delete the driver pod when deletion of the `SparkApplication` is requested). The purpose of this is to make sure the driver pod is deleted when the `SparkApplication` gets deleted without relying on an `OwnerReference`. Previously the operator deleted the driver pod and other relevant k8s resources when `onDelete` is called. 

Using a finalizer on a custom resource risks running into this issue: https://github.com/kubernetes/kubernetes/issues/60538 for some versions of Kubernetes. I propose here to remove the use of the finalizer and simply delete the resources when `onDelete` is called. This might risk missing delete events, but the chance is rare. Also given that Kubernetes 1.12 started to support TTL on finished pods (see https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/), using a finalizer is even less appealing for the purpose discussed above. We can set a TTL on the driver pod, which should be garbage collected when the TTL expires, without using an `OwnerReference`. 

@akhurana001 