### PR TITLE
Support prometheus custom configuration file

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ A `PrometheusSpec` configures how metrics are exposed to Prometheus.
 | ------------- | ------------- | ------------- |
 | `JmxExporterJar` | N/A | This specifies the path to the [Prometheus JMX exporter](https://github.com/prometheus/jmx_exporter) jar. |
 | `Port` | N/A | If specified, the value will be used in the Java agent configuration for the Prometheus JMX exporter. The Java agent gets bound to the specified port if specified or `8090` otherwise by default. |
-| `ConfigFile` | N/A | This specifies the full path of the Prometheus configuration file in the Spark job image. If specified, it will override the default configurations and take precedence over `Configuration` shown below. |
+| `ConfigFile` | N/A | This specifies the full path of the Prometheus configuration file in the Spark image. If specified, it will override the default configurations and take precedence over `Configuration` shown below. |
 | `Configuration` | N/A | If specified, this contains the contents of a custom Prometheus configuration used by the Prometheus JMX exporter. Otherwise, the contents of `spark-docker/conf/prometheus.yaml` will be used, unless `ConfigFile` is specified. |
 
 ### `SparkApplicationStatus`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,7 @@
 # SparkApplication API
 
-The Kubernetes Operator for Apache Spark uses  [CustomResourceDefinitions](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) 
-named `SparkApplication` and `ScheduledSparkApplication` for specifying one-time Spark applications and Spark applications
-that are supposed to run on a standard [cron](https://en.wikipedia.org/wiki/Cron) schedule. Similarly to other kinds of 
-Kubernetes resources, they consist of a specification in a `Spec` field and a `Status` field. The definitions are organized 
-in the following structure. The v1beta1 version of the API definition is implemented 
-[here](../pkg/apis/sparkoperator.k8s.io/v1beta1/types.go).
+The Kubernetes Operator for Apache Spark uses  [CustomResourceDefinitions](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) named `SparkApplication` and `ScheduledSparkApplication` for specifying one-time Spark applications and Spark applications
+that are supposed to run on a standard [cron](https://en.wikipedia.org/wiki/Cron) schedule. Similarly to other kinds of Kubernetes resources, they consist of a specification in a `Spec` field and a `Status` field. The definitions are organized in the following structure. The v1beta1 version of the API definition is implemented [here](../pkg/apis/sparkoperator.k8s.io/v1beta1/types.go).
 
 ```
 ScheduledSparkApplication
@@ -124,7 +120,8 @@ A `PrometheusSpec` configures how metrics are exposed to Prometheus.
 | ------------- | ------------- | ------------- |
 | `JmxExporterJar` | N/A | This specifies the path to the [Prometheus JMX exporter](https://github.com/prometheus/jmx_exporter) jar. |
 | `Port` | N/A | If specified, the value will be used in the Java agent configuration for the Prometheus JMX exporter. The Java agent gets bound to the specified port if specified or `8090` otherwise by default. |
-| `Configuration` | N/A | If specified, this contains the content of a custom Prometheus configuration used by the Prometheus JMX exporter. Otherwise, the content of `spark-docker/conf/prometheus.yaml` will be used. |
+| `ConfigFile` | N/A | This specifies the full path of the Prometheus configuration file in the Spark job image. If specified, it will override the default configurations and take precedence over `Configuration` shown below. |
+| `Configuration` | N/A | If specified, this contains the contents of a custom Prometheus configuration used by the Prometheus JMX exporter. Otherwise, the contents of `spark-docker/conf/prometheus.yaml` will be used, unless `ConfigFile` is specified. |
 
 ### `SparkApplicationStatus`
 

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -478,7 +478,7 @@ type PrometheusSpec struct {
 	// Optional.
 	// If not specified, 8090 will be used as the default.
 	Port *int32 `json:"port"`
-	// ConfigFile is the path to the custom Prometheus configuration file provided in the Spark job image.
+	// ConfigFile is the path to the custom Prometheus configuration file provided in the Spark image.
 	// ConfigFile takes precedence over Configuration, which is shown below.
 	ConfigFile *string `json:"configFile,omitempty"`
 	// Configuration is the content of the Prometheus configuration needed by the Prometheus JMX exporter.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -480,10 +480,10 @@ type PrometheusSpec struct {
 	Port *int32 `json:"port"`
 	// ConfigFile is the path to the custom Prometheus configuration file provided in the Spark job image.
 	// ConfigFile takes precedence over Configuration, which is shown below.
-	ConfigFile string `json:"configFile"`
+	ConfigFile *string `json:"configFile,omitempty"`
 	// Configuration is the content of the Prometheus configuration needed by the Prometheus JMX exporter.
 	// Optional.
 	// If not specified, the content in spark-docker/conf/prometheus.yaml will be used.
 	// Configuration has no effect if ConfigFile is set.
-	Configuration *string `json:"configuration"`
+	Configuration *string `json:"configuration,omitempty"`
 }

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -478,8 +478,12 @@ type PrometheusSpec struct {
 	// Optional.
 	// If not specified, 8090 will be used as the default.
 	Port *int32 `json:"port"`
+	// ConfigFile is the path to the custom Prometheus configuration file provided in the Spark job image.
+	// ConfigFile takes precedence over Configuration, which is shown below.
+	ConfigFile string `json:"configFile"`
 	// Configuration is the content of the Prometheus configuration needed by the Prometheus JMX exporter.
 	// Optional.
 	// If not specified, the content in spark-docker/conf/prometheus.yaml will be used.
+	// Configuration has no effect if ConfigFile is set.
 	Configuration *string `json:"configuration"`
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -177,84 +177,84 @@ const DefaultPrometheusConfiguration = `
 lowercaseOutputName: true
 attrNameSnakeCase: true
 rules:
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
     name: spark_driver_$3_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
     name: spark_streaming_driver_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
     name: spark_structured_streaming_driver_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
       query_name: "$3"
-  - pattern: metrics<name=(\S+)-(\S+)\.(\S+)\.executor\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.(\S+)\.executor\.(\S+)><>Value
     name: spark_executor_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.DAGScheduler\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.DAGScheduler\.(.*)><>Count
     name: spark_driver_DAGScheduler_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
     name: spark_driver_HiveExternalCatalog_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.CodeGenerator\.(.*)><>Count
     name: spark_driver_CodeGenerator_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
     name: spark_driver_LiveListenerBus_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
     name: spark_driver_LiveListenerBus_$3
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
-  - pattern: metrics<name=(\S+)-(\S+)\.(.*)\.executor\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.(.*)\.executor\.(.*)><>Count
     name: spark_executor_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+)-(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
     name: spark_executor_$4_$5
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+)-(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
     name: spark_executor_HiveExternalCatalog_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+)-(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
     name: spark_executor_CodeGenerator_$4_count
     type: COUNTER
     labels:

--- a/pkg/controller/sparkapplication/monitoring_config.go
+++ b/pkg/controller/sparkapplication/monitoring_config.go
@@ -45,10 +45,10 @@ func configPrometheusMonitoring(app *v1beta1.SparkApplication, kubeClient client
 		port = *app.Spec.Monitoring.Prometheus.Port
 	}
 
-	configFile := app.Spec.Monitoring.Prometheus.ConfigFile
+	configFile := *app.Spec.Monitoring.Prometheus.ConfigFile
 	var javaOption string
 	if configFile != "" {
-		glog.V(2).Infof("Overriding the default Prometheus configuration with config file %s in the Spark job image.", configFile)
+		glog.V(2).Infof("Overriding the default Prometheus configuration with config file %s in the Spark image.", configFile)
 		javaOption = fmt.Sprintf("-javaagent:%s=%d:%s", app.Spec.Monitoring.Prometheus.JmxExporterJar,
 			port, configFile)
 	} else {

--- a/pkg/controller/sparkapplication/monitoring_config.go
+++ b/pkg/controller/sparkapplication/monitoring_config.go
@@ -74,6 +74,7 @@ func configPrometheusMonitoring(app *v1beta1.SparkApplication, kubeClient client
 		if retryErr != nil {
 			return fmt.Errorf("failed to apply %s in namespace %s: %v", prometheusConfigMapName, app.Namespace, retryErr)
 		}
+
 		javaOption = fmt.Sprintf("-javaagent:%s=%d:%s/%s", app.Spec.Monitoring.Prometheus.JmxExporterJar,
 			port, prometheusConfigMapMountPath, prometheusConfigKey)
 

--- a/pkg/controller/sparkapplication/monitoring_config.go
+++ b/pkg/controller/sparkapplication/monitoring_config.go
@@ -45,7 +45,10 @@ func configPrometheusMonitoring(app *v1beta1.SparkApplication, kubeClient client
 		port = *app.Spec.Monitoring.Prometheus.Port
 	}
 
-	configFile := *app.Spec.Monitoring.Prometheus.ConfigFile
+	var configFile string
+	if app.Spec.Monitoring.Prometheus.ConfigFile != nil {
+		configFile = *app.Spec.Monitoring.Prometheus.ConfigFile
+	}
 	var javaOption string
 	if configFile != "" {
 		glog.V(2).Infof("Overriding the default Prometheus configuration with config file %s in the Spark image.", configFile)

--- a/pkg/controller/sparkapplication/monitoring_config.go
+++ b/pkg/controller/sparkapplication/monitoring_config.go
@@ -92,7 +92,7 @@ func configPrometheusMonitoring(app *v1beta1.SparkApplication, kubeClient client
 	}
 
 	/* work around for push gateway issue: https://github.com/prometheus/pushgateway/issues/97 */
-	metricNamespace := fmt.Sprintf("%s-%s", app.Namespace, app.Name)
+	metricNamespace := fmt.Sprintf("%s.%s", app.Namespace, app.Name)
 	metricConf := fmt.Sprintf("%s/%s", prometheusConfigMapMountPath, metricsPropertiesKey)
 	if app.Spec.SparkConf == nil {
 		app.Spec.SparkConf = make(map[string]string)

--- a/pkg/controller/sparkapplication/monitoring_config_test.go
+++ b/pkg/controller/sparkapplication/monitoring_config_test.go
@@ -61,7 +61,7 @@ func TestConfigPrometheusMonitoring(t *testing.T) {
 			t.Errorf("prometheus.yaml expected %s got %s", test.prometheusConfig, configMap.Data[prometheusConfigKey])
 		}
 
-		expectedMetricsNamespace := fmt.Sprintf("%s-%s", test.app.Namespace, test.app.Name)
+		expectedMetricsNamespace := fmt.Sprintf("%s.%s", test.app.Namespace, test.app.Name)
 		if test.app.Spec.SparkConf["spark.metrics.namespace"] != expectedMetricsNamespace {
 			t.Errorf("metrics namespace expected %s got %s", expectedMetricsNamespace, test.app.Spec.SparkConf["spark.metrics.namespace"])
 		}

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -209,9 +209,8 @@ func addGeneralConfigMaps(pod *corev1.Pod) []*patchOperation {
 	for name, mountPath := range namesToMountPaths {
 		volumeName := name + "-vol"
 		if len(volumeName) > maxNameLength {
-			glog.V(2).Infof("ConfigMap volume name %s is too long. Truncating to length %d.", volumeName, maxNameLength)
 			volumeName = volumeName[0:maxNameLength]
-			glog.V(2).Infof("Truncated volume name: %s.", volumeName)
+			glog.V(2).Infof("ConfigMap volume name is too long. Truncating to length %d. Result: %s.", maxNameLength, volumeName)
 		}
 		patchOps = append(patchOps, addConfigMapVolume(pod, name, volumeName))
 		patchOps = append(patchOps, addConfigMapVolumeMount(pod, volumeName, mountPath))

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -256,7 +256,7 @@ func mutatePods(review *admissionv1beta1.AdmissionReview, sparkJobNs string) *ad
 	response := &admissionv1beta1.AdmissionResponse{Allowed: true}
 
 	if !isSparkPod(pod) || !inSparkJobNamespace(review.Request.Namespace, sparkJobNs) {
-		glog.V(2).Info(pod.Name, " in namespace ", review.Request.Namespace, " not mutated")
+		glog.V(2).Info(pod.GetObjectMeta().GetName(), " in namespace ", review.Request.Namespace, " not mutated.")
 		return response
 	}
 

--- a/spark-docker/conf/prometheus.yaml
+++ b/spark-docker/conf/prometheus.yaml
@@ -20,14 +20,14 @@ attrNameSnakeCase: true
 rules:
   # These come from the application driver if it's a streaming application
   # Example: default/streaming.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
     name: spark_streaming_driver_$4
     labels:
       app_namespace: "$1"
       app_name: "$2"
   # These come from the application driver if it's a structured streaming application
   # Example: default/sstreaming.driver.spark.streaming.QueryName.inputRate-total
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
     name: spark_structured_streaming_driver_$4
     labels:
       app_namespace: "$1"
@@ -35,7 +35,7 @@ rules:
       query_name: "$3"
   # These come from the application executors
   # Example: default/spark-pi.0.executor.threadpool.activeTasks
-  - pattern: metrics<name=(\S+)-(\S+)\.(\S+)\.executor\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.(\S+)\.executor\.(\S+)><>Value
     name: spark_executor_$4
     type: GAUGE
     labels:
@@ -44,7 +44,7 @@ rules:
       executor_id: "$3"
   # These come from the application driver
   # Example: default/spark-pi.driver.DAGScheduler.stage.failedStages
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
     name: spark_driver_$3_$4
     type: GAUGE
     labels:
@@ -52,14 +52,14 @@ rules:
       app_name: "$2"
   # These come from the application driver
   # Emulate timers for DAGScheduler like messagePRocessingTime
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.DAGScheduler\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.DAGScheduler\.(.*)><>Count
     name: spark_driver_DAGScheduler_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
   # HiveExternalCatalog is of type counter
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
     name: spark_driver_HiveExternalCatalog_$3_count
     type: COUNTER
     labels:
@@ -67,7 +67,7 @@ rules:
       app_name: "$2"
   # These come from the application driver
   # Emulate histograms for CodeGenerator
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.CodeGenerator\.(.*)><>Count
     name: spark_driver_CodeGenerator_$3_count
     type: COUNTER
     labels:
@@ -75,21 +75,21 @@ rules:
       app_name: "$2"
   # These come from the application driver
   # Emulate timer (keep only count attribute) plus counters for LiveListenerBus
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
     name: spark_driver_LiveListenerBus_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
       app_name: "$2"
   # Get Gauge type metrics for LiveListenerBus
-  - pattern: metrics<name=(\S+)-(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
     name: spark_driver_LiveListenerBus_$3
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
   # Executors counters
-  - pattern: metrics<name=(\S+)-(\S+)\.(.*)\.executor\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.(.*)\.executor\.(.*)><>Count
     name: spark_executor_$4_count
     type: COUNTER
     labels:
@@ -98,14 +98,14 @@ rules:
       executor_id: "$3"
   # These come from the application executors
   # Example: app-20160809000059-0000.0.jvm.threadpool.activeTasks
-  - pattern: metrics<name=(\S+)-(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
+  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
     name: spark_executor_$4_$5
     type: GAUGE
     labels:
       app_namespace: "$1"
       app_name: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+)-(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
     name: spark_executor_HiveExternalCatalog_$4_count
     type: COUNTER
     labels:
@@ -114,7 +114,7 @@ rules:
       executor_id: "$3"
   # These come from the application driver
   # Emulate histograms for CodeGenerator
-  - pattern: metrics<name=(\S+)-(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
     name: spark_executor_CodeGenerator_$4_count
     type: COUNTER
     labels:


### PR DESCRIPTION
1. Added an API to pass custom Prometheus configuration file contained in a job image. The current APIs only support passing the contents of a custom Prometheus configuration file, but not the file name. The new API allows the user to bake his config file in the Spark job image and reference it in the job YAML.

2. Automatically truncate the volume name to fit 63 chars. This [PR](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/405) introduced a band-aid solution to shorten the suffixes appended by the operator. Now the operator simply truncates the volume name to be 63 characters if it's longer than 63. The user will no longer to experience a failed job because of this issue.

Both of these issues are what we faced in our internal applications using the operator at Lightbend. We think these improvements will enhance the user experience and improve robustness of the operator. 

3. Changed the separator between the namespace and the rest of the metric name from hyphen to dot. Hyphen is really a poor choice of a separator because both the namespace and the metric name can contain hyphens, causing mismatches in the regex. Dot would solve this problem as K8s resource names are not allowed to contain dots.