### PR TITLE
Use semantic DeepEqual for object comparison

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -19,13 +19,13 @@ package sparkapplication
 import (
 	"fmt"
 	"os/exec"
-	"reflect"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"golang.org/x/time/rate"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -180,7 +180,7 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 
 	// The spec has changed. This is currently best effort as we can potentially miss updates
 	// and end up in an inconsistent state.
-	if !reflect.DeepEqual(oldApp.Spec, newApp.Spec) {
+	if !equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) {
 		// Force-set the application status to Invalidating which handles clean-up and application re-run.
 		if _, err := c.updateApplicationStatusWithRetries(newApp, func(status *v1beta1.SparkApplicationStatus) {
 			status.AppState.State = v1beta1.InvalidatingState
@@ -677,7 +677,7 @@ func (c *Controller) updateApplicationStatusWithRetries(
 	var lastUpdateErr error
 	for i := 0; i < maximumUpdateRetries; i++ {
 		updateFunc(&toUpdate.Status)
-		if reflect.DeepEqual(original.Status, toUpdate.Status) {
+		if equality.Semantic.DeepEqual(original.Status, toUpdate.Status) {
 			return toUpdate, nil
 		}
 		_, err := c.crdClient.SparkoperatorV1beta1().SparkApplications(toUpdate.Namespace).Update(toUpdate)
@@ -709,7 +709,7 @@ func (c *Controller) updateApplicationStatusWithRetries(
 // updateStatusAndExportMetrics updates the status of the SparkApplication and export the metrics.
 func (c *Controller) updateStatusAndExportMetrics(oldApp, newApp *v1beta1.SparkApplication) error {
 	// Skip update if nothing changed.
-	if reflect.DeepEqual(oldApp, newApp) {
+	if equality.Semantic.DeepEqual(oldApp, newApp) {
 		return nil
 	}
 

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -18,13 +18,13 @@ package crd
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/golang/glog"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -43,7 +43,7 @@ func CreateOrUpdateCRD(
 
 	if err == nil && existing != nil {
 		// Update case.
-		if !reflect.DeepEqual(existing.Spec, definition.Spec) {
+		if !equality.Semantic.DeepEqual(existing.Spec, definition.Spec) {
 			existing.Spec = definition.Spec
 			glog.Infof("Updating CustomResourceDefinition %s", definition.Name)
 			if _, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Update(existing); err != nil {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
-	"reflect"
 	"time"
 
 	"github.com/golang/glog"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/api/admissionregistration/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -223,7 +223,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 	if getErr == nil && existing != nil {
 		// Update case.
 		glog.Info("Updating existing MutatingWebhookConfiguration for the Spark pod admission webhook")
-		if !reflect.DeepEqual(webhooks, existing.Webhooks) {
+		if !equality.Semantic.DeepEqual(webhooks, existing.Webhooks) {
 			existing.Webhooks = webhooks
 			if _, err := client.Update(existing); err != nil {
 				return err


### PR DESCRIPTION
Prevents superfluous updates when semantically-equal objects are not equal in memory.

Specifically solves the following scenario that we were observing:

- User submits a SparkApplication with an empty slice in the spec
- The operator submits the application and updates the status field
- When the updated SparkApplication is marshaled, the field containing the empty slice is dropped due to `omitempty`
- When the SparkApplication is unmarshaled, the field is now `nil`, and the spec is considered changed, because `nil != []foo`
- The operator runs spark-submit a second time, deleting and recreating the driver pod

This is the function that k8s uses internally for semantic deep equality. See:
- https://godoc.org/k8s.io/kubernetes/third_party/forked/golang/reflect
- https://github.com/kubernetes/apimachinery/blob/master/pkg/api/equality/semantic.go