### PR TITLE
Update the user guide with info on the default secretType

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -157,6 +157,7 @@ spec:
 
 The type of a Secret as specified by the `secretType` field is a hint to the operator on what extra configuration it needs to take care of for the specific type of Secrets. For example, if a Secret is of type **`GCPServiceAccount`**, the operator additionally sets the environment variable **`GOOGLE_APPLICATION_CREDENTIALS`** to point to the JSON key file stored in the secret. Please refer to 
 [Getting Started with Authentication](https://cloud.google.com/docs/authentication/getting-started) for more information on how to authenticate with GCP services using a service account JSON key file. Note that the operator assumes that the key of the service account JSON key file in the Secret data map is **`key.json`** so it is able to set the environment variable automatically. Similarly, if the type of a Secret is **`HadoopDelegationToken`**, the operator additionally sets the environment variable **`HADOOP_TOKEN_FILE_LOCATION`** to point to the file storing the Hadoop delegation token. In this case, the operator assumes that the key of the delegation token file in the Secret data map is **`hadoop.token`**.
+The `secretType` field should have the value `Generic` if no extra configuration is required.
 
 ### Mounting ConfigMaps
 


### PR DESCRIPTION
I could not find what `secretType` I had to use if I didn't need any special configuration handling and I ended up having to look it up in the source code. I added a single line to help people find this information.