### PR TITLE
Fixed gencert job in e2e tests

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -2,7 +2,7 @@
 
 End-to-end (e2e) testing is automated testing for real user scenarios.
 
-## Build and run test
+## Build and Run Tests
 
 Prerequisites:
 - A running k8s cluster and kube config. We will need to pass kube config as arguments.
@@ -15,7 +15,7 @@ e2e tests are written as Go test. All go test techniques apply (e.g. picking wha
 $ go test -v ./test/e2e/ --kubeconfig "$HOME/.kube/config" --operator-image=gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-latest
 ```
 
-### Available tests
+### Available Tests
 
 Note that all tests are run on a live Kubernetes cluster. After the tests are done, the Spark Operator deployment and associated resources (e.g. ClusterRole and ClusterRoleBinding) are deleted from the cluster.
 


### PR DESCRIPTION
1. The gencerts job needs to be cleaned up once completed. Not doing so would potentially cause the tests to fail, because this [line](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/test/e2e/framework/framework.go#L148) checks that the first pod it sees to be in "RUNNING" status.
2. The gencerts job image wasn't being configured. Now it's fixed.