### PR TITLE
fix duplicate volume err when patch pod with subpath volume mount

### DIFF
--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -117,6 +117,7 @@ func addVolumes(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation
 	}
 
 	var ops []patchOperation
+	addedVolumeMap := make(map[string]corev1.Volume)
 	for _, m := range volumeMounts {
 		// Skip adding localDirVolumes
 		if strings.HasPrefix(m.Name, config.SparkLocalDirVolumePrefix) {
@@ -124,7 +125,10 @@ func addVolumes(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation
 		}
 
 		if v, ok := volumeMap[m.Name]; ok {
-			ops = append(ops, addVolume(pod, v))
+			if _, ok := addedVolumeMap[m.Name]; !ok {
+				ops = append(ops, addVolume(pod, v))
+				addedVolumeMap[m.Name] = v
+			}
 			ops = append(ops, addVolumeMount(pod, m))
 		}
 	}


### PR DESCRIPTION
when I use SparkApplication with subpath, for example:

```
apiVersion: sparkoperator.k8s.io/v1beta2
kind: SparkApplication
metadata:
  name: spark-sfs
spec:
  arguments:
  - "40000"
  driver:
    coreLimit: "1"
    cores: 1
    memory: 1536m
    memoryOverhead: 512m
    volumeMounts:
    - mountPath: /package
      name: cci-sfs-spark
      subPath: spark-jar
    - mountPath: /sfs
      name: cci-sfs-spark
      readOnly: false
  executor:
    coreLimit: 1000m
    coreRequest: 1000m
    instances: 1
    memory: 1536m
    memoryOverhead: 512m
    volumeMounts:
    - mountPath: /package
      name: cci-sfs-spark
      subPath: spark-jar
    - mountPath: /sfs
      name: cci-sfs-spark
      readOnly: false
  image: image:test
  imagePullPolicy: Always
  mainApplicationFile: local:///package/spark-examples_2.11-2.4.5-SNAPSHOT.jar
  mainClass: org.apache.spark.examples.SparkPi
  mode: cluster
  restartPolicy:
    onFailureRetries: 1
    onFailureRetryInterval: 1
    type: Never
  volumes:
  - name: cci-sfs-spark
    persistentVolumeClaim:
      claimName: cci-sfs-spark
```

the sparkapp will fail

```
Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://kubernetes.default.svc/api/v1/namespaces/cci-cromwell-zxx/pods. Message: Pod "bks-spark-2020171-driver" is invalid: spec.volumes[7].name: Duplicate value: "bks-pvc-k53kxt3s-u775". Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=spec.volumes[7].name, message=Duplicate value: "bks-pvc-k53kxt3s-u775", reason=FieldValueDuplicate, additionalProperties={})], group=null, kind=Pod, name=bks-spark-2020171-driver, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=Pod "bks-spark-2020171-driver" is invalid: spec.volumes[7].name: Duplicate value: "bks-pvc-k53kxt3s-u775", metadata=ListMeta(_continue=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).
```


/assign @liyinan926 