### PR TITLE
update image and mainApplicationFile

### DIFF
--- a/examples/spark-pi-prometheus.yaml
+++ b/examples/spark-pi-prometheus.yaml
@@ -22,10 +22,10 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v2.4.5-gcs-prometheus"
+  image: "gcr.io/spark-operator/spark:v2.4.5-SNAPSHOT-gcs-prometheus"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar"
   arguments:
     - "100000"
   sparkVersion: "2.4.5"


### PR DESCRIPTION
there is no a suitable image with tag "**v2.4.5-gcs-prometheus**"  in the registry [gcr.io/spark-operator/spark](https://console.cloud.google.com/gcr/images/spark-operator/GLOBAL/spark) 
There is one suitable image with tag "**v2.4.5-SNAPSHOT-gcs-prometheus**". This image contains a jar file "/opt/spark/examples/jars/spark-examples_2.11-2.4.5-SNAPSHOT.jar" and the  file from yaml doesn't exist.

Set properly image and mainApplicationFile parameters.

Other solution might be change the image - tag name and jar file.