### PR TITLE
Driver may still be in running state after executors has terminated

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -394,7 +394,7 @@ func (c *Controller) getAndUpdateExecutorState(app *v1beta2.SparkApplication) er
 	// Handle missing/deleted executors.
 	for name, oldStatus := range app.Status.ExecutorState {
 		_, exists := executorStateMap[name]
-		if !isExecutorTerminated(oldStatus) && !exists {
+		if !isExecutorTerminated(oldStatus) && !exists && !isDriverRunning(app) {
 			// If ApplicationState is SUCCEEDING, in other words, the driver pod has been completed
 			// successfully. The executor pods terminate and are cleaned up, so we could not found
 			// the executor pod, under this circumstances, we assume the executor pod are completed.

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -87,6 +87,10 @@ func isExecutorTerminated(executorState v1beta2.ExecutorState) bool {
 	return executorState == v1beta2.ExecutorCompletedState || executorState == v1beta2.ExecutorFailedState
 }
 
+func isDriverRunning(app *v1beta2.SparkApplication) bool {
+	return app.Status.AppState.State == v1beta2.RunningState
+}
+
 func driverStateToApplicationState(podStatus apiv1.PodStatus) v1beta2.ApplicationStateType {
 	switch podStatus.Phase {
 	case apiv1.PodPending:


### PR DESCRIPTION
(#715)
Current logic is wrong, because it sets Executor status to failed or completed in case if the pod is already terminated and Driver pod is still running. 
In fact, some executors can be finished and some executors still working on it's jobs. Current logic will set status of finished executors to failed only because there are still running executors, thus driver can't be in SucceedingState.

I think the solution is setting Completed/Failed to executors only after Application moved from RUNNING state.
