### PR TITLE
Hard code the USER in OpenShift Dockerfile to 185

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -21,7 +21,6 @@
 # 2. export DOCKER_BUILDKIT=1
 
 ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.0
-ARG USER_ID=185
 
 FROM golang:1.11.5-alpine as builder
 ARG DEP_VERSION="0.5.0"
@@ -37,7 +36,7 @@ RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
-USER root
+USER 185
 
 # Comment out the following three lines if you do not have a RedHat subscription.
 COPY hack/install_packages.sh /
@@ -49,5 +48,4 @@ RUN chmod -R u+x /tmp
 RUN apk add --no-cache openssl curl tini
 COPY hack/gencerts.sh /usr/bin/
 COPY entrypoint.sh /usr/bin/
-USER ${USER_ID}
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]


### PR DESCRIPTION
Due to a known [issue](https://github.com/moby/moby/issues/34129#issuecomment-315856425) with Moby, which is used to build the OpenShift operator image, parameterizing the USER caused the operator image to have the `root` user no matter what ARG is set. So for now, hard coding the USER to 185/JBoss for the OpenShift image is unfortunately the only option. 