### PR TITLE
Allows arbitrary JSON patch operations for the driver and the executors.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -409,6 +409,10 @@ spec:
         - name: edns0
 ```
 
+### Arbitrary json modification
+Allows aplying arbitrary json patches to the pods definitions created by spark submit. Enables removal/modification of settings that may be required in some edge cases.
+
+
 Note that the mutating admission webhook is needed to use this feature. Please refer to the 
 [Quick Start Guide](quick-start-guide.md) on how to enable the mutating admission webhook.
 

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -404,7 +404,7 @@ type SparkPodSpec struct {
 	DNSConfig *apiv1.PodDNSConfig `json:"dnsConfig,omitempty"`
 	// JSONPatchOperations aribitraty set of json patch operations to be applied to the resulting pods before admission.
 	// Optional
-	JSONPatchOperations []PatchOperation
+	JSONPatchOperations []PatchOperation `json:"patchOps,omitempty"`
 }
 
 // DriverSpec is specification of the driver.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -402,6 +402,9 @@ type SparkPodSpec struct {
 	// DnsConfig dns settings for the pod, following the Kubernetes specifications.
 	// Optional.
 	DNSConfig *apiv1.PodDNSConfig `json:"dnsConfig,omitempty"`
+	// JSONPatchOperations aribitraty set of json patch operations to be applied to the resulting pods before admission.
+	// Optional
+	JSONPatchOperations []PatchOperation
 }
 
 // DriverSpec is specification of the driver.
@@ -520,6 +523,13 @@ type GPUSpec struct {
 	Name string `json:"name"`
 	// Quantity is the number of GPUs to request for driver or executor.
 	Quantity int64 `json:"quantity"`
+}
+
+// PatchOperation represents a RFC6902 JSON patch operation.
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // PrometheusMonitoringEnabled returns if Prometheus monitoring is enabled or not.


### PR DESCRIPTION
Hi

This PR adds the capability of applying arbitrary json patches on the executor and driver pod.
This enables the use case of virtual kubelet which does not support env variables fromField pod definitions.