### PR TITLE
Added support for separate key for driver physical CPU request

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -946,6 +946,19 @@ in-cluster-client.</p>
 </tr>
 <tr>
 <td>
+<code>coreRequest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CoreRequest is the physical CPU core request for the driver.
+Maps to <code>spark.kubernetes.driver.request.cores</code> that is available since Spark 3.0.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>serviceAccount</code></br>
 <em>
 string
@@ -1023,7 +1036,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>CoreRequest is the physical CPU core request for the executors.</p>
+<p>CoreRequest is the physical CPU core request for the executors.
+Maps to <code>spark.kubernetes.executor.request.cores</code> that is available since Spark 2.4.</p>
 </td>
 </tr>
 <tr>
@@ -1034,6 +1048,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>JavaOptions is a string of extra JVM options to pass to the executors. For instance,
 GC settings or other logging.</p>
 </td>
@@ -1046,8 +1061,9 @@ bool
 </em>
 </td>
 <td>
-<p>DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination
-Optional</p>
+<em>(Optional)</em>
+<p>DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination.
+Maps to <code>spark.kubernetes.executor.deleteOnTermination</code> that is available since Spark 3.0.</p>
 </td>
 </tr>
 </tbody>
@@ -2216,7 +2232,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>Cores is the number of CPU cores to request for the pod.</p>
+<p>Cores maps to <code>spark.driver.cores</code> or <code>spark.executor.cores</code> for the driver and executors, respectively.</p>
 </td>
 </tr>
 <tr>
@@ -2515,5 +2531,5 @@ Kubernetes core/v1.PodDNSConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>988409b</code>.
+on git commit <code>1b96b7b</code>.
 </em></p>

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -382,7 +382,7 @@ type Dependencies struct {
 // SparkPodSpec defines common things that can be customized for a Spark driver or executor pod.
 // TODO: investigate if we should use v1.PodSpec and limit what can be set instead.
 type SparkPodSpec struct {
-	// Cores is the number of CPU cores to request for the pod.
+	// Cores maps to `spark.driver.cores` or `spark.executor.cores` for the driver and executors, respectively.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	Cores *int32 `json:"cores,omitempty"`
@@ -467,6 +467,10 @@ type DriverSpec struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
 	PodName *string `json:"podName,omitempty"`
+	// CoreRequest is the physical CPU core request for the driver.
+	// Maps to `spark.kubernetes.driver.request.cores` that is available since Spark 3.0.
+	// +optional
+	CoreRequest *string `json:"coreRequest,omitempty"`
 	// ServiceAccount is the name of the Kubernetes service account used by the driver pod
 	// when requesting executor pods from the API server.
 	ServiceAccount *string `json:"serviceAccount,omitempty"`
@@ -483,13 +487,16 @@ type ExecutorSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	Instances *int32 `json:"instances,omitempty"`
 	// CoreRequest is the physical CPU core request for the executors.
+	// Maps to `spark.kubernetes.executor.request.cores` that is available since Spark 2.4.
 	// +optional
 	CoreRequest *string `json:"coreRequest,omitempty"`
 	// JavaOptions is a string of extra JVM options to pass to the executors. For instance,
 	// GC settings or other logging.
+	// +optional
 	JavaOptions *string `json:"javaOptions,omitempty"`
-	// DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination
-	// Optional
+	// DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination.
+	// Maps to `spark.kubernetes.executor.deleteOnTermination` that is available since Spark 3.0.
+	// +optional
 	DeleteOnTermination *bool `json:"deleteOnTermination,omitempty"`
 }
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -74,12 +74,14 @@ const (
 	SparkDriverContainerImageKey = "spark.kubernetes.driver.container.image"
 	// SparkExecutorContainerImageKey is the configuration property for specifying a custom executor container image.
 	SparkExecutorContainerImageKey = "spark.kubernetes.executor.container.image"
+	// SparkDriverCoreRequestKey is the configuration property for specifying the physical CPU request for the driver.
+	SparkDriverCoreRequestKey = "spark.kubernetes.driver.request.cores"
+	// SparkExecutorCoreRequestKey is the configuration property for specifying the physical CPU request for executors.
+	SparkExecutorCoreRequestKey = "spark.kubernetes.executor.request.cores"
 	// SparkDriverCoreLimitKey is the configuration property for specifying the hard CPU limit for the driver pod.
 	SparkDriverCoreLimitKey = "spark.kubernetes.driver.limit.cores"
 	// SparkExecutorCoreLimitKey is the configuration property for specifying the hard CPU limit for the executor pods.
 	SparkExecutorCoreLimitKey = "spark.kubernetes.executor.limit.cores"
-	// SparkExecutorCoreRequestKey is the configuration property for specifying the physical CPU request for executors.
-	SparkExecutorCoreRequestKey = "spark.kubernetes.executor.request.cores"
 	// SparkDriverSecretKeyPrefix is the configuration property prefix for specifying secrets to be mounted into the
 	// driver.
 	SparkDriverSecretKeyPrefix = "spark.kubernetes.driver.secrets."

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -269,6 +269,10 @@ func addDriverConfOptions(app *v1beta2.SparkApplication, submissionID string) ([
 		driverConfOptions = append(driverConfOptions,
 			fmt.Sprintf("spark.driver.cores=%d", *app.Spec.Driver.Cores))
 	}
+	if app.Spec.Driver.CoreRequest != nil {
+		driverConfOptions = append(driverConfOptions,
+			fmt.Sprintf("%s=%s", config.SparkDriverCoreRequestKey, *app.Spec.Driver.CoreRequest))
+	}
 	if app.Spec.Driver.CoreLimit != nil {
 		driverConfOptions = append(driverConfOptions,
 			fmt.Sprintf("%s=%s", config.SparkDriverCoreLimitKey, *app.Spec.Driver.CoreLimit))
@@ -333,14 +337,14 @@ func addExecutorConfOptions(app *v1beta2.SparkApplication, submissionID string) 
 			fmt.Sprintf("%s=%s", config.SparkExecutorContainerImageKey, *app.Spec.Executor.Image))
 	}
 
-	if app.Spec.Executor.CoreRequest != nil {
-		executorConfOptions = append(executorConfOptions,
-			fmt.Sprintf("%s=%s", config.SparkExecutorCoreRequestKey, *app.Spec.Executor.CoreRequest))
-	}
 	if app.Spec.Executor.Cores != nil {
 		// Property "spark.executor.cores" does not allow float values.
 		executorConfOptions = append(executorConfOptions,
 			fmt.Sprintf("spark.executor.cores=%d", int32(*app.Spec.Executor.Cores)))
+	}
+	if app.Spec.Executor.CoreRequest != nil {
+		executorConfOptions = append(executorConfOptions,
+			fmt.Sprintf("%s=%s", config.SparkExecutorCoreRequestKey, *app.Spec.Executor.CoreRequest))
 	}
 	if app.Spec.Executor.CoreLimit != nil {
 		executorConfOptions = append(executorConfOptions,


### PR DESCRIPTION
The new field `.spec.driver.coreRequest` only works with Spark 3.0.