### PR TITLE
Add volumes support for Spark scratch space spark.local.dir

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -106,6 +106,10 @@ const (
 	SparkDriverLabelKeyPrefix = "spark.kubernetes.driver.label."
 	// SparkExecutorLabelKeyPrefix is the Spark configuration key prefix for labels on the executor Pods.
 	SparkExecutorLabelKeyPrefix = "spark.kubernetes.executor.label."
+	// SparkDriverVolumesPrefix is the Spark volumes configuration for mounting a volume into the driver pod.
+	SparkDriverVolumesPrefix = "spark.kubernetes.driver.volumes."
+	// SparkExecutorVolumesPrefix is the Spark volumes configuration for mounting a volume into the driver pod.
+	SparkExecutorVolumesPrefix = "spark.kubernetes.executor.volumes."
 	// SparkDriverPodNameKey is the Spark configuration key for driver pod name.
 	SparkDriverPodNameKey = "spark.kubernetes.driver.pod.name"
 	// SparkDriverServiceAccountName is the Spark configuration key for specifying name of the Kubernetes service
@@ -267,4 +271,7 @@ const (
 	SparkDriverContainerName = "spark-kubernetes-driver"
 	// SparkExecutorContainerName is name of executor container in spark executor pod
 	SparkExecutorContainerName = "executor"
+
+	// SparkLocalDirVolumePrefix is the volume name prefix for "scratch" space directory
+	SparkLocalDirVolumePrefix = "spark-local-dir-"
 )

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -18,6 +18,8 @@ package sparkapplication
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/apis/policy"
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
@@ -113,4 +115,17 @@ func driverStateToApplicationState(podStatus apiv1.PodStatus) v1beta2.Applicatio
 	default:
 		return v1beta2.UnknownState
 	}
+}
+
+func getVolumeFSType(v v1.Volume) (policy.FSType, error) {
+	switch {
+	case v.HostPath != nil:
+		return policy.HostPath, nil
+	case v.EmptyDir != nil:
+		return policy.EmptyDir, nil
+	case v.PersistentVolumeClaim != nil:
+		return policy.PersistentVolumeClaim, nil
+	}
+
+	return "", fmt.Errorf("unknown volume type for volume: %#v", v)
 }

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -25,7 +25,9 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/policy"
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
@@ -163,6 +165,17 @@ func buildSubmissionCommandArgs(app *v1beta2.SparkApplication, driverPodName str
 	}
 	for _, option := range options {
 		args = append(args, "--conf", option)
+	}
+
+	if app.Spec.Volumes != nil {
+		options, err = addLocalDirConfOptions(app)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, option := range options {
+			args = append(args, "--conf", option)
+		}
 	}
 
 	if app.Spec.MainApplicationFile != nil {
@@ -366,4 +379,76 @@ func addExecutorConfOptions(app *v1beta2.SparkApplication, submissionID string) 
 	executorConfOptions = append(executorConfOptions, config.GetExecutorEnvVarConfOptions(app)...)
 
 	return executorConfOptions, nil
+}
+
+// addLocalDirConfOptions excludes local dir volumes, update SparkApplication and returns local dir config options
+func addLocalDirConfOptions(app *v1beta2.SparkApplication) ([]string, error) {
+	var localDirConfOptions []string
+
+	sparkLocalVolumes := map[string]v1.Volume{}
+	var mutateVolumes []v1.Volume
+
+	// Filter local dir volumes
+	for _, volume := range app.Spec.Volumes {
+		if strings.HasPrefix(volume.Name, config.SparkLocalDirVolumePrefix) {
+			sparkLocalVolumes[volume.Name] = volume
+		} else {
+			mutateVolumes = append(mutateVolumes, volume)
+		}
+	}
+	app.Spec.Volumes = mutateVolumes
+
+	// Filter local dir volumeMounts and set mutate volume mounts to driver and executor
+	if app.Spec.Driver.VolumeMounts != nil {
+		driverMutateVolumeMounts, driverLocalDirConfConfOptions := filterMutateMountVolumes(app.Spec.Driver.VolumeMounts, config.SparkDriverVolumesPrefix, sparkLocalVolumes)
+		app.Spec.Driver.VolumeMounts = driverMutateVolumeMounts
+		localDirConfOptions = append(localDirConfOptions, driverLocalDirConfConfOptions...)
+	}
+
+	if app.Spec.Executor.VolumeMounts != nil {
+		executorMutateVolumeMounts, executorLocalDirConfConfOptions := filterMutateMountVolumes(app.Spec.Executor.VolumeMounts, config.SparkExecutorVolumesPrefix, sparkLocalVolumes)
+		app.Spec.Executor.VolumeMounts = executorMutateVolumeMounts
+		localDirConfOptions = append(localDirConfOptions, executorLocalDirConfConfOptions...)
+	}
+
+	return localDirConfOptions, nil
+}
+
+func filterMutateMountVolumes(volumeMounts []v1.VolumeMount, prefix string, sparkLocalVolumes map[string]v1.Volume) ([]v1.VolumeMount, []string) {
+	var mutateMountVolumes []v1.VolumeMount
+	var localDirConfOptions []string
+	for _, volumeMount := range volumeMounts {
+		if volume, ok := sparkLocalVolumes[volumeMount.Name]; ok {
+			options := buildLocalVolumeOptions(prefix, volume, volumeMount)
+			for _, option := range options {
+				localDirConfOptions = append(localDirConfOptions, option)
+			}
+		} else {
+			mutateMountVolumes = append(mutateMountVolumes, volumeMount)
+		}
+	}
+
+	return mutateMountVolumes, localDirConfOptions
+}
+
+func buildLocalVolumeOptions(prefix string, volume v1.Volume, volumeMount v1.VolumeMount) []string {
+	VolumeMountPathTemplate := prefix + "%s.%s.mount.path=%s"
+	VolumeMountOptionTemplate := prefix + "%s.%s.options.%s=%s"
+
+	var options []string
+	switch {
+	case volume.HostPath != nil:
+		options = append(options, fmt.Sprintf(VolumeMountPathTemplate, string(policy.HostPath), volume.Name, volumeMount.MountPath))
+		options = append(options, fmt.Sprintf(VolumeMountOptionTemplate, string(policy.HostPath), volume.Name, "path", volume.HostPath.Path))
+		if volume.HostPath.Type != nil {
+			options = append(options, fmt.Sprintf(VolumeMountOptionTemplate, string(policy.HostPath), volume.Name, "type", *volume.HostPath.Type))
+		}
+	case volume.EmptyDir != nil:
+		options = append(options, fmt.Sprintf(VolumeMountPathTemplate, string(policy.EmptyDir), volume.Name, volumeMount.MountPath))
+	case volume.PersistentVolumeClaim != nil:
+		options = append(options, fmt.Sprintf(VolumeMountPathTemplate, string(policy.PersistentVolumeClaim), volume.Name, volumeMount.MountPath))
+		options = append(options, fmt.Sprintf(VolumeMountOptionTemplate, string(policy.PersistentVolumeClaim), volume.Name, "claimName", volume.PersistentVolumeClaim.ClaimName))
+	}
+
+	return options
 }

