### PR TITLE
Add deleteOnTermination option to keep executor pods after a job is completed

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -476,6 +476,9 @@ type ExecutorSpec struct {
 	// JavaOptions is a string of extra JVM options to pass to the executors. For instance,
 	// GC settings or other logging.
 	JavaOptions *string `json:"javaOptions,omitempty"`
+	// DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination
+	// Optional
+	DeleteOnTermination *bool `json:"deleteOnTermination,omitempty"`
 }
 
 // NamePath is a pair of a name and a path to which the named objects should be mounted to.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -187,6 +187,11 @@ func (in *ExecutorSpec) DeepCopyInto(out *ExecutorSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DeleteOnTermination != nil {
+		in, out := &in.DeleteOnTermination, &out.DeleteOnTermination
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -135,6 +135,8 @@ const (
 	SparkDriverJavaOptions = "spark.driver.extraJavaOptions"
 	// SparkExecutorJavaOptions is the Spark configuration key for a string of extra JVM options to pass to executors.
 	SparkExecutorJavaOptions = "spark.executor.extraJavaOptions"
+	// SparkExecutorDeleteOnTermination is the Spark configuration for specifying whether executor pods should be deleted in case of failure or normal termination
+	SparkExecutorDeleteOnTermination = "spark.kubernetes.executor.deleteOnTermination"
 )
 
 const (

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -342,6 +342,11 @@ func addExecutorConfOptions(app *v1beta2.SparkApplication, submissionID string) 
 			fmt.Sprintf("spark.executor.memoryOverhead=%s", *app.Spec.Executor.MemoryOverhead))
 	}
 
+	if app.Spec.Executor.DeleteOnTermination != nil {
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("%s=%t", config.SparkExecutorDeleteOnTermination, *app.Spec.Executor.DeleteOnTermination))
+	}
+
 	for key, value := range app.Spec.Executor.Labels {
 		executorConfOptions = append(executorConfOptions,
 			fmt.Sprintf("%s%s=%s", config.SparkExecutorLabelKeyPrefix, key, value))


### PR DESCRIPTION
Part of #702 

Upstream Issue: 
https://issues.apache.org/jira/browse/SPARK-25515
https://github.com/apache/spark/pull/23136

Note: This is only working for spark-3.0.0. 

Test samples:

```
  executor:
    deleteOnTermination: false
    cores: 1
    instances: 2
    memory: "512m"
```

spark-submit logs inside spark-operator
```
--conf spark.executor.cores=1 --conf spark.executor.memory=512m --conf spark.kubernetes.executor.deleteOnTermination=false --conf spark.kubernetes.executor.label.version=3.0.0-SNAPSHOT local:///opt/spark/examples/jars/spark-examples_2.12-3.0.0-SNAPSHOT.ja
```

```
 kubectl get pods
NAME                                    READY   STATUS      RESTARTS   AGE
spark-pi-b672b16ef29c7918-exec-1        0/1     Completed   0          37s
spark-pi-b672b16ef29c7918-exec-2        0/1     Completed   0          37s
spark-pi-driver                         0/1     Completed   0          48s
```