### PR TITLE
Fix integration issue with volcano

### DIFF
--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -24,7 +24,7 @@ spec:
   image: "gcr.io/spark-operator/spark:v2.4.4"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
   sparkVersion: "2.4.0"
   restartPolicy:
     type: Never

--- a/main.go
+++ b/main.go
@@ -55,7 +55,6 @@ import (
 var (
 	master                         = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	kubeConfig                     = flag.String("kubeConfig", "", "Path to a kube config. Only required if out-of-cluster.")
-	installCRDs                    = flag.Bool("install-crds", true, "Whether to install CRDs")
 	controllerThreads              = flag.Int("controller-threads", 10, "Number of worker threads used by the SparkApplication controller.")
 	resyncInterval                 = flag.Int("resync-interval", 30, "Informer resync interval in seconds.")
 	namespace                      = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -125,6 +125,9 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 				MinMember:    size,
 				MinResources: &minResource,
 			},
+			Status: v1alpha2.PodGroupStatus{
+				Phase: v1alpha2.PodGroupPending,
+			},
 		}
 
 		if app.Spec.BatchSchedulerOptions != nil {
@@ -144,7 +147,10 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 			_, err = v.volcanoClient.SchedulingV1alpha2().PodGroups(app.Namespace).Update(pg)
 		}
 	}
-	return fmt.Errorf("failed to sync PodGroup with error: %s. Abandon schedule pods via volcano", err)
+	if err != nil {
+		return fmt.Errorf("failed to sync PodGroup with error: %s. Abandon schedule pods via volcano", err)
+	}
+	return nil
 }
 
 func New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {


### PR DESCRIPTION
This patch fixes some issues when integration with volcano scheduler.
1. Fix podgroup not block driver from creating.
2. Fix annotation not passed to driver&executor pods
3. Update spark jar version in yaml
4. remove unused argument in sparkoperator CLI.

Now there would be a repo which demonstrate the advantages that can bring to spark operator when configured with volcano [here](https://github.com/TommyLike/spark-operator-volcano-demo)