### PR TITLE
Add Bringg to who-is-using.md

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -6,6 +6,7 @@
 | Lightbend |@yuchaoran2011| Production | Data Infrastructure & Operations |
 | StackTome | @emiliauskas-fuzzy | Production | Data pipelines |
 | Salesforce | @khogeland | Production | Data transformation |
+| Bringg | @EladDolev | Production | ML & Analytics Data Platform |
 | CERN|@mrow4a| Evaluation | Data Mining & Analytics |
 | Lyft |@kumare3| Evaluation | ML & Data Infrastructure |
 | MapR Technologies |@sarjeet2013| Evaluation | ML/AI & Analytics Data Platform |


### PR DESCRIPTION
We're using spark-on-k8s-operator for 5 months now, and are very happy with it.
The feature which is most important for us is the ability to run Spark jobs on a dedicated node pool.
Before the operator we used Spark on K8S in client mode, both streaming using Deployment, and batch using CronJobs.