### PR TITLE
Made field serviceAccount available for both driver and executors

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -911,19 +911,6 @@ Maps to <code>spark.kubernetes.driver.request.cores</code> that is available sin
 </tr>
 <tr>
 <td>
-<code>serviceAccount</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccount is the name of the Kubernetes service account used by the driver pod
-when requesting executor pods from the API server.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>javaOptions</code></br>
 <em>
 string
@@ -2548,6 +2535,18 @@ int64
 <p>Termination grace periond seconds for the pod</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>serviceAccount</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccount is the name of the custom Kubernetes service account used by the pod.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.SparkUIConfiguration">SparkUIConfiguration
@@ -2611,5 +2610,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>0e7e97d</code>.
+on git commit <code>43fb5e7</code>.
 </em></p>

--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -2838,6 +2838,8 @@ spec:
                               type: string
                           type: object
                       type: object
+                    serviceAccount:
+                      type: string
                     sidecars:
                       items:
                         properties:

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -2824,6 +2824,8 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccount:
+                  type: string
                 sidecars:
                   items:
                     properties:

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -480,6 +480,9 @@ type SparkPodSpec struct {
 	// Termination grace periond seconds for the pod
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+	// ServiceAccount is the name of the custom Kubernetes service account used by the pod.
+	// +optional
+	ServiceAccount *string `json:"serviceAccount,omitempty"`
 }
 
 // DriverSpec is specification of the driver.
@@ -496,10 +499,6 @@ type DriverSpec struct {
 	// Maps to `spark.kubernetes.driver.request.cores` that is available since Spark 3.0.
 	// +optional
 	CoreRequest *string `json:"coreRequest,omitempty"`
-	// ServiceAccount is the name of the Kubernetes service account used by the driver pod
-	// when requesting executor pods from the API server.
-	// +optional
-	ServiceAccount *string `json:"serviceAccount,omitempty"`
 	// JavaOptions is a string of extra JVM options to pass to the driver. For instance,
 	// GC settings or other logging.
 	// +optional

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -321,7 +321,7 @@ func TestCreateSparkUIIngress(t *testing.T) {
 					"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
 				},
 				IngressTLS: []extensions.IngressTLS{
-					{[]string{"host1", "host2"}, "secret"},
+					{Hosts: []string{"host1", "host2"}, SecretName: "secret"},
 				},
 			},
 		},
@@ -345,7 +345,7 @@ func TestCreateSparkUIIngress(t *testing.T) {
 					"kubernetes.io/ingress.class": "nginx",
 				},
 				IngressTLS: []extensions.IngressTLS{
-					{[]string{"host1", "host2"}, ""},
+					{Hosts: []string{"host1", "host2"}, SecretName: ""},
 				},
 			},
 		},
@@ -390,7 +390,7 @@ func TestCreateSparkUIIngress(t *testing.T) {
 					"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
 				},
 				ingressTLS: []extensions.IngressTLS{
-					{[]string{"host1", "host2"}, "secret"},
+					{Hosts: []string{"host1", "host2"}, SecretName: "secret"},
 				},
 			},
 			expectError: false,
@@ -406,7 +406,7 @@ func TestCreateSparkUIIngress(t *testing.T) {
 					"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
 				},
 				ingressTLS: []extensions.IngressTLS{
-					{[]string{"host1", "host2"}, ""},
+					{Hosts: []string{"host1", "host2"}, SecretName: ""},
 				},
 			},
 			expectError: true,


### PR DESCRIPTION
Spark 3.0 will support specifying a k8s service account for the executor pods. This CL prepares the operator to support that in the upcoming Spark 3.0.0 release.