### PR TITLE
Reset ExecutionAttempts/SubmissionAttempts properly

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -295,9 +295,11 @@ type SparkApplicationStatus struct {
 	AppState ApplicationState `json:"applicationState,omitempty"`
 	// ExecutorState records the state of executors by executor Pod names.
 	ExecutorState map[string]ExecutorState `json:"executorState,omitempty"`
-	// ExecutionAttempts is the total number of attempts made to run a submitted Spark App to successful completion.
+	// ExecutionAttempts is the total number of attempts to run a submitted application to completion.
+	// Incremented upon each attempted run of the application and reset upon invalidation.
 	ExecutionAttempts int32 `json:"executionAttempts,omitempty"`
-	// SubmissionAttempts is the total number of submission attempts made to submit a Spark App.
+	// SubmissionAttempts is the total number of attempts to submit an application to run.
+	// Incremented upon each attempted submission of the application and reset upon invalidation and rerun.
 	SubmissionAttempts int32 `json:"submissionAttempts,omitempty"`
 }
 

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -526,7 +526,6 @@ func (c *Controller) syncSparkApplication(key string) error {
 					appToUpdate.Namespace, appToUpdate.Name, err)
 				return err
 			}
-			appToUpdate.Status.AppState.ErrorMessage = ""
 			appToUpdate.Status.AppState.State = v1beta1.PendingRerunState
 		}
 	case v1beta1.FailedSubmissionState:
@@ -905,10 +904,14 @@ func (c *Controller) clearStatus(status *v1beta1.SparkApplicationStatus) {
 		status.ExecutionAttempts = 0
 		status.LastSubmissionAttemptTime = metav1.Time{}
 		status.TerminationTime = metav1.Time{}
+		status.AppState.ErrorMessage = ""
 		status.ExecutorState = nil
 	} else if status.AppState.State == v1beta1.PendingRerunState {
 		status.SparkApplicationID = ""
+		status.SubmissionAttempts = 0
+		status.LastSubmissionAttemptTime = metav1.Time{}
 		status.DriverInfo = v1beta1.DriverInfo{}
+		status.AppState.ErrorMessage = ""
 		status.ExecutorState = nil
 	}
 }


### PR DESCRIPTION
Currently we don't reset `ExecutionAttempts` upon a successful run of an application. This cause the counter to quickly reach the retry limit if it has previously failed several times. For example, assuming that an application failed 3 times in a row, and then succeeded once. If the retry limit on failures is 3, then the application will not be retried the next time it fails as its `ExecutionAttempts` has already exceeded 3. The semantics of ``ExecutionAttempts`, however, is a counter of failed attempts, and its value is used to determine if the controller should keep retrying running an application in case of failure, as the [code](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/pkg/controller/sparkapplication/controller.go#L421) shows. `The same goes for `SubmissionAttempts`. This PR fixes the bug by resetting `ExecutionAttempts` and `SubmissionAttempts` upon a successful run and submission of an application.

@akhurana001 