### PR TITLE
Added DNS config option for the driver and executor pods

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -378,6 +378,24 @@ spec:
       ...
 ```
 
+### Using DNS Settings
+A `SparkApplication` can define DNS settings for the driver and/or executor pod, by adding the standart [DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config) kubernetes settings. Fields to add such configuration are `.spec.driver.dnsConfig` and `.spec.executor.dnsConfig`. Example:
+
+```yaml
+spec:
+  driver:
+    dnsConfig:
+      nameservers:
+        - 1.2.3.4
+      searches:
+        - ns1.svc.cluster.local
+        - my.dns.search.suffix
+      options:
+        - name: ndots
+          value: "2"
+        - name: edns0
+```
+
 Note that the mutating admission webhook is needed to use this feature. Please refer to the 
 [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.
 

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -397,6 +397,9 @@ type SparkPodSpec struct {
 	// This field is mutually exclusive with nodeSelector at SparkApplication level (which will be deprecated).
 	// Optional.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// DnsConfig dns settings for the pod, following the Kubernetes specifications.
+	// Optional.
+	DNSConfig *apiv1.PodDNSConfig `json:"dnsConfig,omitempty"`
 }
 
 // DriverSpec is specification of the driver.


### PR DESCRIPTION
This PRs adds the option to specify DNSConfig as defined in [k8s api](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#poddnsconfig-v1-core)  for the Driver and the Executor pods. 

It adds the objects in the api and modifies the weebhook