--- a/pkg/controller/sparkapplication/submission_test.go
+++ b/pkg/controller/sparkapplication/submission_test.go
@@ -15,3 +15,342 @@ limitations under the License.
 */
 
 package sparkapplication
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+)
+
+const (
+	VolumeMountPathTemplate       = "spark.kubernetes.%s.volumes.%s.%s.mount.path=%s"
+	VolumeMountOptionPathTemplate = "spark.kubernetes.%s.volumes.%s.%s.options.%s=%s"
+)
+
+func TestAddLocalDir_HostPath(t *testing.T) {
+	volumes := []corev1.Volume{
+		{
+			Name: "spark-local-dir-1",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/mnt",
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "spark-local-dir-1",
+			MountPath: "/tmp/mnt-1",
+		},
+	}
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Volumes: volumes,
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+		},
+	}
+
+	localDirOptions, err := addLocalDirConfOptions(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, len(app.Spec.Volumes))
+	assert.Equal(t, 0, len(app.Spec.Driver.VolumeMounts))
+	assert.Equal(t, 2, len(localDirOptions))
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "driver", "hostPath", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[0])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "driver", "hostPath", volumes[0].Name, "path", volumes[0].HostPath.Path), localDirOptions[1])
+}
+
+func TestAddLocalDir_PVC(t *testing.T) {
+	volumes := []corev1.Volume{
+		{
+			Name: "spark-local-dir-1",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "/tmp/mnt-1",
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "spark-local-dir-1",
+			MountPath: "/tmp/mnt-1",
+		},
+	}
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Volumes: volumes,
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+		},
+	}
+
+	localDirOptions, err := addLocalDirConfOptions(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, len(app.Spec.Volumes))
+	assert.Equal(t, 0, len(app.Spec.Driver.VolumeMounts))
+	assert.Equal(t, 2, len(localDirOptions))
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "driver", "persistentVolumeClaim", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[0])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "driver", "persistentVolumeClaim", volumes[0].Name, "claimName", volumes[0].PersistentVolumeClaim.ClaimName), localDirOptions[1])
+}
+
+func TestAddLocalDir_MixedVolumes(t *testing.T) {
+	volumes := []corev1.Volume{
+		{
+			Name: "spark-local-dir-1",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/mnt-1",
+				},
+			},
+		},
+		{
+			Name: "log-dir",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/log/spark",
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "spark-local-dir-1",
+			MountPath: "/tmp/mnt-1",
+		},
+		{
+			Name:      "log-dir",
+			MountPath: "/var/log/spark",
+		},
+	}
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Volumes: volumes,
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+		},
+	}
+
+	localDirOptions, err := addLocalDirConfOptions(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(app.Spec.Volumes))
+	assert.Equal(t, 1, len(app.Spec.Driver.VolumeMounts))
+	assert.Equal(t, 2, len(localDirOptions))
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "driver", "hostPath", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[0])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "driver", "hostPath", volumes[0].Name, "path", volumes[0].HostPath.Path), localDirOptions[1])
+}
+
+func TestAddLocalDir_MultipleScratchVolumes(t *testing.T) {
+	volumes := []corev1.Volume{
+		{
+			Name: "spark-local-dir-1",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/mnt-1",
+				},
+			},
+		},
+		{
+			Name: "spark-local-dir-2",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/mnt-2",
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "spark-local-dir-1",
+			MountPath: "/tmp/mnt-1",
+		},
+		{
+			Name:      "spark-local-dir-2",
+			MountPath: "/tmp/mnt-2",
+		},
+	}
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Volumes: volumes,
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+		},
+	}
+
+	localDirOptions, err := addLocalDirConfOptions(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, len(app.Spec.Volumes))
+	assert.Equal(t, 0, len(app.Spec.Driver.VolumeMounts))
+	assert.Equal(t, 4, len(localDirOptions))
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "driver", "hostPath", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[0])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "driver", "hostPath", volumes[0].Name, "path", volumes[0].HostPath.Path), localDirOptions[1])
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "driver", "hostPath", volumes[1].Name, volumeMounts[1].MountPath), localDirOptions[2])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "driver", "hostPath", volumes[1].Name, "path", volumes[1].HostPath.Path), localDirOptions[3])
+}
+
+func TestAddLocalDir_Executor(t *testing.T) {
+	volumes := []corev1.Volume{
+		{
+			Name: "spark-local-dir-1",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/mnt",
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "spark-local-dir-1",
+			MountPath: "/tmp/mnt-1",
+		},
+	}
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Volumes: volumes,
+			Executor: v1beta2.ExecutorSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+		},
+	}
+
+	localDirOptions, err := addLocalDirConfOptions(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, len(app.Spec.Volumes))
+	assert.Equal(t, 0, len(app.Spec.Executor.VolumeMounts))
+	assert.Equal(t, 2, len(localDirOptions))
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "executor", "hostPath", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[0])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "executor", "hostPath", volumes[0].Name, "path", volumes[0].HostPath.Path), localDirOptions[1])
+}
+
+func TestAddLocalDir_Driver_Executor(t *testing.T) {
+	volumes := []corev1.Volume{
+		{
+			Name: "spark-local-dir-1",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/mnt",
+				},
+			},
+		},
+		{
+			Name: "test-volume",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/test",
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "spark-local-dir-1",
+			MountPath: "/tmp/mnt-1",
+		},
+		{
+			Name:      "test-volume",
+			MountPath: "/tmp/test",
+		},
+	}
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Volumes: volumes,
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+			Executor: v1beta2.ExecutorSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					VolumeMounts: volumeMounts,
+				},
+			},
+		},
+	}
+
+	localDirOptions, err := addLocalDirConfOptions(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(app.Spec.Volumes))
+	assert.Equal(t, 1, len(app.Spec.Driver.VolumeMounts))
+	assert.Equal(t, 1, len(app.Spec.Executor.VolumeMounts))
+	assert.Equal(t, 4, len(localDirOptions))
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "driver", "hostPath", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[0])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "driver", "hostPath", volumes[0].Name, "path", volumes[0].HostPath.Path), localDirOptions[1])
+	assert.Equal(t, fmt.Sprintf(VolumeMountPathTemplate, "executor", "hostPath", volumes[0].Name, volumeMounts[0].MountPath), localDirOptions[2])
+	assert.Equal(t, fmt.Sprintf(VolumeMountOptionPathTemplate, "executor", "hostPath", volumes[0].Name, "path", volumes[0].HostPath.Path), localDirOptions[3])
+}

