### PR TITLE
Minor fixes to CRD validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.0
 
-FROM golang:1.11.4-alpine as builder
+FROM golang:1.11.5-alpine as builder
 ARG DEP_VERSION="0.5.0"
 RUN apk add --no-cache bash git
 ADD https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 /usr/bin/dep

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -23,7 +23,7 @@
 ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.0
 ARG USER_ID=185
 
-FROM golang:1.11.4-alpine as builder
+FROM golang:1.11.5-alpine as builder
 ARG DEP_VERSION="0.5.0"
 RUN apk add --no-cache bash git 
 ADD https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 /usr/bin/dep

--- a/examples/spark-pi-prometheus.yaml
+++ b/examples/spark-pi-prometheus.yaml
@@ -26,6 +26,7 @@ spec:
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar"
+  sparkVersion: "2.4.0"
   restartPolicy:
     type: Never
   driver:

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -26,6 +26,7 @@ spec:
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar"
+  sparkVersion: "2.4.0"
   restartPolicy:
     type: Never
   volumes:

--- a/examples/spark-py-pi.yaml
+++ b/examples/spark-py-pi.yaml
@@ -28,6 +28,7 @@ spec:
   image: "gcr.io/spark-operator/spark-py:v2.4.0"
   imagePullPolicy: Always
   mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
+  sparkVersion: "2.4.0"
   restartPolicy:
     type: OnFailure
     onFailureRetries: 3


### PR DESCRIPTION
1. Upgraded Go to 1.11.5
2. Added required `sparkVersion` in the SparkApplication examples. Otherwise [validation](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/commit/4d6f9a059b86238192421268dc2384f353754383#diff-d1c35bf2dffda85b37b85868c24d9421R157) would fail.