### PR TITLE
Replace NodePort Service with ClusterIP

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -147,7 +147,7 @@ A `DriverInfo` captures information about the driver pod and the Spark web UI ru
 | ------------- | ------------- |
 | `WebUIServiceName` | Name of the service for the Spark web UI. |
 | `WebUIPort` | Port on which the Spark web UI runs on the Node. |
-| `WebUIAddress` | Address to access the web UI from outside the cluster via the Node. |
+| `WebUIAddress` | Address to access the web UI from within the cluster. |
 | `WebUIIngressName` | Name of the ingress for the Spark web UI. |
 | `WebUIIngressAddress` | Address to access the web UI via the Ingress. |
 | `PodName` | Name of the driver pod. |

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -202,7 +202,7 @@ and deleting the pods outside the operator might lead to incorrect metric values
 The operator, by default, makes the Spark UI accessible by creating a service of type `ClusterIP` which exposes the UI. This is only accessible from within the cluster.
 The operator also supports creating an Ingress for the UI. This can be turned on by setting the `ingress-url-format` command-line flag. The `ingress-url-format` should be a template like `{{$appName}}.ingress.cluster.com` and the operator will replace the `{{$appName}}` with the appropriate appName.
 
-The operator also sets both `WebUIAddress` which uses the Node's public IP as well as `WebUIIngressAddress` as part of the `DriverInfo` field of the `SparkApplication`.
+The operator also sets both `WebUIAddress` which is accessible from within the cluster as well as `WebUIIngressAddress` as part of the `DriverInfo` field of the `SparkApplication`.
 
 ## About the Mutating Admission Webhook
 

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -199,7 +199,7 @@ and deleting the pods outside the operator might lead to incorrect metric values
 
 ## Driver UI Access and Ingress
 
-The operator, by default, makes the Spark UI accessible by creating a service of type `NodePort` which exposes the UI via the node running the driver.
+The operator, by default, makes the Spark UI accessible by creating a service of type `ClusterIP` which exposes the UI. This is only accessible from within the cluster.
 The operator also supports creating an Ingress for the UI. This can be turned on by setting the `ingress-url-format` command-line flag. The `ingress-url-format` should be a template like `{{$appName}}.ingress.cluster.com` and the operator will replace the `{{$appName}}` with the appropriate appName.
 
 The operator also sets both `WebUIAddress` which uses the Node's public IP as well as `WebUIIngressAddress` as part of the `DriverInfo` field of the `SparkApplication`.

--- a/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1alpha1/types.go
@@ -422,8 +422,7 @@ const (
 // DriverInfo captures information about the driver.
 type DriverInfo struct {
 	WebUIServiceName string `json:"webUIServiceName,omitempty"`
-	// UI Details for the UI created via NodePort service.
-	// TODO: Remove this in favor of UI access via Ingress.
+	// UI Details for the UI created via ClusterIP service accessible from within the cluster.
 	WebUIPort    int32  `json:"webUIPort,omitempty"`
 	WebUIAddress string `json:"webUIAddress,omitempty"`
 	// Ingress Details if an ingress for the UI was created.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -457,8 +457,7 @@ const (
 // DriverInfo captures information about the driver.
 type DriverInfo struct {
 	WebUIServiceName string `json:"webUIServiceName,omitempty"`
-	// UI Details for the UI created via NodePort service.
-	// TODO: Remove this in favor of UI access via Ingress.
+	// UI Details for the UI created via ClusterIP service accessible from within the cluster.
 	WebUIPort    int32  `json:"webUIPort,omitempty"`
 	WebUIAddress string `json:"webUIAddress,omitempty"`
 	// Ingress Details if an ingress for the UI was created.

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -655,6 +655,7 @@ func (c *Controller) submitSparkApplication(app *v1beta1.SparkApplication) *v1be
 	} else {
 		app.Status.DriverInfo.WebUIServiceName = service.serviceName
 		app.Status.DriverInfo.WebUIPort = service.servicePort
+		app.Status.DriverInfo.WebUIAddress = fmt.Sprintf("%s:%d", service.serviceIP, app.Status.DriverInfo.WebUIPort)
 		// Create UI Ingress if ingress-format is set.
 		if c.ingressURLFormat != "" {
 			ingress, err := createSparkUIIngress(app, *service, c.ingressURLFormat, c.kubeClient)

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -48,7 +48,6 @@ func getSparkUIingressURL(ingressURLFormat string, appName string) string {
 type SparkService struct {
 	serviceName string
 	servicePort int32
-	nodePort    int32
 }
 
 // SparkIngress encapsulates information about the driver UI ingress.
@@ -124,7 +123,7 @@ func createSparkUIService(
 				config.SparkAppNameLabel: app.Name,
 				config.SparkRoleLabel:    config.SparkDriverRole,
 			},
-			Type: apiv1.ServiceTypeNodePort,
+			Type: apiv1.ServiceTypeClusterIP,
 		},
 	}
 
@@ -136,8 +135,7 @@ func createSparkUIService(
 
 	return &SparkService{
 		serviceName: service.Name,
-		servicePort: int32(port),
-		nodePort:    service.Spec.Ports[0].NodePort,
+		servicePort: service.Spec.Ports[0].Port,
 	}, nil
 }
 

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -48,6 +48,7 @@ func getSparkUIingressURL(ingressURLFormat string, appName string) string {
 type SparkService struct {
 	serviceName string
 	servicePort int32
+	serviceIP   string
 }
 
 // SparkIngress encapsulates information about the driver UI ingress.
@@ -136,6 +137,7 @@ func createSparkUIService(
 	return &SparkService{
 		serviceName: service.Name,
 		servicePort: service.Spec.Ports[0].Port,
+		serviceIP:   service.Spec.ClusterIP,
 	}, nil
 }
 

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -67,8 +67,8 @@ func TestCreateSparkUIService(t *testing.T) {
 		if !reflect.DeepEqual(test.expectedSelector, service.Spec.Selector) {
 			t.Errorf("%s: for label selector wanted %s got %s", test.name, test.expectedSelector, service.Spec.Selector)
 		}
-		if service.Spec.Type != apiv1.ServiceTypeNodePort {
-			t.Errorf("%s: for service type wanted %s got %s", test.name, apiv1.ServiceTypeNodePort, service.Spec.Type)
+		if service.Spec.Type != apiv1.ServiceTypeClusterIP {
+			t.Errorf("%s: for service type wanted %s got %s", test.name, apiv1.ServiceTypeClusterIP, service.Spec.Type)
 		}
 		if len(service.Spec.Ports) != 1 {
 			t.Errorf("%s: wanted a single port got %d ports", test.name, len(service.Spec.Ports))


### PR DESCRIPTION
@liyinan926 Removing NodePort Service as we discussed.  I have updated `WebUIAddress` under Status in CRD to `<CLUSTER-IP>:<PORT>` which will be accessible only from within the cluster.

As expected, this is non-backward compatible. I am not sure if any other SparkOperator user might be depending on the node-port service to access the UI.

Let me know your thoughts on this.  

