### PR TITLE
Support backwards compatibility with v1beta1

### DIFF
--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -356,8 +356,9 @@ spec:
                     coreLimit:
                       type: string
                     cores:
+                      exclusiveMinimum: true
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     dnsConfig:
                       properties:
@@ -1244,8 +1245,9 @@ spec:
                     coreRequest:
                       type: string
                     cores:
+                      exclusiveMinimum: true
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     dnsConfig:
                       properties:

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -342,8 +342,9 @@ spec:
                 coreLimit:
                   type: string
                 cores:
+                  exclusiveMinimum: true
                   format: int32
-                  minimum: 1
+                  minimum: 0
                   type: integer
                 dnsConfig:
                   properties:
@@ -1230,8 +1231,9 @@ spec:
                 coreRequest:
                   type: string
                 cores:
+                  exclusiveMinimum: true
                   format: int32
-                  minimum: 1
+                  minimum: 0
                   type: integer
                 dnsConfig:
                   properties:

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
@@ -49,7 +49,7 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 
 func setDriverSpecDefaults(spec DriverSpec) {
 	if spec.Cores == nil {
-		spec.Cores = new(int32)
+		spec.Cores = new(cores)
 		*spec.Cores = 1
 	}
 	if spec.Memory == nil {
@@ -60,7 +60,7 @@ func setDriverSpecDefaults(spec DriverSpec) {
 
 func setExecutorSpecDefaults(spec ExecutorSpec) {
 	if spec.Cores == nil {
-		spec.Cores = new(int32)
+		spec.Cores = new(cores)
 		*spec.Cores = 1
 	}
 	if spec.Memory == nil {

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
@@ -49,7 +49,7 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 
 func setDriverSpecDefaults(spec DriverSpec) {
 	if spec.Cores == nil {
-		spec.Cores = new(cores)
+		spec.Cores = new(Cores)
 		*spec.Cores = 1
 	}
 	if spec.Memory == nil {
@@ -60,7 +60,7 @@ func setDriverSpecDefaults(spec DriverSpec) {
 
 func setExecutorSpecDefaults(spec ExecutorSpec) {
 	if spec.Cores == nil {
-		spec.Cores = new(cores)
+		spec.Cores = new(Cores)
 		*spec.Cores = 1
 	}
 	if spec.Memory == nil {

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -47,15 +47,15 @@ const (
 
 // For backwards compatibility with v1beta1, must be able to unmarshal from float64 and marshal to int32
 // This is achieved by rounding up previous float64-type fields
-type cores int32
+type Cores int32
 
-func (c *cores) UnmarshalJSON(data []byte) error {
+func (c *Cores) UnmarshalJSON(data []byte) error {
 	var v float64
 	err := json.Unmarshal(data, &v)
 	if err != nil {
 		return err
 	}
-	*c = cores(math.Ceil(v))
+	*c = Cores(math.Ceil(v))
 	return nil
 }
 
@@ -383,7 +383,7 @@ type SparkPodSpec struct {
 	// Optional.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:ExclusiveMinimum=true
-	Cores *cores `json:"cores,omitempty"`
+	Cores *Cores `json:"cores,omitempty"`
 	// CoreLimit specifies a hard limit on CPU cores for the pod.
 	// Optional
 	CoreLimit *string `json:"coreLimit,omitempty"`

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -673,7 +673,7 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 	*out = *in
 	if in.Cores != nil {
 		in, out := &in.Cores, &out.Cores
-		*out = new(int32)
+		*out = new(cores)
 		**out = **in
 	}
 	if in.CoreLimit != nil {

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -673,7 +673,7 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 	*out = *in
 	if in.Cores != nil {
 		in, out := &in.Cores, &out.Cores
-		*out = new(cores)
+		*out = new(Cores)
 		**out = **in
 	}
 	if in.CoreLimit != nil {

--- a/pkg/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestGetDriverResource(t *testing.T) {
 
-	var oneCore int32 = 1
+	oneCore := v1beta2.Cores(1)
 	oneCoreStr := "1"
 	oneGB := "1024m"
 	twoCoresStr := "2"
@@ -93,10 +93,10 @@ func TestGetDriverResource(t *testing.T) {
 
 func TestGetExecutorResource(t *testing.T) {
 
-	oneCore := int32(1)
+	oneCore := v1beta2.Cores(1)
 	oneCoreStr := "1"
 	oneGB := "1024m"
-	twoCores := int32(2)
+	twoCores := v1beta2.Cores(2)
 	instances := int32(2)
 
 	result := v1.ResourceList{}


### PR DESCRIPTION
To ease migration from v1beta1 to v1beta2, this PR adds backwards compatibility by rounding up the previously-float `Cores` field.

To migrate with minimal downtime:
- Add `v1beta2` to the old CRDs' `versions` lists
- Deploy the new image
- Switch all apps to `v1beta2`
- Replace the old CRDs with the new CRDs

I'm not sure if this should be merged or maybe released as a transitional image, but I'm leaving it here as a pointer for anyone else who needs to figure out how to upgrade in production.