### PR TITLE
Add sparkVersion in spark-pi-scheduled example

### DIFF
--- a/examples/spark-pi-schedule.yaml
+++ b/examples/spark-pi-schedule.yaml
@@ -29,6 +29,7 @@ spec:
     imagePullPolicy: Always
     mainClass: org.apache.spark.examples.SparkPi
     mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
+    sparkVersion: "2.4.4"
     restartPolicy:
       type: Never
     driver:


### PR DESCRIPTION
Address #703 

`sparkVersion` is a required field in `ScheduledSparkApplication`. Without the field, user will see error like beflow

```
The ScheduledSparkApplication "spark-pi-scheduled" is invalid:
......
validation failure list:
spec.template.sparkVersion in body is required
```