--- a/sparkctl/cmd/s3.go
+++ b/sparkctl/cmd/s3.go
@@ -49,7 +49,7 @@ func newS3Blob(
 	bucket string,
 	endpoint string,
 	region string) (*uploadHandler, error) {
-	// AWS SDK does require specifying regions, thus set it to default GCS region
+	// AWS SDK does require specifying regions, thus set it to default S3 region
 	if region == "" {
 		region = "us-east1"
 	}


### PR DESCRIPTION
This PR helps to mount `HostPath` and `PersistentVolumeClaim` volume for Spark scratch space. Part of #702 

Upstream support was added here and this is included in Spark-3.0.0 (preview)
https://issues.apache.org/jira/browse/SPARK-28042
https://github.com/apache/spark/pull/24879/files

There're two different implementations I considered. 
1. Handle local dir differently and don't use webhook
2. Use webhook patch volume

`spark-local-dir-1` will be created automatically by spark before pods get patched if we don't specify volume for the scratch space. If we choose 2 option, we have to remove this volume and attach new volumes. What's more, SPARK_LOCAL_DIR env needs to be updated as well. I think the first option is more like a native way. 

Let me know if it makes sense and If there's more elegant way, I'd love to make the change.

We can  ask user specify in `SparkApplicationSpec` if they like to use `hostPath`, but this won't give the flexibility like `persistentVolumeClaim` support and we don't know if user want to use multiple disk for scratch space to increase overall IOPS. Need to consider tradeoff here. 
/cc @liyinan926 
