### PR TITLE
Add hostNetwork option for driver and executor.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,7 @@ The Kubernetes Operator for Apache Spark ships with a command-line tool called `
     * [Writing Driver Specification](#writing-driver-specification)
     * [Writing Executor Specification](#writing-executor-specification)
     * [Requesting GPU Resources](#requesting-gpu-resources)
-    * [Setting hostNetwork](#setting-hostnetwork)    
+    * [Host Network](#host-network)    
     * [Mounting Secrets](#mounting-secrets)
     * [Mounting ConfigMaps](#mounting-configmaps)
         * [Mounting a ConfigMap storing Spark Configuration Files](#mounting-a-configmap-storing-spark-configuration-files)
@@ -170,11 +170,10 @@ spec:
     gpu:
       name: "nvidia.com/gpu"
       quantity: 1
-
 ```
 Note that the mutating admission webhook is needed to use this feature. Please refer to the [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.
 
-### Setting hostNetwork
+### Host Network
 
 A `SparkApplication` can specify `hostNetwork` for the driver or executor pod, using the optional field `.spec.driver.hostNetwork` or `.spec.executor.hostNetwork`. When `hostNetwork` is `true`, the operator sets pods' `spec.hostNetwork` to `true` and sets pods' `spec.dnsPolicy` to `ClusterFirstWithHostNet`. Below is an example:
 
@@ -192,7 +191,6 @@ spec:
     cores: 1
     instances: 1
     memory: "512m"
-
 ```
 Note that the mutating admission webhook is needed to use this feature. Please refer to the [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,6 +12,7 @@ The Kubernetes Operator for Apache Spark ships with a command-line tool called `
     * [Writing Driver Specification](#writing-driver-specification)
     * [Writing Executor Specification](#writing-executor-specification)
     * [Requesting GPU Resources](#requesting-gpu-resources)
+    * [Setting hostNetwork](#setting-hostnetwork)    
     * [Mounting Secrets](#mounting-secrets)
     * [Mounting ConfigMaps](#mounting-configmaps)
         * [Mounting a ConfigMap storing Spark Configuration Files](#mounting-a-configmap-storing-spark-configuration-files)
@@ -169,6 +170,28 @@ spec:
     gpu:
       name: "nvidia.com/gpu"
       quantity: 1
+
+```
+Note that the mutating admission webhook is needed to use this feature. Please refer to the [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.
+
+### Setting hostNetwork
+
+A `SparkApplication` can specify `hostNetwork` for the driver or executor pod, using the optional field `.spec.driver.hostNetwork` or `.spec.executor.hostNetwork`. When `hostNetwork` is `true`, the operator sets pods' `spec.hostNetwork` to `true` and sets pods' `spec.dnsPolicy` to `ClusterFirstWithHostNet`. Below is an example:
+
+```yaml
+spec:
+  driver:
+    cores: 0.1
+    coreLimit: "200m"
+    memory: "512m"
+    hostNetwork: true
+    labels:
+      version: 2.4.0
+    serviceAccount: spark
+  executor:
+    cores: 1
+    instances: 1
+    memory: "512m"
 
 ```
 Note that the mutating admission webhook is needed to use this feature. Please refer to the [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -388,6 +388,9 @@ type SparkPodSpec struct {
 	// Sidecars is a list of sidecar containers that run along side the main Spark container.
 	// Optional.
 	Sidecars []apiv1.Container `json:"sidecars,omitempty"`
+	// HostNetwork indicates whether to request host networking for the pod or not.
+	// Optional.
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // DriverSpec is specification of the driver.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/zz_generated.deepcopy.go
@@ -765,6 +765,11 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Hi, this pr adds `hostNetwork` option for driver and executor, according to https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/451 .