### PR TITLE
Update Dockerfiles after #562

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,11 @@
 ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.0
 
 FROM golang:1.12.5-alpine as builder
-ARG DEP_VERSION="0.5.3"
-RUN apk add --no-cache bash git
-ADD https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
 
+RUN apk add --no-cache git
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/spark-on-k8s-operator
-COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure -vendor-only
 COPY . ./
-RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -23,16 +23,10 @@
 ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.0
 
 FROM golang:1.12.5-alpine as builder
-ARG DEP_VERSION="0.5.3"
-RUN apk add --no-cache bash git 
-ADD https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
-
+RUN apk add --no-cache git
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/spark-on-k8s-operator
-COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure -vendor-only
 COPY . ./
-RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/


### PR DESCRIPTION
With this changes users should be able to build spark-operator again with provided Dockerfiles.