### PR TITLE
update code to fix error on termination time when using sidecar

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -309,6 +309,18 @@ type ApplicationState struct {
 	ErrorMessage string               `json:"errorMessage,omitempty"`
 }
 
+// DriverState tells the current state of a spark driver.
+type DriverState string
+
+// Different states a spark driver may have.
+const (
+	DriverPendingState   DriverState = "PENDING"
+	DriverRunningState   DriverState = "RUNNING"
+	DriverCompletedState DriverState = "COMPLETED"
+	DriverFailedState    DriverState = "FAILED"
+	DriverUnknownState   DriverState = "UNKNOWN"
+)
+
 // ExecutorState tells the current state of an executor.
 type ExecutorState string
 

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -324,16 +324,17 @@ func (c *Controller) getAndUpdateDriverState(app *v1beta2.SparkApplication) erro
 	}
 
 	app.Status.SparkApplicationID = getSparkApplicationID(driverPod)
+	driverState := podStatusToDriverState(driverPod.Status)
 
-	if driverPod.Status.Phase == apiv1.PodSucceeded || driverPod.Status.Phase == apiv1.PodFailed {
+	if isDriverTerminated(driverState) {
 		if app.Status.TerminationTime.IsZero() {
 			app.Status.TerminationTime = metav1.Now()
 		}
-		if driverPod.Status.Phase == apiv1.PodFailed {
-			if len(driverPod.Status.ContainerStatuses) > 0 {
-				terminatedState := driverPod.Status.ContainerStatuses[0].State.Terminated
-				if terminatedState != nil {
-					app.Status.AppState.ErrorMessage = fmt.Sprintf("driver pod failed with ExitCode: %d, Reason: %s", terminatedState.ExitCode, terminatedState.Reason)
+		if driverState == v1beta2.DriverFailedState {
+			state := getDriverContainerTerminatedState(driverPod.Status)
+			if state != nil {
+				if state.ExitCode != 0 {
+					app.Status.AppState.ErrorMessage = fmt.Sprintf("driver container failed with ExitCode: %d, Reason: %s", state.ExitCode, state.Reason)
 				}
 			} else {
 				app.Status.AppState.ErrorMessage = "driver container status missing"
@@ -341,12 +342,12 @@ func (c *Controller) getAndUpdateDriverState(app *v1beta2.SparkApplication) erro
 		}
 	}
 
-	newState := driverStateToApplicationState(driverPod.Status)
+	newState := driverStateToApplicationState(driverState)
 	// Only record a driver event if the application state (derived from the driver pod phase) has changed.
 	if newState != app.Status.AppState.State {
-		c.recordDriverEvent(app, driverPod.Status.Phase, driverPod.Name)
+		c.recordDriverEvent(app, driverState, driverPod.Name)
+		app.Status.AppState.State = newState
 	}
-	app.Status.AppState.State = newState
 
 	return nil
 }
@@ -937,17 +938,17 @@ func (c *Controller) recordSparkApplicationEvent(app *v1beta2.SparkApplication) 
 	}
 }
 
-func (c *Controller) recordDriverEvent(app *v1beta2.SparkApplication, phase apiv1.PodPhase, name string) {
+func (c *Controller) recordDriverEvent(app *v1beta2.SparkApplication, phase v1beta2.DriverState, name string) {
 	switch phase {
-	case apiv1.PodSucceeded:
+	case v1beta2.DriverCompletedState:
 		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkDriverCompleted", "Driver %s completed", name)
-	case apiv1.PodPending:
+	case v1beta2.DriverPendingState:
 		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkDriverPending", "Driver %s is pending", name)
-	case apiv1.PodRunning:
+	case v1beta2.DriverRunningState:
 		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkDriverRunning", "Driver %s is running", name)
-	case apiv1.PodFailed:
+	case v1beta2.DriverFailedState:
 		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkDriverFailed", "Driver %s failed", name)
-	case apiv1.PodUnknown:
+	case v1beta2.DriverUnknownState:
 		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkDriverUnknownState", "Driver %s in unknown state", name)
 	}
 }

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -326,7 +326,7 @@ func (c *Controller) getAndUpdateDriverState(app *v1beta2.SparkApplication) erro
 	app.Status.SparkApplicationID = getSparkApplicationID(driverPod)
 	driverState := podStatusToDriverState(driverPod.Status)
 
-	if isDriverTerminated(driverState) {
+	if hasDriverTerminated(driverState) {
 		if app.Status.TerminationTime.IsZero() {
 			app.Status.TerminationTime = metav1.Now()
 		}

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -1033,9 +1033,180 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 					ResourceVersion: "1",
 				},
 				Status: apiv1.PodStatus{
+					Phase: apiv1.PodRunning,
+					ContainerStatuses: []apiv1.ContainerStatus{
+						{
+							Name: config.SparkDriverContainerName,
+							State: apiv1.ContainerState{
+								Running: &apiv1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name: "sidecar",
+							State: apiv1.ContainerState{
+								Terminated: &apiv1.ContainerStateTerminated{
+									ExitCode: 0,
+								},
+							},
+						},
+					},
+				},
+			},
+			executorPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exec-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkExecutorRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodSucceeded,
+				},
+			},
+			expectedAppState:      v1beta2.RunningState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorCompletedState},
+			expectedAppMetrics:    metrics{},
+			expectedExecutorMetrics: executorMetrics{
+				successMetricCount: 1,
+			},
+		},
+		{
+			appName:           appName,
+			oldAppStatus:      v1beta2.RunningState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodRunning,
+					ContainerStatuses: []apiv1.ContainerStatus{
+						{
+							Name: config.SparkDriverContainerName,
+							State: apiv1.ContainerState{
+								Terminated: &apiv1.ContainerStateTerminated{
+									ExitCode: 0,
+								},
+							},
+						},
+						{
+							Name: "sidecar",
+							State: apiv1.ContainerState{
+								Running: &apiv1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+			executorPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exec-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkExecutorRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodSucceeded,
+				},
+			},
+			expectedAppState:      v1beta2.SucceedingState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorCompletedState},
+			expectedAppMetrics: metrics{
+				successMetricCount: 1,
+			},
+			expectedExecutorMetrics: executorMetrics{
+				successMetricCount: 1,
+			},
+		},
+		{
+			appName:           appName,
+			oldAppStatus:      v1beta2.RunningState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodRunning,
+					ContainerStatuses: []apiv1.ContainerStatus{
+						{
+							Name: config.SparkDriverContainerName,
+							State: apiv1.ContainerState{
+								Terminated: &apiv1.ContainerStateTerminated{
+									ExitCode: 137,
+									Reason:   "OOMKilled",
+								},
+							},
+						},
+						{
+							Name: "sidecar",
+							State: apiv1.ContainerState{
+								Running: &apiv1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+			executorPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exec-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkExecutorRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodSucceeded,
+				},
+			},
+			expectedAppState:      v1beta2.FailingState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorCompletedState},
+			expectedAppMetrics: metrics{
+				failedMetricCount: 1,
+			},
+			expectedExecutorMetrics: executorMetrics{
+				successMetricCount: 1,
+			},
+		},
+		{
+			appName:           appName,
+			oldAppStatus:      v1beta2.RunningState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
 					Phase: apiv1.PodFailed,
 					ContainerStatuses: []apiv1.ContainerStatus{
 						{
+							Name: config.SparkDriverContainerName,
 							State: apiv1.ContainerState{
 								Terminated: &apiv1.ContainerStateTerminated{
 									ExitCode: 137,
@@ -1067,6 +1238,66 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			},
 			expectedExecutorMetrics: executorMetrics{
 				failedMetricCount: 1,
+			},
+		},
+		{
+			appName:           appName,
+			oldAppStatus:      v1beta2.RunningState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodFailed,
+					ContainerStatuses: []apiv1.ContainerStatus{
+						{
+							Name: config.SparkDriverContainerName,
+							State: apiv1.ContainerState{
+								Terminated: &apiv1.ContainerStateTerminated{
+									ExitCode: 0,
+								},
+							},
+						},
+						{
+							Name: "sidecar",
+							State: apiv1.ContainerState{
+								Terminated: &apiv1.ContainerStateTerminated{
+									ExitCode: 137,
+									Reason:   "OOMKilled",
+								},
+							},
+						},
+					},
+				},
+			},
+			executorPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exec-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkExecutorRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodSucceeded,
+				},
+			},
+			expectedAppState:      v1beta2.SucceedingState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorCompletedState},
+			expectedAppMetrics: metrics{
+				successMetricCount: 1,
+			},
+			expectedExecutorMetrics: executorMetrics{
+				successMetricCount: 1,
 			},
 		},
 		{
@@ -1192,8 +1423,10 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 		// Validate error message if the driver pod failed.
 		if test.driverPod != nil && test.driverPod.Status.Phase == apiv1.PodFailed {
 			if len(test.driverPod.Status.ContainerStatuses) > 0 && test.driverPod.Status.ContainerStatuses[0].State.Terminated != nil {
-				assert.Equal(t, updatedApp.Status.AppState.ErrorMessage,
-					fmt.Sprintf("driver pod failed with ExitCode: %d, Reason: %s", test.driverPod.Status.ContainerStatuses[0].State.Terminated.ExitCode, test.driverPod.Status.ContainerStatuses[0].State.Terminated.Reason))
+				if test.driverPod.Status.ContainerStatuses[0].State.Terminated.ExitCode != 0 {
+					assert.Equal(t, updatedApp.Status.AppState.ErrorMessage,
+						fmt.Sprintf("driver container failed with ExitCode: %d, Reason: %s", test.driverPod.Status.ContainerStatuses[0].State.Terminated.ExitCode, test.driverPod.Status.ContainerStatuses[0].State.Terminated.Reason))
+				}
 			} else {
 				assert.Equal(t, updatedApp.Status.AppState.ErrorMessage, "driver container status missing")
 			}

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -133,7 +133,7 @@ func podStatusToDriverState(podStatus apiv1.PodStatus) v1beta2.DriverState {
 	}
 }
 
-func isDriverTerminated(driverState v1beta2.DriverState) bool {
+func hasDriverTerminated(driverState v1beta2.DriverState) bool {
 	return driverState == v1beta2.DriverCompletedState || driverState == v1beta2.DriverFailedState
 }
 

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -95,29 +95,58 @@ func isDriverRunning(app *v1beta2.SparkApplication) bool {
 	return app.Status.AppState.State == v1beta2.RunningState
 }
 
-func driverStateToApplicationState(podStatus apiv1.PodStatus) v1beta2.ApplicationStateType {
+func getDriverContainerTerminatedState(podStatus apiv1.PodStatus) *apiv1.ContainerStateTerminated {
+	for _, c := range podStatus.ContainerStatuses {
+		if c.Name == config.SparkDriverContainerName {
+			if c.State.Terminated != nil {
+				return c.State.Terminated
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func podStatusToDriverState(podStatus apiv1.PodStatus) v1beta2.DriverState {
 	switch podStatus.Phase {
 	case apiv1.PodPending:
-		return v1beta2.SubmittedState
+		return v1beta2.DriverPendingState
 	case apiv1.PodRunning:
-		// TODO: upcoming Kubernenetes feature will make this code redundant
-		// https://github.com/kubernetes/enhancements/issues/753
-		for _, c := range podStatus.ContainerStatuses {
-			if c.Name == config.SparkDriverContainerName {
-				if c.State.Terminated != nil {
-					if c.State.Terminated.ExitCode == 0 {
-						return v1beta2.SucceedingState
-					}
-					return v1beta2.FailingState
-				}
-				break
+		state := getDriverContainerTerminatedState(podStatus)
+		if state != nil {
+			if state.ExitCode == 0 {
+				return v1beta2.DriverCompletedState
 			}
+			return v1beta2.DriverFailedState
 		}
-		return v1beta2.RunningState
+		return v1beta2.DriverRunningState
 	case apiv1.PodSucceeded:
-		return v1beta2.SucceedingState
+		return v1beta2.DriverCompletedState
 	case apiv1.PodFailed:
+		state := getDriverContainerTerminatedState(podStatus)
+		if state != nil && state.ExitCode == 0 {
+			return v1beta2.DriverCompletedState
+		}
+		return v1beta2.DriverFailedState
+	default:
+		return v1beta2.DriverUnknownState
+	}
+}
+
+func isDriverTerminated(driverState v1beta2.DriverState) bool {
+	return driverState == v1beta2.DriverCompletedState || driverState == v1beta2.DriverFailedState
+}
+
+func driverStateToApplicationState(driverState v1beta2.DriverState) v1beta2.ApplicationStateType {
+	switch driverState {
+	case v1beta2.DriverPendingState:
+		return v1beta2.SubmittedState
+	case v1beta2.DriverCompletedState:
+		return v1beta2.SucceedingState
+	case v1beta2.DriverFailedState:
 		return v1beta2.FailingState
+	case v1beta2.DriverRunningState:
+		return v1beta2.RunningState
 	default:
 		return v1beta2.UnknownState
 	}


### PR DESCRIPTION
Hello,

This PR is related to issue #841 

Following the discussion on this issue, i've implemented `option 2`

Specifically, I've introduced a new State Machine specific to the Driver that allow finer grain detection of application end when using sidecar containers
This is also compatible with  kubernetes sidecar implementation on version 1.18

I've also updated the tests to cover sidecar cases

PS: for the review the commit are  scoped
bfacfe9 is logic only
dbd2f21 is to fix and update tests