### PR TITLE
ScheduledSparkApplications: NextRun should be recalculated if desired schedule changes

### DIFF
--- a/pkg/controller/scheduledsparkapplication/controller.go
+++ b/pkg/controller/scheduledsparkapplication/controller.go
@@ -172,9 +172,11 @@ func (c *Controller) syncScheduledSparkApplication(key string) error {
 		status.ScheduleState = v1beta2.ScheduledState
 		now := c.clock.Now()
 		nextRunTime := status.NextRun.Time
-		if nextRunTime.IsZero() {
+		// if we updated the schedule for an earlier execution - those changes need to be reflected
+		updatedScheduleRuntime := schedule.Next(now)
+		if nextRunTime.IsZero() || updatedScheduleRuntime.Before(nextRunTime) {
 			// The first run of the application.
-			nextRunTime = schedule.Next(now)
+			nextRunTime = updatedScheduleRuntime
 			status.NextRun = metav1.NewTime(nextRunTime)
 		}
 		if nextRunTime.Before(now) {

--- a/pkg/controller/scheduledsparkapplication/controller.go
+++ b/pkg/controller/scheduledsparkapplication/controller.go
@@ -173,10 +173,10 @@ func (c *Controller) syncScheduledSparkApplication(key string) error {
 		now := c.clock.Now()
 		nextRunTime := status.NextRun.Time
 		// if we updated the schedule for an earlier execution - those changes need to be reflected
-		updatedScheduleRuntime := schedule.Next(now)
-		if nextRunTime.IsZero() || updatedScheduleRuntime.Before(nextRunTime) {
+		updatedNextRunTime := schedule.Next(now)
+		if nextRunTime.IsZero() || updatedNextRunTime.Before(nextRunTime) {
 			// The first run of the application.
-			nextRunTime = updatedScheduleRuntime
+			nextRunTime = updatedNextRunTime
 			status.NextRun = metav1.NewTime(nextRunTime)
 		}
 		if nextRunTime.Before(now) {


### PR DESCRIPTION
I ran into an issue where we had a scheduled job that we wanted to test a little earlier than the `nextRun`, so we applied changes with a modified schedule.  (e.g. `0 6 * * *` to `10 4 * * *` / 06:00 to 04:10 scheduled execution time) 

However, I observed at 04:30 that the scheduled spark application did not run and went to investigate why.  The next run was still set at `06:00`.  The only way I could get this issue rectified at the time was to delete and recreate the ScheduledSparkApplication. `replace` / `apply` operations did not affect the `nextRun` time at all from my experiments. 

Based off [this](https://kubernetes.slack.com/archives/CALBDHMTL/p1585877089005500?thread_ts=1585845895.005300&cid=CALBDHMTL), my understanding was that the next run is only set after each run, which would've explained why our schedule modification did not take effect. 

This PR introduces a change where we check whether the `nextRunTime` due to an updated schedule is before the original `nextRunTime`. If the recalculated `nextRunTime` is before the original `nextRunTime`, the recalculated `nextRunTime` is chosen as the next scheduled spark application run, which is more consistent with the behaviour of the `apps/v1/CronJob` Kubernetes primitive.  I added a test to ensure that this is the expected behaviour if the schedule is updated by an operator similar to the fashion I described above. 