### PR TITLE
Prometheus: Fixed separator escaping. Renamed field

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -177,89 +177,89 @@ const DefaultPrometheusConfiguration = `
 lowercaseOutputName: true
 attrNameSnakeCase: true
 rules:
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
     name: spark_driver_$3_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
     name: spark_streaming_driver_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
     name: spark_structured_streaming_driver_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       query_name: "$3"
-  - pattern: metrics<name=(\S+).(\S+)\.(\S+)\.executor\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.(\S+)\.executor\.(\S+)><>Value
     name: spark_executor_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.DAGScheduler\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.DAGScheduler\.(.*)><>Count
     name: spark_driver_DAGScheduler_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
     name: spark_driver_HiveExternalCatalog_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.CodeGenerator\.(.*)><>Count
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.CodeGenerator\.(.*)><>Count
     name: spark_driver_CodeGenerator_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
     name: spark_driver_LiveListenerBus_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
     name: spark_driver_LiveListenerBus_$3
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
-  - pattern: metrics<name=(\S+).(\S+)\.(.*)\.executor\.(.*)><>Count
+      app_id: "$2"
+  - pattern: metrics<name=(\S+)\.(\S+)\.(.*)\.executor\.(.*)><>Count
     name: spark_executor_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
     name: spark_executor_$4_$5
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
     name: spark_executor_HiveExternalCatalog_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
     name: spark_executor_CodeGenerator_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
 `
 const DefaultPrometheusJavaAgentPort int32 = 8090

--- a/pkg/controller/sparkapplication/sparkapp_metrics_test.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics_test.go
@@ -28,7 +28,7 @@ func TestSparkAppMetrics(t *testing.T) {
 	http.DefaultServeMux = new(http.ServeMux)
 	// Test with label containing "-". Expect them to be converted to "_".
 	metrics := newSparkAppMetrics("", []string{"app-name"})
-	app1 := map[string]string{"app_name": "test1"}
+	app1 := map[string]string{"app_id": "test1"}
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/controller/sparkapplication/sparkapp_metrics_test.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics_test.go
@@ -27,7 +27,7 @@ import (
 func TestSparkAppMetrics(t *testing.T) {
 	http.DefaultServeMux = new(http.ServeMux)
 	// Test with label containing "-". Expect them to be converted to "_".
-	metrics := newSparkAppMetrics("", []string{"app-name"})
+	metrics := newSparkAppMetrics("", []string{"app-id"})
 	app1 := map[string]string{"app_id": "test1"}
 
 	var wg sync.WaitGroup

--- a/pkg/util/metrics_test.go
+++ b/pkg/util/metrics_test.go
@@ -36,9 +36,9 @@ func TestPositiveGauge_EmptyLabels(t *testing.T) {
 }
 
 func TestPositiveGauge_WithLabels(t *testing.T) {
-	gauge := NewPositiveGauge("testGauge1", "test-description-1", []string{"app_name"})
-	app1 := map[string]string{"app_name": "test1"}
-	app2 := map[string]string{"app_name": "test2"}
+	gauge := NewPositiveGauge("testGauge1", "test-description-1", []string{"app_id"})
+	app1 := map[string]string{"app_id": "test1"}
+	app2 := map[string]string{"app_id": "test2"}
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/spark-docker/conf/prometheus.yaml
+++ b/spark-docker/conf/prometheus.yaml
@@ -20,104 +20,104 @@ attrNameSnakeCase: true
 rules:
   # These come from the application driver if it's a streaming application
   # Example: default/streaming.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
     name: spark_streaming_driver_$4
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # These come from the application driver if it's a structured streaming application
   # Example: default/sstreaming.driver.spark.streaming.QueryName.inputRate-total
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
     name: spark_structured_streaming_driver_$4
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       query_name: "$3"
   # These come from the application executors
   # Example: default/spark-pi.0.executor.threadpool.activeTasks
-  - pattern: metrics<name=(\S+).(\S+)\.(\S+)\.executor\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.(\S+)\.executor\.(\S+)><>Value
     name: spark_executor_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
   # These come from the application driver
   # Example: default/spark-pi.driver.DAGScheduler.stage.failedStages
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
     name: spark_driver_$3_$4
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # These come from the application driver
   # Emulate timers for DAGScheduler like messagePRocessingTime
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.DAGScheduler\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.DAGScheduler\.(.*)><>Count
     name: spark_driver_DAGScheduler_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # HiveExternalCatalog is of type counter
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
     name: spark_driver_HiveExternalCatalog_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # These come from the application driver
   # Emulate histograms for CodeGenerator
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.CodeGenerator\.(.*)><>Count
     name: spark_driver_CodeGenerator_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # These come from the application driver
   # Emulate timer (keep only count attribute) plus counters for LiveListenerBus
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
     name: spark_driver_LiveListenerBus_$3_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # Get Gauge type metrics for LiveListenerBus
-  - pattern: metrics<name=(\S+).(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
     name: spark_driver_LiveListenerBus_$3
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
   # Executors counters
-  - pattern: metrics<name=(\S+).(\S+)\.(.*)\.executor\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.(.*)\.executor\.(.*)><>Count
     name: spark_executor_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
   # These come from the application executors
   # Example: app-20160809000059-0000.0.jvm.threadpool.activeTasks
-  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
     name: spark_executor_$4_$5
     type: GAUGE
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
-  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
     name: spark_executor_HiveExternalCatalog_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"
   # These come from the application driver
   # Emulate histograms for CodeGenerator
-  - pattern: metrics<name=(\S+).(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
     name: spark_executor_CodeGenerator_$4_count
     type: COUNTER
     labels:
       app_namespace: "$1"
-      app_name: "$2"
+      app_id: "$2"
       executor_id: "$3"


### PR DESCRIPTION
1. Fixed the escaping of the dot separator between the namespace and the app name in the metric names.
2. Changed `app_name` to `app_id` to be consistent with the naming in the Spark Prometheus [configuration](https://github.com/prometheus/jmx_exporter/blob/master/example_configs/spark.yml).