### PR TITLE
Fix maven repo URL

### DIFF
--- a/spark-docker/Dockerfile
+++ b/spark-docker/Dockerfile
@@ -19,7 +19,7 @@ FROM ${SPARK_IMAGE}
 
 # Setup dependencies for Google Cloud Storage access.
 RUN rm $SPARK_HOME/jars/guava-14.0.1.jar
-ADD http://central.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar $SPARK_HOME/jars
 # Add the connector jar needed to access Google Cloud Storage using the Hadoop FileSystem API.
 ADD https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar $SPARK_HOME/jars
 ADD https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-latest.jar $SPARK_HOME/jars


### PR DESCRIPTION
The current URL looks invalid:
```
Step 4/11 : ADD http://central.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar $SPARK_HOME/jars
ADD failed: failed to GET http://central.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar with status 503 Service Unavailable: <html><head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>ERROR: connection refused</title>
</head><body>
Failed to lookup host: central.maven.org
<br>
<p>Server is <a href="https://github.com/moby/vpnkit">moby/vpnkit</a></p>
</body>
</html>
```