### PR TITLE
Add job start latency metrics and add namespace tag in metrics

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -188,7 +188,9 @@ If enabled, the operator generates the following metrics:
 | `spark_app_failure_count` | Total number of SparkApplication which failed to complete. |
 | `spark_app_running_count` | Total number of SparkApplication which are currently running.|
 | `spark_app_success_execution_time_microseconds` | Execution time for applications which succeeded.|
-| `spark_app_failure_execution_time_microseconds` |Execution time for applications which failed. |
+| `spark_app_failure_execution_time_microseconds` | Execution time for applications which failed. |
+| `spark_app_start_latency_microseconds` | Start latency of SparkApplication as type of [Prometheus Summary](https://prometheus.io/docs/concepts/metric_types/#summary). |
+| `spark_app_start_latency_seconds` | Start latency of SparkApplication as type of [Prometheus Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram). |
 | `spark_app_executor_success_count` | Total number of Spark Executors which completed successfully. |
 | `spark_app_executor_failure_count` | Total number of Spark Executors which failed. |
 | `spark_app_executor_running_count` | Total number of Spark Executors which are currently running. |

--- a/main.go
+++ b/main.go
@@ -78,6 +78,10 @@ var (
 func main() {
 	var metricsLabels util.ArrayFlags
 	flag.Var(&metricsLabels, "metrics-labels", "Labels for the metrics")
+	var metricsJobStartLatencyBuckets util.HistogramBuckets = util.DefaultJobStartLatencyBuckets
+	flag.Var(&metricsJobStartLatencyBuckets, "metrics-job-start-latency-buckets",
+		"Comma-separated boundary values (in seconds) for the job start latency histogram bucket; "+
+			"it accepts any numerical values that can be parsed into a 64-bit floating point")
 	flag.Parse()
 
 	// Create the client config. Use kubeConfig if given, otherwise assume in-cluster.
@@ -159,10 +163,11 @@ func main() {
 	var metricConfig *util.MetricConfig
 	if *enableMetrics {
 		metricConfig = &util.MetricConfig{
-			MetricsEndpoint: *metricsEndpoint,
-			MetricsPort:     *metricsPort,
-			MetricsPrefix:   *metricsPrefix,
-			MetricsLabels:   metricsLabels,
+			MetricsEndpoint:               *metricsEndpoint,
+			MetricsPort:                   *metricsPort,
+			MetricsPrefix:                 *metricsPrefix,
+			MetricsLabels:                 metricsLabels,
+			MetricsJobStartLatencyBuckets: metricsJobStartLatencyBuckets,
 		}
 
 		glog.Info("Enabling metrics collecting and exporting to Prometheus")

--- a/main.go
+++ b/main.go
@@ -60,10 +60,6 @@ var (
 	namespace                      = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
 	enableWebhook                  = flag.Bool("enable-webhook", false, "Whether to enable the mutating admission webhook for admitting and patching Spark pods.")
 	enableResourceQuotaEnforcement = flag.Bool("enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
-	enableMetrics                  = flag.Bool("enable-metrics", false, "Whether to enable the metrics endpoint.")
-	metricsPort                    = flag.String("metrics-port", "10254", "Port for the metrics endpoint.")
-	metricsEndpoint                = flag.String("metrics-endpoint", "/metrics", "Metrics endpoint.")
-	metricsPrefix                  = flag.String("metrics-prefix", "", "Prefix for the metrics.")
 	ingressURLFormat               = flag.String("ingress-url-format", "", "Ingress URL format.")
 	enableLeaderElection           = flag.Bool("leader-election", false, "Enable Spark operator leader election.")
 	leaderElectionLockNamespace    = flag.String("leader-election-lock-namespace", "spark-operator", "Namespace in which to create the ConfigMap for leader election.")
@@ -71,14 +67,17 @@ var (
 	leaderElectionLeaseDuration    = flag.Duration("leader-election-lease-duration", 15*time.Second, "Leader election lease duration.")
 	leaderElectionRenewDeadline    = flag.Duration("leader-election-renew-deadline", 14*time.Second, "Leader election renew deadline.")
 	leaderElectionRetryPeriod      = flag.Duration("leader-election-retry-period", 4*time.Second, "Leader election retry period.")
-	enableBatchScheduler           = flag.Bool("enable-batch-scheduler", false,
-		fmt.Sprintf("Enable batch schedulers for pods' scheduling, the available batch schedulers are: (%s).", strings.Join(batchscheduler.GetRegisteredNames(), ",")))
+	enableBatchScheduler           = flag.Bool("enable-batch-scheduler", false, fmt.Sprintf("Enable batch schedulers for pods' scheduling, the available batch schedulers are: (%s).", strings.Join(batchscheduler.GetRegisteredNames(), ",")))
+	enableMetrics                  = flag.Bool("enable-metrics", false, "Whether to enable the metrics endpoint.")
+	metricsPort                    = flag.String("metrics-port", "10254", "Port for the metrics endpoint.")
+	metricsEndpoint                = flag.String("metrics-endpoint", "/metrics", "Metrics endpoint.")
+	metricsPrefix                  = flag.String("metrics-prefix", "", "Prefix for the metrics.")
+	metricsLabels                  util.ArrayFlags
+	metricsJobStartLatencyBuckets  util.HistogramBuckets = util.DefaultJobStartLatencyBuckets
 )
 
 func main() {
-	var metricsLabels util.ArrayFlags
 	flag.Var(&metricsLabels, "metrics-labels", "Labels for the metrics")
-	var metricsJobStartLatencyBuckets util.HistogramBuckets = util.DefaultJobStartLatencyBuckets
 	flag.Var(&metricsJobStartLatencyBuckets, "metrics-job-start-latency-buckets",
 		"Comma-separated boundary values (in seconds) for the job start latency histogram bucket; "+
 			"it accepts any numerical values that can be parsed into a 64-bit floating point")

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -122,7 +122,7 @@ func newSparkApplicationController(
 	}
 
 	if metricsConfig != nil {
-		controller.metrics = newSparkAppMetrics(metricsConfig.MetricsPrefix, metricsConfig.MetricsLabels)
+		controller.metrics = newSparkAppMetrics(metricsConfig.MetricsPrefix, metricsConfig.MetricsLabels, metricsConfig.MetricsJobStartLatencyBuckets)
 		controller.metrics.registerMetrics()
 	}
 
@@ -455,18 +455,18 @@ func shouldRetry(app *v1beta2.SparkApplication) bool {
 
 // State Machine for SparkApplication:
 //+--------------------------------------------------------------------------------------------------------------------+
-//|                                                                                                                    |
-//|                +---------+                                                                                         |
-//|                |         |                                                                                         |
-//|                |         +                                                                                         |
-//|                |Submission                                                                                         |
-//|           +----> Failed  +-----+------------------------------------------------------------------+                |
-//|           |    |         |     |                                                                  |                |
-//|           |    |         |     |                                                                  |                |
-//|           |    +----^----+     |                                                                  |                |
-//|           |         |          |                                                                  |                |
-//|           |         |          |                                                                  |                |
-//|      +----+----+    |    +-----v----+          +----------+           +-----------+          +----v-----+          |
+//|        +---------------------------------------------------------------------------------------------+             |
+//|        |       +----------+                                                                          |             |
+//|        |       |          |                                                                          |             |
+//|        |       |          |                                                                          |             |
+//|        |       |Submission|                                                                          |             |
+//|        |  +---->  Failed  +----+------------------------------------------------------------------+  |             |
+//|        |  |    |          |    |                                                                  |  |             |
+//|        |  |    |          |    |                                                                  |  |             |
+//|        |  |    +----^-----+    |  +-----------------------------------------+                     |  |             |
+//|        |  |         |          |  |                                         |                     |  |             |
+//|        |  |         |          |  |                                         |                     |  |             |
+//|      +-+--+----+    |    +-----v--+-+          +----------+           +-----v-----+          +----v--v--+          |
 //|      |         |    |    |          |          |          |           |           |          |          |          |
 //|      |         |    |    |          |          |          |           |           |          |		    |          |
 //|      |   New   +---------> Submitted+----------> Running  +----------->  Failing  +---------->  Failed  |          |

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -122,7 +122,7 @@ func newSparkApplicationController(
 	}
 
 	if metricsConfig != nil {
-		controller.metrics = newSparkAppMetrics(metricsConfig.MetricsPrefix, metricsConfig.MetricsLabels, metricsConfig.MetricsJobStartLatencyBuckets)
+		controller.metrics = newSparkAppMetrics(metricsConfig)
 		controller.metrics.registerMetrics()
 	}
 
@@ -468,7 +468,7 @@ func shouldRetry(app *v1beta2.SparkApplication) bool {
 //|        |  |         |          |  |                                         |                     |  |             |
 //|      +-+--+----+    |    +-----v--+-+          +----------+           +-----v-----+          +----v--v--+          |
 //|      |         |    |    |          |          |          |           |           |          |          |          |
-//|      |         |    |    |          |          |          |           |           |          |		    |          |
+//|      |         |    |    |          |          |          |           |           |          |          |          |
 //|      |   New   +---------> Submitted+----------> Running  +----------->  Failing  +---------->  Failed  |          |
 //|      |         |    |    |          |          |          |           |           |          |          |          |
 //|      |         |    |    |          |          |          |           |           |          |          |          |

--- a/pkg/controller/sparkapplication/sparkapp_metrics_test.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics_test.go
@@ -27,8 +27,8 @@ import (
 func TestSparkAppMetrics(t *testing.T) {
 	http.DefaultServeMux = new(http.ServeMux)
 	// Test with label containing "-". Expect them to be converted to "_".
-	metrics := newSparkAppMetrics("", []string{"app-id"})
-	app1 := map[string]string{"app_id": "test1"}
+	metrics := newSparkAppMetrics("", []string{"app-id", "namespace"}, []float64{30, 60, 90, 120})
+	app1 := map[string]string{"app_id": "test1", "namespace": "default"}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -42,6 +42,7 @@ func TestSparkAppMetrics(t *testing.T) {
 			metrics.sparkAppSuccessExecutionTime.With(app1).Observe(float64(100 * i))
 			metrics.sparkAppFailureExecutionTime.With(app1).Observe(float64(500 * i))
 			metrics.sparkAppStartLatency.With(app1).Observe(float64(10 * i))
+			metrics.sparkAppStartLatencyHistogram.With(app1).Observe(float64(10 * i))
 			metrics.sparkAppExecutorRunningCount.Inc(app1)
 			metrics.sparkAppExecutorSuccessCount.With(app1).Inc()
 			metrics.sparkAppExecutorFailureCount.With(app1).Inc()

--- a/pkg/controller/sparkapplication/sparkapp_metrics_test.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
 	"net/http"
 	"sync"
 	"testing"
@@ -27,7 +28,12 @@ import (
 func TestSparkAppMetrics(t *testing.T) {
 	http.DefaultServeMux = new(http.ServeMux)
 	// Test with label containing "-". Expect them to be converted to "_".
-	metrics := newSparkAppMetrics("", []string{"app-id", "namespace"}, []float64{30, 60, 90, 120})
+	metricsConfig := &util.MetricConfig{
+		MetricsPrefix:                 "",
+		MetricsLabels:                 []string{"app-id", "namespace"},
+		MetricsJobStartLatencyBuckets: []float64{30, 60, 90, 120},
+	}
+	metrics := newSparkAppMetrics(metricsConfig)
 	app1 := map[string]string{"app_id": "test1", "namespace": "default"}
 
 	var wg sync.WaitGroup

--- a/pkg/controller/sparkapplication/sparkapp_metrics_test.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics_test.go
@@ -41,6 +41,7 @@ func TestSparkAppMetrics(t *testing.T) {
 			metrics.sparkAppFailedSubmissionCount.With(app1).Inc()
 			metrics.sparkAppSuccessExecutionTime.With(app1).Observe(float64(100 * i))
 			metrics.sparkAppFailureExecutionTime.With(app1).Observe(float64(500 * i))
+			metrics.sparkAppStartLatency.With(app1).Observe(float64(10 * i))
 			metrics.sparkAppExecutorRunningCount.Inc(app1)
 			metrics.sparkAppExecutorSuccessCount.With(app1).Inc()
 			metrics.sparkAppExecutorFailureCount.With(app1).Inc()

--- a/pkg/util/histogram_buckets.go
+++ b/pkg/util/histogram_buckets.go
@@ -33,7 +33,7 @@ func (hb *HistogramBuckets) String() string {
 func (hb *HistogramBuckets) Set(value string) error {
 	*hb = nil
 	for _, boundaryStr := range strings.Split(value, ",") {
-		boundary, err := strconv.ParseFloat(boundaryStr, 64)
+		boundary, err := strconv.ParseFloat(strings.TrimSpace(boundaryStr), 64)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/histogram_buckets.go
+++ b/pkg/util/histogram_buckets.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var DefaultJobStartLatencyBuckets = []float64{30, 60, 90, 120, 150, 180, 210, 240, 270, 300}
+
+type HistogramBuckets []float64
+
+func (hb *HistogramBuckets) String() string {
+	return fmt.Sprint(*hb)
+}
+
+func (hb *HistogramBuckets) Set(value string) error {
+	*hb = nil
+	for _, boundaryStr := range strings.Split(value, ",") {
+		boundary, err := strconv.ParseFloat(boundaryStr, 64)
+		if err != nil {
+			return err
+		}
+		*hb = append(*hb, boundary)
+	}
+	return nil
+}

--- a/pkg/util/metrics.go
+++ b/pkg/util/metrics.go
@@ -49,10 +49,11 @@ func RegisterMetric(metric prometheus.Collector) {
 // MetricConfig is a container of configuration properties for the collection and exporting of
 // application metrics to Prometheus.
 type MetricConfig struct {
-	MetricsEndpoint string
-	MetricsPort     string
-	MetricsPrefix   string
-	MetricsLabels   []string
+	MetricsEndpoint               string
+	MetricsPort                   string
+	MetricsPrefix                 string
+	MetricsLabels                 []string
+	MetricsJobStartLatencyBuckets []float64
 }
 
 // A variant of Prometheus Gauge that only holds non-negative values.


### PR DESCRIPTION
This PR adds job start latency metric. The job start latency is defined as the time since the sparkapp k8s object is created till when the job is in a running or terminal state. There are two metrics introduced in this change, one is `spark_app_start_latency_microseconds`, which is of Prometheus Summary type, and the other one is `spark_app_start_latency_seconds`, which is of Histogram type. The summary one is to give the user accurate latency values in different percentiles (e.g. 0.5, 0.9. 0.99), thus it's in microseconds. The histogram one is to give the user an option to configure the bucket boundaries, see how the job latency values fall into different histogram buckets, and thus can pick appropriate service job start latency SLA out of it, and thus it's in seconds for easier configuration.

This PR also adds configurability to include `namespace` as a tag in the metrics, to make metrics more useful in a multi-tenant k8s cluster.

I also corrected the state machine diagram in `controller.go` during implementation.