### PR TITLE
Fixed webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@
 
 ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.0
 
-FROM golang:1.10.2-alpine as builder
-ARG DEP_VERSION="0.4.1"
+FROM golang:1.11.2-alpine as builder
+ARG DEP_VERSION="0.5.0"
 RUN apk add --no-cache bash git
 ADD https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 /usr/bin/dep
 RUN chmod +x /usr/bin/dep
@@ -32,4 +32,6 @@ FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
 RUN apk add --no-cache openssl curl
 COPY hack/gencerts.sh /usr/bin/
+
 ENTRYPOINT ["/usr/bin/spark-operator"]
+

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -31,11 +31,11 @@ EOF
 }
 
 function parse_arguments {
-  while [ $# -gt 0 ]
+  while [[ $# -gt 0 ]]
   do
     case "$1" in
       -n|--namespace)
-      if [ -n "$2" ]; then
+      if [[ -n "$2" ]]; then
         NAMESPACE="$2"
       else
         echo "-n or --namespace requires a value."
@@ -46,7 +46,7 @@ function parse_arguments {
       ;;
       -s|--service)
       if [ -n "$2" ]; then
-	SERVICE="$2"
+        SERVICE="$2"
       else
 	echo "-s or --service requires a value."
 	exit 1
@@ -112,18 +112,18 @@ openssl genrsa -out ${TMP_DIR}/server-key.pem 2048
 openssl req -new -key ${TMP_DIR}/server-key.pem -out ${TMP_DIR}/server.csr -subj "/CN=${SERVICE}.${NAMESPACE}.svc" -config ${TMP_DIR}/server.conf
 openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/ca-cert.pem -CAkey ${TMP_DIR}/ca-key.pem -CAcreateserial -out ${TMP_DIR}/server-cert.pem -days 100000 -extensions v3_req -extfile ${TMP_DIR}/server.conf
 
-if [ "$IN_POD" == "true" ];  then
-	TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+if [[ "$IN_POD" == "true" ]];  then
+  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 
-	# Base64 encode secrets and then remove the trailing newline to avoid issues in the curl command
-	ca_cert=$(cat ${TMP_DIR}/ca-cert.pem | base64 | tr -d '\n')
-	ca_key=$(cat ${TMP_DIR}/ca-key.pem | base64 | tr -d '\n')
-	server_cert=$(cat ${TMP_DIR}/server-cert.pem | base64 | tr -d '\n')
-	server_key=$(cat ${TMP_DIR}/server-key.pem | base64 | tr -d '\n')
+  # Base64 encode secrets and then remove the trailing newline to avoid issues in the curl command
+  ca_cert=$(cat ${TMP_DIR}/ca-cert.pem | base64 | tr -d '\n')
+  ca_key=$(cat ${TMP_DIR}/ca-key.pem | base64 | tr -d '\n')
+  server_cert=$(cat ${TMP_DIR}/server-cert.pem | base64 | tr -d '\n')
+  server_key=$(cat ${TMP_DIR}/server-key.pem | base64 | tr -d '\n')
 
-	# Create the secret resource
-	echo "Creating a secret for the certificate and keys"
-	STATUS=$(curl -ik \
+  # Create the secret resource
+  echo "Creating a secret for the certificate and keys"
+  STATUS=$(curl -ik \
 	  -o ${TMP_DIR}/output \
 	  -w "%{http_code}" \
 	  -X POST \
@@ -146,22 +146,22 @@ if [ "$IN_POD" == "true" ];  then
 	}' \
 	https://kubernetes.default.svc/api/v1/namespaces/${NAMESPACE}/secrets)
 
-	cat ${TMP_DIR}/output
+  cat ${TMP_DIR}/output
 
-	case "$STATUS" in
-	  201)
-	    printf "\nSuccess - secret created.\n"
-	  ;;
-	  409)
-	    printf "\nSuccess - secret already exists.\n"
-	  ;;
-	  *)
-	    printf "\nFailed creating secret.\n"
-	    exit 1
-	  ;;
-    esac
+  case "$STATUS" in
+    201)
+      printf "\nSuccess - secret created.\n"
+    ;;
+    409)
+      printf "\nSuccess - secret already exists.\n"
+     ;;
+     *)
+      printf "\nFailed creating secret.\n"
+      exit 1
+     ;;
+  esac
 else
