### PR TITLE
Re-enable scheduled app unit test (TestSyncScheduledSparkApplication_Forbid)

### DIFF
--- a/pkg/controller/scheduledsparkapplication/controller.go
+++ b/pkg/controller/scheduledsparkapplication/controller.go
@@ -249,7 +249,7 @@ func (c *Controller) createSparkApplication(
 		Name:       scheduledApp.Name,
 		UID:        scheduledApp.UID,
 	})
-	app.ObjectMeta.Namespace = scheduleApp.Namespace
+	app.ObjectMeta.Namespace = scheduledApp.Namespace
 	app.ObjectMeta.Labels = make(map[string]string)
 	for key, value := range scheduledApp.Labels {
 		app.ObjectMeta.Labels[key] = value

--- a/pkg/controller/scheduledsparkapplication/controller.go
+++ b/pkg/controller/scheduledsparkapplication/controller.go
@@ -249,6 +249,7 @@ func (c *Controller) createSparkApplication(
 		Name:       scheduledApp.Name,
 		UID:        scheduledApp.UID,
 	})
+	app.ObjectMeta.Namespace = scheduleApp.Namespace
 	app.ObjectMeta.Labels = make(map[string]string)
 	for key, value := range scheduledApp.Labels {
 		app.ObjectMeta.Labels[key] = value

--- a/pkg/controller/scheduledsparkapplication/controller_test.go
+++ b/pkg/controller/scheduledsparkapplication/controller_test.go
@@ -176,9 +176,6 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 }
 
 func TestSyncScheduledSparkApplication_Forbid(t *testing.T) {
-	// TODO: figure out why the test fails and remove this.
-	t.Skip()
-
 	app := &v1beta2.ScheduledSparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",


### PR DESCRIPTION
Apparently if we don't explicitly set the namespace of the sparkApp, it will be "" and thus causing the unit test to fail.