### PR TITLE
feat: Add caicloud as a adopter

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -2,6 +2,7 @@
 
 | Organization | Contact (Github User Name) | Environment | Description of Use |
 | ------------- | ------------- | ------------- | ------------- |
+| [Caicloud](https://intl.caicloud.io/) | @gaocegege | Production | Cloud-Native AI Platform |
 | Microsoft (MileIQ) |@dharmeshkakadia| Production | AI & Analytics |
 | Lightbend |@yuchaoran2011| Production | Data Infrastructure & Operations |
 | StackTome | @emiliauskas-fuzzy | Production | Data pipelines |


### PR DESCRIPTION
We are using the operator in production and glad to add the information to the adopters list.

Signed-off-by: Ce Gao <gaoce@caicloud.io>