### PR TITLE
Add resource quota callbacks before starting the informer

### DIFF
--- a/pkg/webhook/resourceusage/enforcer.go
+++ b/pkg/webhook/resourceusage/enforcer.go
@@ -27,14 +27,12 @@ func NewResourceQuotaEnforcer(crdInformerFactory crdinformers.SharedInformerFact
 	}
 }
 
-// TODO: There appears to be a deadlock in cache.WaitForCacheSync. Possibly related? https://github.com/kubernetes/kubernetes/issues/71450
-// For now, return immediately. There will be a short window after startup where quota calcuation is incorrect.
 func (r ResourceQuotaEnforcer) WaitForCacheSync(stopCh <-chan struct{}) error {
-	/*if !cache.WaitForCacheSync(stopCh, func() bool {
+	if !cache.WaitForCacheSync(stopCh, func() bool {
 		return r.resourceQuotaInformer.Informer().HasSynced()
 	}) {
 		return fmt.Errorf("cache sync canceled")
-	}*/
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixing the same issue as in https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/592, making sure the resourcequota/pod/sparkapplication callbacks are created before starting the informer.

(see https://github.com/kubernetes/client-go/issues/675)