### PR TITLE
Limit SparkApplication name to 63 characters in JSON schema validation

### DIFF
--- a/manifest/spark-operator-crds.yaml
+++ b/manifest/spark-operator-crds.yaml
@@ -32,6 +32,12 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        metadata:
+          properties:
+            name:
+              type: string
+              minLength: 1
+              maxLength: 63
         spec:
           properties:
             deps:

--- a/pkg/crd/sparkapplication/crd.go
+++ b/pkg/crd/sparkapplication/crd.go
@@ -60,6 +60,15 @@ func getCustomResourceValidation() *apiextensionsv1beta1.CustomResourceValidatio
 	return &apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
 			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				"metadata": {
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"name": {
+							Type:      "string",
+							MinLength: int64Ptr(1),
+							MaxLength: int64Ptr(63),
+						},
+					},
+				},
 				"spec": {
 					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 						"type": {
@@ -164,6 +173,10 @@ func getCustomResourceValidation() *apiextensionsv1beta1.CustomResourceValidatio
 			},
 		},
 	}
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
 }
 
 func float64Ptr(f float64) *float64 {


### PR DESCRIPTION
Fixes #465

@liyinan926 