### PR TITLE
Whos using update stacktome

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -4,6 +4,7 @@
 | ------------- | ------------- | ------------- | ------------- |
 | Microsoft (MileIQ) |@dharmeshkakadia| Production | AI & Analytics |
 | Lightbend |@yuchaoran2011| Production | Data Infrastructure & Operations |
+| StackTome | @evaldasw | Production | Data pipelines |
 | CERN|@mrow4a| Evaluation | Data Mining & Analytics |
 | Lyft |@kumare3| Evaluation | ML & Data Infrastructure |
 | MapR Technologies |@sarjeet2013| Evaluation | ML/AI & Analytics Data Platform |

--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -4,7 +4,7 @@
 | ------------- | ------------- | ------------- | ------------- |
 | Microsoft (MileIQ) |@dharmeshkakadia| Production | AI & Analytics |
 | Lightbend |@yuchaoran2011| Production | Data Infrastructure & Operations |
-| StackTome | @evaldasw | Production | Data pipelines |
+| StackTome | @emiliauskas-fuzzy | Production | Data pipelines |
 | CERN|@mrow4a| Evaluation | Data Mining & Analytics |
 | Lyft |@kumare3| Evaluation | ML & Data Infrastructure |
 | MapR Technologies |@sarjeet2013| Evaluation | ML/AI & Analytics Data Platform |


### PR DESCRIPTION
We're started using spark operator in place of spark jobserver in production for ELT type of data pipelines. We even created a skuber extension to make it easy for communicating with spark operator on kubernetes using scala - https://github.com/stacktome/skuber-spark-operator.