### PR TITLE
Fix entrypoint.sh to /usr/bin/tini

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,4 @@ if [[ -z "$uidentry" ]] ; then
     fi
 fi
 
-exec /sbin/tini -s -- /usr/bin/spark-operator "$@"
+exec /usr/bin/tini -s -- /usr/bin/spark-operator "$@"


### PR DESCRIPTION
Somehow this got lost in the updates.
The debian tini install puts it into /usr/bin/tini