### PR TITLE
Add InClusterconfig for sparkctl if no kubeconfig provided

### DIFF
--- a/sparkctl/cmd/client.go
+++ b/sparkctl/cmd/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	"os"
 )
 
 func buildConfig(kubeConfig string) (*rest.Config, error) {

--- a/sparkctl/cmd/client.go
+++ b/sparkctl/cmd/client.go
@@ -21,14 +21,13 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"os"
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
-	"os"
 )
 
 func buildConfig(kubeConfig string) (*rest.Config, error) {
-
 	// Check if kubeConfig exist
 	if _, err := os.Stat(kubeConfig); os.IsNotExist(err) {
 		// Try InclusterConfig for sparkctl running in a pod

--- a/sparkctl/cmd/client.go
+++ b/sparkctl/cmd/client.go
@@ -17,11 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"

--- a/sparkctl/cmd/client.go
+++ b/sparkctl/cmd/client.go
@@ -27,6 +27,18 @@ import (
 )
 
 func buildConfig(kubeConfig string) (*rest.Config, error) {
+
+	// Check if kubeConfig exist
+	if _, err := os.Stat(kubeConfig); os.IsNotExist(err) {
+		// Try InclusterConfig for sparkctl running in a pod
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		return config, nil
+	}
+
 	return clientcmd.BuildConfigFromFlags("", kubeConfig)
 }
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/419