### PR TITLE
Enumerate string spec on Python version

### DIFF
--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -1918,8 +1918,8 @@ spec:
                   type: object
                 pythonVersion:
                   enum:
-                  - 2
-                  - 3
+                  - "2"
+                  - "3"
                   type: string
                 restartPolicy:
                   properties:

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -1904,8 +1904,8 @@ spec:
               type: object
             pythonVersion:
               enum:
-              - 2
-              - 3
+              - "2"
+              - "3"
               type: string
             restartPolicy:
               properties:


### PR DESCRIPTION
**Context:**
Running Python3 on a K8s cluster kept throwing: 
```
spec.pythonVersion in body must be of type string: "integer"
spec.pythonVersion in body should be one of [2 3]
```
Conflicting message - the list of possible values was listed as integers but it expects a string. 

**Changes:**
Simply make the list of possible values be string i.s.o. integers.

**Checks:**
Made the changes locally, applied the CRDs on a K8s cluster, and was able to deploy a SparkApplication resource successfully without getting any errors.