### PR TITLE
Full support of k8s environment variables for SparkApplication through webhook

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -398,11 +398,16 @@ type SparkPodSpec struct {
 	// Secrets carries information of secrets to add to the pod.
 	// Optional.
 	Secrets []SecretInfo `json:"secrets,omitempty"`
+	// Env carries the environment variables to add to the pod.
+	// Optional.
+	Env []apiv1.EnvVar `json:"env,omitempty"`
 	// EnvVars carries the environment variables to add to the pod.
 	// Optional.
+	// DEPRECATED.
 	EnvVars map[string]string `json:"envVars,omitempty"`
 	// EnvSecretKeyRefs holds a mapping from environment variable names to SecretKeyRefs.
 	// Optional.
+	// DEPRECATED.
 	EnvSecretKeyRefs map[string]NameKey `json:"envSecretKeyRefs,omitempty"`
 	// Labels are the Kubernetes labels to be added to the pod.
 	// Optional.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -742,6 +742,13 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 		*out = make([]SecretInfo, len(*in))
 		copy(*out, *in)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.EnvVars != nil {
 		in, out := &in.EnvVars, &out.EnvVars
 		*out = make(map[string]string, len(*in))

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -1108,6 +1108,98 @@ func TestPatchSparkPod_HostNetwork(t *testing.T) {
 	}
 }
 
+func TestPatchSparkPod_Env(t *testing.T) {
+	drvEnvKey := "TEST_DRV_ENV_VAR_KEY"
+	drvEnvVal := "test_drv_env_var_val"
+	exeEnvKey := "TEST_EXE_ENV_VAR_KEY"
+	exeEnvVal := "test_exe_env_var_val"
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Executor: v1beta2.ExecutorSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Env: []corev1.EnvVar{
+						{
+							Name:  exeEnvKey,
+							Value: exeEnvVal,
+						},
+					},
+				},
+			},
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Env: []corev1.EnvVar{
+						{
+							Name:  drvEnvKey,
+							Value: drvEnvVal,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executorPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-executor",
+			Labels: map[string]string{
+				config.SparkRoleLabel:               config.SparkExecutorRole,
+				config.LaunchedBySparkOperatorLabel: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  config.SparkExecutorContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	driverPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-driver",
+			Labels: map[string]string{
+				config.SparkRoleLabel:               config.SparkDriverRole,
+				config.LaunchedBySparkOperatorLabel: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  config.SparkDriverContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	modifiedExecutorPod, err := getModifiedPod(executorPod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(modifiedExecutorPod.Spec.Containers[0].Env))
+	assert.Equal(t, exeEnvKey, modifiedExecutorPod.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, exeEnvVal, modifiedExecutorPod.Spec.Containers[0].Env[0].Value)
+	assert.True(t, modifiedExecutorPod.Spec.Containers[0].Env[0].ValueFrom == nil)
+
+	modifiedDriverPod, err := getModifiedPod(driverPod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(modifiedDriverPod.Spec.Containers[0].Env))
+	assert.Equal(t, drvEnvKey, modifiedDriverPod.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, drvEnvVal, modifiedDriverPod.Spec.Containers[0].Env[0].Value)
+	assert.True(t, modifiedDriverPod.Spec.Containers[0].Env[0].ValueFrom == nil)
+}
+
 func getModifiedPod(pod *corev1.Pod, app *v1beta2.SparkApplication) (*corev1.Pod, error) {
 	patchOps := patchSparkPod(pod, app)
 	patchBytes, err := json.Marshal(patchOps)


### PR DESCRIPTION
Current support of environment variables is only for standard key-value through spark-submit.
K8S can support more complex envrionment variables like fetching values from other fields and secrets.
