### PR TITLE
Use SPARK_REGISTRY and SPARK_VERSION for build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,16 @@ build:
     DOCKER_HOST: tcp://docker:2375
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY ;
-    - tagStamp=$(git describe --dirty) ; echo tagStamp is ${tagStamp} ;
-    - echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
-    - time docker build -t ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp} .
+    - >
+      if [ "${SPARK_REGISTRY}" != "" -a "${SPARK_VERSION}" != "" ] ; then
+        tagStamp=$(git describe --dirty)_${SPARK_VERSION}
+        echo Using SPARK_IMAGE ${SPARK_REGISTRY}:${SPARK_VERSION}
+        echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
+        docker build --build-arg SPARK_IMAGE=${SPARK_REGISTRY}:${SPARK_VERSION} -t ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp} .
+      else
+        tagStamp=$(git describe --dirty) ; echo tagStamp is ${tagStamp} ;
+        echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
+        docker build -t ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp} .
+      fi
     - time docker push ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
     - docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.4
+ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v2.4.5-SNAPSHOT
 
 FROM golang:1.12.5-alpine as builder
 ARG DEP_VERSION="0.5.3"
@@ -30,7 +30,9 @@ RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/
-RUN apk add --no-cache openssl curl tini
+RUN apt-get update \
+    && apt-get install -y openssl curl tini \
+    && rm -rf /var/lib/apt/lists/*
 COPY hack/gencerts.sh /usr/bin/
 
 COPY entrypoint.sh /usr/bin/


### PR DESCRIPTION
Construct a build tag for the spark-operator with the SPARK_VERSION
appended.  Thus the operator-version_spark-version as in:
- v1beta2-8-g3e080b2_v2.4.4-12-g9f9ae44

This is an alternative, more minimal change than https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/723

But note that it assumes you are using a version of spark that is based on openjdk:8-jdk-slim as the current 2.4 branch for spark.