### PR TITLE
Multi Version Support via Job:  Add Tests + other changes 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1187,6 +1187,7 @@
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/fields",

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go
@@ -54,8 +54,7 @@ type RestartPolicy struct {
 	OnFailureRetries           *int32 `json:"onFailureRetries,omitempty"`
 
 	// Interval to wait between successive retries of a failed application.
-	OnSubmissionFailureRetryInterval *int64 `json:"onSubmissionFailureRetryInterval,omitempty"`
-	OnFailureRetryInterval           *int64 `json:"onFailureRetryInterval,omitempty"`
+	OnFailureRetryInterval *int64 `json:"onFailureRetryInterval,omitempty"`
 }
 
 type RestartPolicyType string

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/zz_generated.deepcopy.go
@@ -292,11 +292,6 @@ func (in *RestartPolicy) DeepCopyInto(out *RestartPolicy) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.OnSubmissionFailureRetryInterval != nil {
-		in, out := &in.OnSubmissionFailureRetryInterval, &out.OnSubmissionFailureRetryInterval
-		*out = new(int64)
-		**out = **in
-	}
 	if in.OnFailureRetryInterval != nil {
 		in, out := &in.OnFailureRetryInterval, &out.OnFailureRetryInterval
 		*out = new(int64)
@@ -774,6 +769,18 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 		in, out := &in.HostNetwork, &out.HostNetwork
 		*out = new(bool)
 		**out = **in
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.DNSConfig != nil {
+		in, out := &in.DNSConfig, &out.DNSConfig
+		*out = new(v1.PodDNSConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -32,6 +32,8 @@ type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	SparkoperatorV1alpha1() sparkoperatorv1alpha1.SparkoperatorV1alpha1Interface
 	SparkoperatorV1beta1() sparkoperatorv1beta1.SparkoperatorV1beta1Interface
+	// Deprecated: please explicitly pick a version if possible.
+	Sparkoperator() sparkoperatorv1beta1.SparkoperatorV1beta1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -49,6 +51,12 @@ func (c *Clientset) SparkoperatorV1alpha1() sparkoperatorv1alpha1.SparkoperatorV
 
 // SparkoperatorV1beta1 retrieves the SparkoperatorV1beta1Client
 func (c *Clientset) SparkoperatorV1beta1() sparkoperatorv1beta1.SparkoperatorV1beta1Interface {
+	return c.sparkoperatorV1beta1
+}
+
+// Deprecated: Sparkoperator retrieves the default version of SparkoperatorClient.
+// Please explicitly pick a version.
+func (c *Clientset) Sparkoperator() sparkoperatorv1beta1.SparkoperatorV1beta1Interface {
 	return c.sparkoperatorV1beta1
 }
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -84,3 +84,8 @@ func (c *Clientset) SparkoperatorV1alpha1() sparkoperatorv1alpha1.SparkoperatorV
 func (c *Clientset) SparkoperatorV1beta1() sparkoperatorv1beta1.SparkoperatorV1beta1Interface {
 	return &fakesparkoperatorv1beta1.FakeSparkoperatorV1beta1{Fake: &c.Fake}
 }
+
+// Sparkoperator retrieves the SparkoperatorV1beta1Client
+func (c *Clientset) Sparkoperator() sparkoperatorv1beta1.SparkoperatorV1beta1Interface {
+	return &fakesparkoperatorv1beta1.FakeSparkoperatorV1beta1{Fake: &c.Fake}
+}

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -501,6 +501,7 @@ func (c *Controller) syncSparkApplication(key string) error {
 		succeeded, completionTime, err := c.subJobManager.hasJobSucceeded(appToUpdate)
 
 		if succeeded != nil {
+			// Submission Job terminated in either success or failure.
 			if *succeeded {
 				c.createSparkUIResources(appToUpdate)
 				appToUpdate.Status.AppState.State = v1beta1.SubmittedState
@@ -515,6 +516,7 @@ func (c *Controller) syncSparkApplication(key string) error {
 				// state to FailedSubmission, which is a terminal state.
 				appToUpdate.Status.AppState.State = v1beta1.FailedSubmissionState
 				if err != nil {
+					// Propagate the error if the Submission job ended in failure after retries.
 					appToUpdate.Status.AppState.ErrorMessage = err.Error()
 				}
 				c.recordSparkApplicationEvent(appToUpdate)

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -732,7 +732,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 					},
 				},
 			},
-			expectedState: v1beta1.FailedSubmissionState,
+			expectedState: v1beta1.PendingRerunState,
 		},
 		{
 			app: &v1beta1.SparkApplication{
@@ -878,7 +878,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 					RestartPolicy: restartPolicyOnFailure,
 				},
 			},
-			expectedState: v1beta1.FailedSubmissionState,
+			expectedState: v1beta1.FailedState,
 		},
 	}
 

--- a/pkg/controller/sparkapplication/job.go
+++ b/pkg/controller/sparkapplication/job.go
@@ -39,9 +39,8 @@ import (
 const (
 	sparkSubmitPodMemoryRequest = "100Mi"
 	sparkSubmitPodCpuRequest    = "100m"
-	sparkSubmitPodMemoryLimit = "256Mi"
-	sparkSubmitPodCpuLimit   = "250m"
-
+	sparkSubmitPodMemoryLimit   = "256Mi"
+	sparkSubmitPodCpuLimit      = "250m"
 )
 
 type submissionJobManager interface {

--- a/pkg/controller/sparkapplication/job.go
+++ b/pkg/controller/sparkapplication/job.go
@@ -18,8 +18,12 @@ package sparkapplication
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"k8s.io/api/core/v1"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,40 +40,54 @@ const (
 	sparkSubmitPodCpu    = "1024m"
 )
 
+type submissionJobManagerIface interface {
+	createSubmissionJob(app *v1beta1.SparkApplication) (*string, *string, error)
+	deleteSubmissionJob(app *v1beta1.SparkApplication) error
+	getSubmissionJob(app *v1beta1.SparkApplication) (*batchv1.Job, error)
+	hasJobSucceeded(app *v1beta1.SparkApplication) (*bool, *metav1.Time, error)
+}
+
 type submissionJobManager struct {
 	kubeClient kubernetes.Interface
 	jobLister  batchv1listers.JobLister
 }
 
-func (sjm *submissionJobManager) createSubmissionJob(s *submission) (*batchv1.Job, error) {
+func (sjm *submissionJobManager) createSubmissionJob(app *v1beta1.SparkApplication) (*string, *string, error) {
 	var image string
-	if s.app.Spec.Image != nil {
-		image = *s.app.Spec.Image
-	} else if s.app.Spec.Driver.Image != nil {
-		image = *s.app.Spec.Driver.Image
+	if app.Spec.Image != nil {
+		image = *app.Spec.Image
+	} else if app.Spec.Driver.Image != nil {
+		image = *app.Spec.Driver.Image
 	}
 	if image == "" {
-		return nil, fmt.Errorf("no image specified in .spec.image or .spec.driver.image in SparkApplication %s/%s",
-			s.app.Namespace, s.app.Name)
+		return nil, nil, fmt.Errorf("no image specified in .spec.image or .spec.driver.image in SparkApplication %s/%s",
+			app.Namespace, app.Name)
 	}
 
-	command := []string{"sh", "-c", fmt.Sprintf("$SPARK_HOME/bin/spark-submit %s", strings.Join(s.args, " "))}
+	driverPodName := getDriverPodName(app)
+	submissionID := uuid.New().String()
+	submissionCmdArgs, err := buildSubmissionCommandArgs(app, driverPodName, submissionID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	command := []string{"sh", "-c", fmt.Sprintf("$SPARK_HOME/bin/spark-submit %s", strings.Join(submissionCmdArgs, " "))}
 	var one int32 = 1
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getSubmissionJobName(s.app),
-			Namespace: s.app.Namespace,
+			Name:      getSubmissionJobName(app),
+			Namespace: app.Namespace,
 			Labels: map[string]string{
-				config.SparkAppNameLabel:            s.app.Name,
+				config.SparkAppNameLabel:            app.Name,
 				config.LaunchedBySparkOperatorLabel: "true",
 			},
-			Annotations:     s.app.Annotations,
-			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(s.app)},
+			Annotations:     app.Annotations,
+			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(app)},
 		},
 		Spec: batchv1.JobSpec{
 			Parallelism:  &one,
 			Completions:  &one,
-			BackoffLimit: s.app.Spec.RestartPolicy.OnSubmissionFailureRetries,
+			BackoffLimit: app.Spec.RestartPolicy.OnSubmissionFailureRetries,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -94,14 +112,19 @@ func (sjm *submissionJobManager) createSubmissionJob(s *submission) (*batchv1.Jo
 			},
 		},
 	}
-	if s.app.Spec.ServiceAccount != nil {
-		job.Spec.Template.Spec.ServiceAccountName = *s.app.Spec.ServiceAccount
+	if app.Spec.ServiceAccount != nil {
+		job.Spec.Template.Spec.ServiceAccountName = *app.Spec.ServiceAccount
 	}
 	// Copy the labels on the SparkApplication to the Job.
-	for key, val := range s.app.Labels {
+	for key, val := range app.Labels {
 		job.Labels[key] = val
 	}
-	return sjm.kubeClient.BatchV1().Jobs(s.app.Namespace).Create(job)
+	_, err = sjm.kubeClient.BatchV1().Jobs(app.Namespace).Create(job)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Submission Job Created successfully.
+	return stringptr(submissionID), stringptr(driverPodName), nil
 }
 
 func (sjm *submissionJobManager) getSubmissionJob(app *v1beta1.SparkApplication) (*batchv1.Job, error) {
@@ -114,22 +137,29 @@ func (sjm *submissionJobManager) deleteSubmissionJob(app *v1beta1.SparkApplicati
 
 // hasJobSucceeded returns a boolean that indicates if the job has succeeded or not if the job has terminated.
 // Otherwise, it returns a nil to indicate that the job has not terminated yet.
+//  An error is returned if the the job failed or if there was an issue querying the job.
 func (sjm *submissionJobManager) hasJobSucceeded(app *v1beta1.SparkApplication) (*bool, *metav1.Time, error) {
 	job, err := sjm.getSubmissionJob(app)
 	if err != nil {
 		return nil, nil, err
 	}
 	for _, cond := range job.Status.Conditions {
-		if cond.Type == batchv1.JobComplete {
+		if cond.Type == batchv1.JobComplete && cond.Status == v1.ConditionTrue {
 			return boolptr(true), job.Status.CompletionTime, nil
 		}
-		if cond.Type == batchv1.JobFailed {
-			return boolptr(false), nil, nil
+		if cond.Type == batchv1.JobFailed && cond.Status == v1.ConditionTrue {
+			return boolptr(false), nil,
+				errors.New(fmt.Sprintf("Submission Job Failed. Error: %s. %s", cond.Reason, cond.Message))
+
 		}
 	}
 	return nil, nil, nil
 }
 
 func boolptr(v bool) *bool {
+	return &v
+}
+
+func stringptr(v string) *string {
 	return &v
 }

--- a/pkg/controller/sparkapplication/job.go
+++ b/pkg/controller/sparkapplication/job.go
@@ -37,8 +37,11 @@ import (
 )
 
 const (
-	sparkSubmitPodMemory = "256Mi"
-	sparkSubmitPodCpu    = "250m"
+	sparkSubmitPodMemoryRequest = "100Mi"
+	sparkSubmitPodCpuRequest    = "100m"
+	sparkSubmitPodMemoryLimit = "256Mi"
+	sparkSubmitPodCpuLimit   = "250m"
+
 )
 
 type submissionJobManager interface {
@@ -98,12 +101,12 @@ func (sjm *realSubmissionJobManager) createSubmissionJob(app *v1beta1.SparkAppli
 							Command: command,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(sparkSubmitPodCpu),
-									corev1.ResourceMemory: resource.MustParse(sparkSubmitPodMemory),
+									corev1.ResourceCPU:    resource.MustParse(sparkSubmitPodCpuRequest),
+									corev1.ResourceMemory: resource.MustParse(sparkSubmitPodMemoryRequest),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(sparkSubmitPodCpu),
-									corev1.ResourceMemory: resource.MustParse(sparkSubmitPodMemory),
+									corev1.ResourceCPU:    resource.MustParse(sparkSubmitPodCpuLimit),
+									corev1.ResourceMemory: resource.MustParse(sparkSubmitPodMemoryLimit),
 								},
 							},
 						},

--- a/pkg/controller/sparkapplication/job_test.go
+++ b/pkg/controller/sparkapplication/job_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sparkapplication
+
+import (
+	"k8s.io/api/core/v1"
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	batchv1 "k8s.io/api/batch/v1"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubeclientfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
+)
+
+func newFakeJobManager(jobs ...*batchv1.Job) submissionJobManagerIface {
+	kubeClient := kubeclientfake.NewSimpleClientset()
+
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0*time.Second)
+	lister := informerFactory.Batch().V1().Jobs().Lister()
+	informer := informerFactory.Batch().V1().Jobs().Informer()
+	for _, job := range jobs {
+		if job != nil {
+			informer.GetIndexer().Add(job)
+			kubeClient.BatchV1().Jobs(job.GetNamespace()).Create(job)
+		}
+	}
+	return &submissionJobManager{
+		jobLister:  lister,
+		kubeClient: kubeClient,
+	}
+}
+
+func TestGetSubmissionJob(t *testing.T) {
+
+	app := &v1beta1.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta1.SparkApplicationStatus{},
+	}
+
+	// Case 1: Job doesn't exist.
+	jobManager := newFakeJobManager(nil)
+	jobResult, err := jobManager.getSubmissionJob(app)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	assert.Nil(t, jobResult)
+
+	// Case 2: Job exists.
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-spark-submit",
+			Namespace: "default",
+		},
+	}
+	jobManager = newFakeJobManager(job)
+
+	jobResult, err = jobManager.getSubmissionJob(app)
+	assert.Nil(t, err)
+	assert.NotNil(t, jobResult)
+	assert.Equal(t, job, jobResult)
+}
+
+func TestDeleteSubmissionJob(t *testing.T) {
+	app := &v1beta1.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta1.SparkApplicationStatus{},
+	}
+
+	// Case 1: Job doesn't exist.
+	jobManager := newFakeJobManager(nil)
+	err := jobManager.deleteSubmissionJob(app)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	// Case 2: Job exists
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-spark-submit",
+			Namespace: "default",
+		},
+	}
+	jobManager = newFakeJobManager(job)
+	err = jobManager.deleteSubmissionJob(app)
+	assert.Nil(t, err)
+}
+
+func TestCreateSubmissionJob(t *testing.T) {
+	os.Setenv(kubernetesServiceHostEnvVar, "localhost")
+	os.Setenv(kubernetesServicePortEnvVar, "443")
+
+	// Case 1: Image doesn't exist.
+	app := &v1beta1.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta1.SparkApplicationStatus{},
+	}
+
+	jobManager := newFakeJobManager(nil)
+	submissionID, driverPodName, err := jobManager.createSubmissionJob(app)
+	assert.NotNil(t, err)
+	assert.Nil(t, submissionID)
+	assert.Nil(t, driverPodName)
+
+	// Case 2:  Job creation successful.
+	app = &v1beta1.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: v1beta1.SparkApplicationSpec{
+			Image: stringptr("spark-base-image"),
+		},
+		Status: v1beta1.SparkApplicationStatus{},
+	}
+	jobManager = newFakeJobManager(nil)
+	submissionID, driverPodName, err = jobManager.createSubmissionJob(app)
+	assert.Nil(t, err)
+	assert.NotNil(t, submissionID)
+	assert.NotNil(t, driverPodName)
+
+}
+
+func TestHasJobSucceeded(t *testing.T) {
+	app := &v1beta1.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta1.SparkApplicationStatus{},
+	}
+
+	// Case 1: Job doesn't exist.
+	jobManager := newFakeJobManager(nil)
+	result, successTime, err := jobManager.hasJobSucceeded(app)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	assert.Nil(t, result)
+	assert.Nil(t, successTime)
+
+	// Case 2: Job exists but not completed.
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-spark-submit",
+			Namespace: "default",
+		},
+	}
+	jobManager = newFakeJobManager(job)
+	result, successTime, err = jobManager.hasJobSucceeded(app)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, successTime)
+
+	// Case 3: Job failed.
+	job = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-spark-submit",
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{
+				Type:    batchv1.JobFailed,
+				Status:  v1.ConditionTrue,
+				Reason:  "pod failed",
+				Message: "Pod foo-spark-submit-1 failed",
+			}},
+		},
+	}
+	jobManager = newFakeJobManager(job)
+	result, successTime, err = jobManager.hasJobSucceeded(app)
+	assert.Equal(t, err.Error(), "Submission Job Failed. Error: pod failed. Pod foo-spark-submit-1 failed")
+	assert.False(t, *result)
+	assert.Nil(t, successTime)
+
+	// Case 4: Job succeeded.
+	job = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-spark-submit",
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{
+				Type:   batchv1.JobComplete,
+				Status: v1.ConditionTrue,
+			}},
+			CompletionTime: &metav1.Time{Time: time.Now()},
+		},
+	}
+	jobManager = newFakeJobManager(job)
+	result, successTime, err = jobManager.hasJobSucceeded(app)
+	assert.Nil(t, err)
+	assert.True(t, *result)
+	assert.NotNil(t, successTime)
+}

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -29,23 +29,9 @@ import (
 )
 
 const (
-	sparkHomeEnvVar             = "SPARK_HOME"
 	kubernetesServiceHostEnvVar = "KUBERNETES_SERVICE_HOST"
 	kubernetesServicePortEnvVar = "KUBERNETES_SERVICE_PORT"
 )
-
-// submission includes information of a Spark application to be submitted.
-type submission struct {
-	app  *v1beta1.SparkApplication
-	args []string
-}
-
-func newSubmission(args []string, app *v1beta1.SparkApplication) *submission {
-	return &submission{
-		app:  app,
-		args: args,
-	}
-}
 
 func buildSubmissionCommandArgs(app *v1beta1.SparkApplication, driverPodName string, submissionID string) ([]string, error) {
 	var args []string


### PR DESCRIPTION
Some changes for the multi-version branch (Ref: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/526):
-  Fix Controller tests & add tests for SubmissionJobManager.
-  Create interface for SubmissionJobManager and move `submissionCmdArgs` generation to within SubmissionJobManager.
- Add default resource limits for the Job pods. We use resourceQuotas on clusters which cause failures unless resource requests/limits are set on the job pod.
- Remove OnSubmissionFailureRetryInterval from v1beta1 spec.

I also see that now `FailedSubmissionState`  is terminal and we don't move it to `FailedState` or retry it even if the retryPolicy is `Always` . This is a behavior change compared to master, we can chat more if we want to update this.

PTAL @liyinan926  when you get a chance. 