### PR TITLE
Create builds with spark:2.4.5-SNAPSHOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN apt-get update \
     && apt-get install -y openssl curl tini \
     && rm -rf /var/lib/apt/lists/*
 COPY hack/gencerts.sh /usr/bin/
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini \
-    && mv /tini /sbin/tini
 
 COPY entrypoint.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -20,7 +20,7 @@
 # 1. Your Docker version is >= 18.09.3
 # 2. export DOCKER_BUILDKIT=1
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.4
+ARG SPARK_IMAGE=gcr.io/spark-operator/spark:2.4.5-SNAPSHOT
 
 FROM golang:1.12.5-alpine as builder
 ARG DEP_VERSION="0.5.3"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -10,7 +10,7 @@ The easiest way to build the operator without worrying about its dependencies is
 $ docker build -t <image-tag> .
 ```
 
-The operator image is built upon a base Spark image that defaults to `gcr.io/spark-operator/spark:v2.4.4`. If you want to use your own Spark image (e.g., an image with a different version of Spark or some custom dependencies), specify the argument `SPARK_IMAGE` as the following example shows: 
+The operator image is built upon a base Spark image that defaults to `gcr.io/spark-operator/spark:2.4.5-SNAPSHOT`. If you want to use your own Spark image (e.g., an image with a different version of Spark or some custom dependencies), specify the argument `SPARK_IMAGE` as the following example shows:
 
 ```bash
 $ docker build --build-arg SPARK_IMAGE=<your Spark image> -t <image-tag> .

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -64,9 +64,9 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: gcr.io/spark/spark:v2.4.4
+  image: gcr.io/spark/spark:v.4.5-SNAPSHOT
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar
 ```
 
 ### Specifying Application Dependencies
@@ -130,7 +130,7 @@ spec:
     coreLimit: 200m
     memory: 512m
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
 ```
 
@@ -150,7 +150,7 @@ spec:
     instances: 1
     memory: 512m
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
 ```
 
 ### Specifying Extra Java Options
@@ -179,7 +179,7 @@ spec:
       name: "amd.com/gpu"   # GPU resource name
       quantity: 1           # number of GPUs to request
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
   executor:
     cores: 1
@@ -203,7 +203,7 @@ spec:
     memory: "512m"
     hostNetwork: true
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
   executor:
     cores: 1
@@ -539,7 +539,7 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: gcr.io/spark/spark:v2.4.4
+    image: gcr.io/spark/spark:v2.4.5-SNAPSHOT
     mainClass: org.apache.spark.examples.SparkPi
     mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.3.0.jar
     driver:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -64,7 +64,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: gcr.io/spark/spark:v.4.5-SNAPSHOT
+  image: gcr.io/spark/spark:2.4.5-SNAPSHOT
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar
 ```
@@ -451,7 +451,7 @@ Note that Python binding for PySpark is available in Apache Spark 2.4.
 
 The operator supports using the Spark metric system to expose metrics to a variety of sinks. Particularly, it is able to automatically configure the metric system to expose metrics to [Prometheus](https://prometheus.io/). Specifically, the field `.spec.monitoring` specifies how application monitoring is handled and particularly how metrics are to be reported. The metric system is configured through the configuration file `metrics.properties`, which gets its content from the field `.spec.monitoring.metricsProperties`. The content of [metrics.properties](../spark-docker/conf/metrics.properties) will be used by default if `.spec.monitoring.metricsProperties` is not specified. You can choose to enable or disable reporting driver and executor metrics using the fields `.spec.monitoring.exposeDriverMetrics` and `.spec.monitoring.exposeExecutorMetrics`, respectively. 
 
-Further, the field `.spec.monitoring.prometheus` specifies how metrics are exposed to Prometheus using the [Prometheus JMX exporter](https://github.com/prometheus/jmx_exporter). When `.spec.monitoring.prometheus` is specified, the operator automatically configures the JMX exporter to run as a Java agent. The only required field of `.spec.monitoring.prometheus` is `jmxExporterJar`, which specified the path to the Prometheus JMX exporter Java agent jar in the container. If you use the image `gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus`, the jar is located at `/prometheus/jmx_prometheus_javaagent-0.11.0.jar`. The field `.spec.monitoring.prometheus.port` specifies the port the JMX exporter Java agent binds to and defaults to `8090` if not specified. The field `.spec.monitoring.prometheus.configuration` specifies the content of the configuration to be used with the JMX exporter. The content of [prometheus.yaml](../spark-docker/conf/prometheus.yaml) will be used by default if `.spec.monitoring.prometheus.configuration` is not specified.    
+Further, the field `.spec.monitoring.prometheus` specifies how metrics are exposed to Prometheus using the [Prometheus JMX exporter](https://github.com/prometheus/jmx_exporter). When `.spec.monitoring.prometheus` is specified, the operator automatically configures the JMX exporter to run as a Java agent. The only required field of `.spec.monitoring.prometheus` is `jmxExporterJar`, which specified the path to the Prometheus JMX exporter Java agent jar in the container. If you use the image `gcr.io/spark-operator/spark:2.4.5-SNAPSHOT-gcs-prometheus`, the jar is located at `/prometheus/jmx_prometheus_javaagent-0.11.0.jar`. The field `.spec.monitoring.prometheus.port` specifies the port the JMX exporter Java agent binds to and defaults to `8090` if not specified. The field `.spec.monitoring.prometheus.configuration` specifies the content of the configuration to be used with the JMX exporter. The content of [prometheus.yaml](../spark-docker/conf/prometheus.yaml) will be used by default if `.spec.monitoring.prometheus.configuration` is not specified.
 
 Below is an example that shows how to configure the metric system to expose metrics to Prometheus using the Prometheus JMX exporter. Note that the JMX exporter Java agent jar is listed as a dependency and will be downloaded to where `.spec.dep.jarsDownloadDir` points to in Spark 2.3.x, which is `/var/spark-data/spark-jars` by default. Things are different in Spark 2.4 as dependencies will be downloaded to the local working directory instead in Spark 2.4. A complete example can be found in [examples/spark-pi-prometheus.yaml](../examples/spark-pi-prometheus.yaml).
 
@@ -539,7 +539,7 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: gcr.io/spark/spark:v2.4.5-SNAPSHOT
+    image: gcr.io/spark/spark:2.4.5-SNAPSHOT
     mainClass: org.apache.spark.examples.SparkPi
     mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.3.0.jar
     driver:

--- a/docs/volcano-integration.md
+++ b/docs/volcano-integration.md
@@ -31,11 +31,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v2.4.4"
+  image: "gcr.io/spark-operator/spark:2.4.5-SNAPSHOT"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
-  sparkVersion: "2.4.4"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar"
+  sparkVersion: "2.4.5-SNAPSHOT"
   batchScheduler: "volcano"   #Note: the batch scheduler name must be specified with `volcano`
   restartPolicy:
     type: Never
@@ -49,7 +49,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"        
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
@@ -59,7 +59,7 @@ spec:
     instances: 1
     memory: "512m"    
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,4 @@ if [[ -z "$uidentry" ]] ; then
     fi
 fi
 
-exec /sbin/tini -s -- /usr/bin/spark-operator "$@"
+exec /usr/bin/tini -s -- /usr/bin/spark-operator "$@"

--- a/examples/spark-pi-configmap.yaml
+++ b/examples/spark-pi-configmap.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v2.4.4"
+  image: "gcr.io/spark-operator/spark:2.4.5-SNAPSHOT"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
-  sparkVersion: "2.4.4"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar"
+  sparkVersion: "2.4.5-SNAPSHOT"
   restartPolicy:
     type: Never
   volumes:
@@ -37,7 +37,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
     volumeMounts:
       - name: config-vol
@@ -47,7 +47,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     volumeMounts:
       - name: config-vol
         mountPath: /opt/spark/mycm

--- a/examples/spark-pi-prometheus.yaml
+++ b/examples/spark-pi-prometheus.yaml
@@ -25,10 +25,10 @@ spec:
   image: "gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar"
   arguments:
     - "100000"
-  sparkVersion: "2.4.4"
+  sparkVersion: "2.4.5-SNAPSHOT"
   restartPolicy:
     type: Never
   driver:
@@ -36,14 +36,14 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
   executor:
     cores: 1
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
   monitoring:
     exposeDriverMetrics: true
     exposeExecutorMetrics: true

--- a/examples/spark-pi-schedule.yaml
+++ b/examples/spark-pi-schedule.yaml
@@ -25,11 +25,11 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: "gcr.io/spark-operator/spark:v2.4.4"
+    image: "gcr.io/spark-operator/spark:2.4.5-SNAPSHOT"
     imagePullPolicy: Always
     mainClass: org.apache.spark.examples.SparkPi
-    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
-    sparkVersion: "2.4.4"
+    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar"
+    sparkVersion: "2.4.5-SNAPSHOT"
     restartPolicy:
       type: Never
     driver:
@@ -37,11 +37,11 @@ spec:
       coreLimit: "1200m"
       memory: "512m"
       labels:
-        version: 2.4.4
+        version: 2.4.5-SNAPSHOT
       serviceAccount: spark
     executor:
       cores: 1
       instances: 1
       memory: "512m"
       labels:
-        version: 2.4.4 
+        version: 2.4.5-SNAPSHOT

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v2.4.4"
+  image: "gcr.io/spark-operator/spark:2.4.5-SNAPSHOT"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
-  sparkVersion: "2.4.4"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar"
+  sparkVersion: "2.4.5-SNAPSHOT"
   restartPolicy:
     type: Never
   volumes:
@@ -38,7 +38,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
@@ -48,7 +48,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-py-pi.yaml
+++ b/examples/spark-py-pi.yaml
@@ -25,10 +25,10 @@ spec:
   type: Python
   pythonVersion: "2"
   mode: cluster
-  image: "gcr.io/spark-operator/spark-py:v2.4.4"
+  image: "gcr.io/spark-operator/spark-py:2.4.5-SNAPSHOT"
   imagePullPolicy: Always
   mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
-  sparkVersion: "2.4.4"
+  sparkVersion: "2.4.5-SNAPSHOT"
   restartPolicy:
     type: OnFailure
     onFailureRetries: 3
@@ -40,11 +40,11 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT
     serviceAccount: spark
   executor:
     cores: 1
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.5-SNAPSHOT

--- a/manifest/spark-operator-with-metrics.yaml
+++ b/manifest/spark-operator-with-metrics.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: sparkoperator
       containers:
       - name: sparkoperator
-        image: gcr.io/spark-operator/spark-operator:v2.4.4-v1beta2-latest
+        image: gcr.io/spark-operator/spark-operator:2.4.5-SNAPSHOT
         imagePullPolicy: Always
         ports:
           - containerPort: 10254

--- a/manifest/spark-operator-with-webhook.yaml
+++ b/manifest/spark-operator-with-webhook.yaml
@@ -43,7 +43,7 @@ spec:
           secretName: spark-webhook-certs
       containers:
       - name: sparkoperator
-        image: gcr.io/spark-operator/spark-operator:v2.4.4-v1beta2-latest
+        image: gcr.io/spark-operator/spark-operator:2.4.5-SNAPSHOT
         imagePullPolicy: Always
         volumeMounts:
         - name: webhook-certs
@@ -75,7 +75,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: main
-        image: gcr.io/spark-operator/spark-operator:v2.4.4-v1beta2-latest
+        image: gcr.io/spark-operator/spark-operator:2.4.5-SNAPSHOT
         imagePullPolicy: IfNotPresent
         command: ["/usr/bin/gencerts.sh", "-p"]
 ---

--- a/manifest/spark-operator.yaml
+++ b/manifest/spark-operator.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: sparkoperator
       containers:
       - name: sparkoperator
-        image: gcr.io/spark-operator/spark-operator:v2.4.4-v1beta2-latest
+        image: gcr.io/spark-operator/spark-operator:2.4.5-SNAPSHOT
         imagePullPolicy: Always
         args:
         - -logtostderr

--- a/spark-docker/Dockerfile
+++ b/spark-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.4
+ARG SPARK_IMAGE=gcr.io/spark-operator/spark:2.4.5-SNAPSHOT
 FROM ${SPARK_IMAGE}
 
 # Setup dependencies for Google Cloud Storage access.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -12,7 +12,7 @@ Prerequisites:
 e2e tests are written as Go test. All go test techniques apply (e.g. picking what to run, timeout length). Let's say I want to run all tests in "test/e2e/":
 
 ```bash
-$ go test -v ./test/e2e/ --kubeconfig "$HOME/.kube/config" --operator-image=gcr.io/spark-operator/spark-operator:v2.4.4-v1beta2-latest
+$ go test -v ./test/e2e/ --kubeconfig "$HOME/.kube/config" --operator-image=gcr.io/spark-operator/spark-operator:2.4.5-SNAPSHOT
 ```
 
 ### Available Tests


### PR DESCRIPTION
This patch set builds the operator using the spark image:
- gcr.io/spark-operator/spark:2.4.5-SNAPSHOT

This is needed as documented in this issue:
- https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/669

The underlying problem is that openjdk on alpine has become unsupported
and the spark project has moved to openjdk:8-jdk-slim which is ubuntu
based as described in this issue:
- https://issues.apache.org/jira/browse/SPARK-28938

Without this, the GKE service accounts or workload identity won't
properly authorize.  This was not observed with the given examples
because they explicitly pass in credentials rather than relying on
workload identity or service accounts.