-	kubectl create secret --namespace=${NAMESPACE} generic spark-webhook-certs --from-file=${TMP_DIR}/ca-key.pem --from-file=${TMP_DIR}/ca-cert.pem --from-file=${TMP_DIR}/server-key.pem --from-file=${TMP_DIR}/server-cert.pem
+  kubectl create secret --namespace=${NAMESPACE} generic spark-webhook-certs --from-file=${TMP_DIR}/ca-key.pem --from-file=${TMP_DIR}/ca-cert.pem --from-file=${TMP_DIR}/server-key.pem --from-file=${TMP_DIR}/server-cert.pem
 fi
 
 # Clean up after we're done.

--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -23,9 +23,9 @@ function usage {
   cat<< EOF
   Usage: $SCRIPT
   Options:
-  -h | --help               	 Display help information.
+  -h | --help                    Display help information.
   -n | --namespace <namespace>   The namespace where the Spark operator is installed.			
-  -s | --service <service>	 The name of the webhook service.
+  -s | --service <service>       The name of the webhook service.
   -p | --in-pod                  Whether the script is running inside a pod or not.
 EOF
 }
@@ -45,11 +45,11 @@ function parse_arguments {
       continue
       ;;
       -s|--service)
-      if [ -n "$2" ]; then
+      if [[ -n "$2" ]]; then
         SERVICE="$2"
       else
-	echo "-s or --service requires a value."
-	exit 1
+        echo "-s or --service requires a value."
+        exit 1
       fi
       shift 2
       continue

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 	resyncInterval      = flag.Int("resync-interval", 30, "Informer resync interval in seconds.")
 	namespace           = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
 	enableWebhook       = flag.Bool("enable-webhook", false, "Whether to enable the mutating admission webhook for admitting and patching Spark pods.")
+	webhookConfigName	= flag.String("webhook-config-name", "spark-webhook-config", "The name of the MutatingWebhookConfiguration object to create.")
 	webhookCertDir      = flag.String("webhook-cert-dir", "/etc/webhook-certs", "The directory where x509 certificate and key files are stored.")
 	webhookSvcNamespace = flag.String("webhook-svc-namespace", "spark-operator", "The namespace of the Service for the webhook server.")
 	webhookSvcName      = flag.String("webhook-svc-name", "spark-webhook", "The name of the Service for the webhook server.")
@@ -167,7 +168,7 @@ func main() {
 		if err != nil {
 			glog.Fatal(err)
 		}
-		if err = hook.Start(); err != nil {
+		if err = hook.Start(*webhookConfigName); err != nil {
 			glog.Fatal(err)
 		}
 	}
@@ -182,7 +183,7 @@ func main() {
 	applicationController.Stop()
 	scheduledApplicationController.Stop()
 	if *enableWebhook {
-		if err := hook.Stop(); err != nil {
+		if err := hook.Stop(*webhookConfigName); err != nil {
 			glog.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ var (
 	resyncInterval      = flag.Int("resync-interval", 30, "Informer resync interval in seconds.")
 	namespace           = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
 	enableWebhook       = flag.Bool("enable-webhook", false, "Whether to enable the mutating admission webhook for admitting and patching Spark pods.")
-	webhookConfigName	= flag.String("webhook-config-name", "spark-webhook-config", "The name of the MutatingWebhookConfiguration object to create.")
+	webhookConfigName   = flag.String("webhook-config-name", "spark-webhook-config", "The name of the MutatingWebhookConfiguration object to create.")
 	webhookCertDir      = flag.String("webhook-cert-dir", "/etc/webhook-certs", "The directory where x509 certificate and key files are stored.")
 	webhookSvcNamespace = flag.String("webhook-svc-namespace", "spark-operator", "The namespace of the Service for the webhook server.")
 	webhookSvcName      = flag.String("webhook-svc-name", "spark-webhook", "The name of the Service for the webhook server.")


### PR DESCRIPTION
This PR needs to be merged first and the image `gcr.io/spark-operator/spark-operator:v2.4.0-v1alpha1-latest` needs to be rebuilt and pushed. After that I'll make a PR with these [changes](https://github.com/helm/charts/compare/master...yuchaoran2011:fixwebhook) against helm/charts repo. Because only after the new image is pushed will the helm/charts CI pass on my PR.

I also made the MutatingWebhookConfiguration name configurable. We have a use case where two teams each has an operator instance running in their own namespace. The team who installs the operator later would override the webhook configuration of the team who deployed earlier.

Fixed #335 