### PR TITLE
Made tests run sequentially

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,10 +15,14 @@ e2e tests are written as Go test. All go test techniques apply (e.g. picking wha
 $ go test -v ./test/e2e/ --kubeconfig "$HOME/.kube/config" --operator-image=gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-latest
 ```
 
-###Available tests
+### Available tests
 
 Note that all tests are run on a live Kubernetes cluster. After the tests are done, the Spark Operator deployment and associated resources (e.g. ClusterRole and ClusterRoleBinding) are deleted from the cluster.
 
 * `basic_test.go`
 
   This test submits `spark-pi.yaml` contained in `\examples`. It then checks that the Spark job successfully completes with the correct result of Pi.
+  
+* `volume_mount_test.go`
+
+  This test submits `spark-pi-configmap.yaml` contained in `\examples`. It verifies that a dummy ConfigMap can be mounted in the Spark pods.

--- a/test/e2e/volume_mount_test.go
+++ b/test/e2e/volume_mount_test.go
@@ -41,8 +41,6 @@ type describeClient struct {
 }
 
 func TestMountConfigMap(t *testing.T) {
-	t.Parallel()
-
 	appName := "spark-pi"
 
 	sa, err := appFramework.MakeSparkApplicationFromYaml("../../examples/spark-pi-configmap.yaml")


### PR DESCRIPTION
1. In my previous PR, the two integration tests run in parallel. Because both jobs have the same name `spark-pi`, they would cause conflicts with each other (e.g. The first test is finished and then deletes the sparkapp `spark-pi`, while the second test is still running). The fix can be either renaming the sparkapp names in the YAMLs, or making them run sequentially.
2. Added missing content in tests README.