### PR TITLE
Add sparkapplications, scheduledsparkapplications permissions to admin

### DIFF
--- a/manifest/spark-operator-rbac.yaml
+++ b/manifest/spark-operator-rbac.yaml
@@ -67,3 +67,22 @@ roleRef:
   kind: ClusterRole
   name: sparkoperator
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: sparkoperator-aggregate-to-admin
+rules:
+- apiGroups: ["sparkoperator.k8s.io"]
+  resources: ["sparkapplications", "scheduledsparkapplications"]
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
After installations of the operator, the `admin` role will not have any permissions to use `sparkapplications` or `scheduledsparkapplications`.

Using `rbac.authorization.k8s.io/aggregate-to-admin: "true"` annotation with `sparkoperator-aggregate-to-admin` will add these permissions to the admin role. This is very useful when you assign admin role for service accounts or users to allow them to use the operator without any extra RBACs. 