### PR TITLE
Add gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+stages:
+- build
+
+build:
+  stage: build
+  image: docker:stable
+  services:
+    - docker:dind
+  before_script:
+    - apk --no-cache add git
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY ;
+    - tagStamp=$(git describe --dirty) ; echo tagStamp is ${tagStamp} ;
+    - echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}:${tagStamp}
+    - time docker build -t ${CI_REGISTRY_IMAGE}:${tagStamp} .
+    - time docker push ${CI_REGISTRY_IMAGE}:${tagStamp}
+    - docker images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
 stages:
 - build
 
+variables:
+    DEP_VERSION: "0.5.3"
+
 build:
   stage: build
   image: docker:stable
@@ -13,7 +16,7 @@ build:
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY ;
     - tagStamp=$(git describe --dirty) ; echo tagStamp is ${tagStamp} ;
-    - echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}:${tagStamp}
-    - time docker build -t ${CI_REGISTRY_IMAGE}:${tagStamp} .
-    - time docker push ${CI_REGISTRY_IMAGE}:${tagStamp}
+    - echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
+    - time docker build -t ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp} .
+    - time docker push ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
     - docker images


### PR DESCRIPTION
This adds a builder for gitlab.com

Note that this depends on "git describe" to create the tag.
For this to work, you need to create some base tag with something like:
- git tag -a v0.0.1 -m 'Starting version v0.0.1'

After that, well-defined versions can be created by tagging with the
actual version number.