### PR TITLE
Set default values when creating a new app 

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -171,6 +171,7 @@ func (c *Controller) Stop() {
 // Callback function called when a new SparkApplication object gets created.
 func (c *Controller) onAdd(obj interface{}) {
 	app := obj.(*v1beta1.SparkApplication)
+	v1beta1.SetSparkApplicationDefaults(app)
 	glog.Infof("SparkApplication %s/%s was added, enqueueing it for submission", app.Namespace, app.Name)
 	c.enqueue(app)
 }


### PR DESCRIPTION
Fixes #417 

Verified it works by observing the expected behavior:
```
I0221 11:02:24.834853      11 controller.go:248] Starting processing key: "spark/spark-pi"
I0221 11:02:24.834887      11 controller.go:510] Trying to update SparkApplication spark/spark-pi, from: [{spark-application-1550746819628 2019-02-21 11:00:10 +0000 UTC 2019-02-21 11:02:21 +0000 UTC {spark-pi-ui-svc 31037    spark-pi-driver} {FAILING } map[spark-pi-1550746808866-exec-1:FAILED] 1 1}] to [{spark-application-1550746819628 2019-02-21 11:00:10 +0000 UTC 2019-02-21 11:02:21 +0000 UTC {spark-pi-ui-svc 31037    spark-pi-driver} {FAILING } map[spark-pi-1550746808866-exec-1:FAILED] 1 1}]
I0221 11:02:24.834980      11 controller.go:255] Ending processing key: "spark/spark-pi"
I0221 11:02:37.452601      11 controller.go:208] SparkApplication spark/spark-pi was updated, enqueueing it
I0221 11:02:37.452658      11 controller.go:248] Starting processing key: "spark/spark-pi"
I0221 11:02:37.452696      11 controller.go:531] currentTime is 2019-02-21 11:02:37.452689462 +0000 UTC m=+151.067030360, interval is 5s
I0221 11:02:37.452756      11 controller.go:683] Deleting pod with name spark-pi-driver in namespace spark
I0221 11:02:37.465396      11 spark_pod_eventhandler.go:52] Pod spark-pi-driver updated in namespace spark.
I0221 11:02:37.465418      11 spark_pod_eventhandler.go:77] Enqueuing SparkApplication spark/spark-pi for status update processing.
I0221 11:02:37.468695      11 controller.go:692] Deleting Spark UI Service spark-pi-ui-svc in namespace spark
I0221 11:02:37.468866      11 spark_pod_eventhandler.go:71] Pod spark-pi-driver deleted in namespace spark.
I0221 11:02:37.468895      11 spark_pod_eventhandler.go:77] Enqueuing SparkApplication spark/spark-pi for status update processing.
I0221 11:02:37.493753      11 controller.go:510] Trying to update SparkApplication spark/spark-pi, from: [{spark-application-1550746819628 2019-02-21 11:00:10 +0000 UTC 2019-02-21 11:02:21 +0000 UTC {spark-pi-ui-svc 31037    spark-pi-driver} {FAILING } map[spark-pi-1550746808866-exec-1:FAILED] 1 1}] to [{spark-application-1550746819628 2019-02-21 11:00:10 +0000 UTC 2019-02-21 11:02:21 +0000 UTC {spark-pi-ui-svc 31037    spark-pi-driver} {PENDING_RERUN } map[spark-pi-1550746808866-exec-1:FAILED] 1 1}]
I0221 11:02:37.503781      11 sparkapp_metrics.go:135] Exporting metrics for spark-pi; old status: {spark-application-1550746819628 2019-02-21 11:00:10 +0000 UTC 2019-02-21 11:02:21 +0000 UTC {spark-pi-ui-svc 31037    spark-pi-driver} {FAILING } map[spark-pi-1550746808866-exec-1:FAILED] 1 1} new status: {spark-application-1550746819628 2019-02-21 11:00:10 +0000 UTC 2019-02-21 11:02:21 +0000 UTC {spark-pi-ui-svc 31037    spark-pi-driver} {PENDING_RERUN } map[spark-pi-1550746808866-exec-1:FAILED] 1 1}
```
the app transitions in a `PENDING_RERUN` state and is re-submitted.