### PR TITLE
Update test suite to run against arbitrary configuration

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -36,7 +36,7 @@ RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
-USER 185
+USER root
 
 # Comment out the following three lines if you do not have a RedHat subscription.
 COPY hack/install_packages.sh /
@@ -45,7 +45,7 @@ RUN rm /install_packages.sh
 
 RUN chmod -R u+x /tmp
 
-RUN apk add --no-cache openssl curl tini
 COPY hack/gencerts.sh /usr/bin/
 COPY entrypoint.sh /usr/bin/
+USER 185
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/sparkctl/build.sh
+++ b/sparkctl/build.sh
@@ -13,13 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
 set -e
-arg1=$(head -2 /opt/spark/credentials | tail -1)
-arg2=$(head -3 /opt/spark/credentials | tail -1)
-arg3=$(head -1 /opt/spark/credentials | tail -1)
-
-subscription-manager register --username=$arg1 --password=$arg2  --name=docker
-subscription-manager attach --pool=$arg3 && yum install -y openssl
-subscription-manager remove --all
-subscription-manager unregister
-subscription-manager clean
+platforms=("linux:amd64" "darwin:amd64")
+for platform in "${platforms[@]}"
+do
+  GOOS="${platform%%:*}"
+  GOARCH="${platform#*:}"
+  echo $GOOS
+  echo $GOARCH
+  CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -o sparkctl-${GOOS}-${GOARCH}
+done

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func getJobStatus(t *testing.T) v1beta1.ApplicationStateType {
-	app, err := appFramework.GetSparkApplication(framework.SparkApplicationClient, "default", "spark-pi")
+	app, err := appFramework.GetSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, "spark-pi")
 	assert.Equal(t, nil, err)
 	return app.Status.AppState.State
 }
@@ -40,12 +40,24 @@ func TestSubmitSparkPiYaml(t *testing.T) {
 	t.Parallel()
 
 	// Wait for test job to finish. Time out after 90 seconds.
-	timeout := 100 * time.Second
+	timeout := 300 * time.Second
 	interval := 5 * time.Second
 
 	sa, err := appFramework.MakeSparkApplicationFromYaml("../../examples/spark-pi.yaml")
+	if appFramework.SparkTestNamespace != "" {
+		sa.ObjectMeta.Namespace = appFramework.SparkTestNamespace
+	}
+
+	if appFramework.SparkTestServiceAccount != "" {
+		sa.Spec.Driver.ServiceAccount = &appFramework.SparkTestServiceAccount
+	}
+
+	if appFramework.SparkTestImage != "" {
+		sa.Spec.Image = &appFramework.SparkTestImage
+	}
+
 	assert.Equal(t, nil, err)
-	err = appFramework.CreateSparkApplication(framework.SparkApplicationClient, "default", sa)
+	err = appFramework.CreateSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, sa)
 	assert.Equal(t, nil, err)
 
 	status := getJobStatus(t)
@@ -58,12 +70,12 @@ func TestSubmitSparkPiYaml(t *testing.T) {
 		return false, nil
 	})
 
-	app, _ := appFramework.GetSparkApplication(framework.SparkApplicationClient, "default", "spark-pi")
+	app, _ := appFramework.GetSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, "spark-pi")
 	podName := app.Status.DriverInfo.PodName
-	rawLogs, err := framework.KubeClient.CoreV1().Pods("default").GetLogs(podName, &v1.PodLogOptions{}).Do().Raw()
+	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do().Raw()
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, -1, strings.Index(string(rawLogs), "Pi is roughly 3"))
 
-	err = appFramework.DeleteSparkApplication(framework.SparkApplicationClient, "default", "spark-pi")
+	err = appFramework.DeleteSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, "spark-pi")
 	assert.Equal(t, nil, err)
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -30,7 +30,11 @@ var framework *operatorFramework.Framework
 func TestMain(m *testing.M) {
 	kubeconfig := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
 	opImage := flag.String("operator-image", "", "operator image, e.g. image:tag")
+	opImagePullPolicy := flag.String("operator-image-pullPolicy", "IfNotPresent", "pull policy, e.g. Always")
 	ns := flag.String("namespace", "spark-operator", "e2e test namespace")
+	sparkTestNamespace := flag.String("spark-test-namespace", "default", "e2e test spark-test-namespace")
+	sparkTestImage := flag.String("spark-test-image", "", "spark test image, e.g. image:tag")
+	sparkTestServiceAccount := flag.String("spark-test-service-account", "default", "e2e test spark test service account")
 	flag.Parse()
 
 	if *kubeconfig == "" {
@@ -39,10 +43,13 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	if framework, err = operatorFramework.New(*ns, *kubeconfig, *opImage); err != nil {
+	if framework, err = operatorFramework.New(*ns, *kubeconfig, *opImage, *opImagePullPolicy); err != nil {
 		log.Fatalf("failed to set up framework: %v\n", err)
 	}
 
+	operatorFramework.SparkTestNamespace = *sparkTestNamespace
+	operatorFramework.SparkTestImage = *sparkTestImage
+	operatorFramework.SparkTestServiceAccount = *sparkTestServiceAccount
 	code := m.Run()
 
 	if err := framework.Teardown(); err != nil {


### PR DESCRIPTION
- Updates the suite so it can use for example an arbitrary namespace and sa.
- fixes several minor issues
Example how it can be used with this patch:
- adds a build script for sparkctl

```
export SPARK_TEST_NAMESPACE=spark
export SPARK_TEST_SERVICE_ACCOUNT=spark-sa
export SPARK_TEST_IMAGE=<image>
go test -v ./test/e2e/ --kubeconfig "$HOME/.kube/config" --operator-image-pullPolicy=Always \
--operator-image=<image> \
--spark-test-namespace=spark --spark-test-image=<image> \
--spark-test-service-account=spark-sa
```