### PR TITLE
Add Data Mechanics to who is using

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -20,3 +20,4 @@
 | Cyren | @avnerl | Evaluation | Data pipelines
 | Shell (Agile Hub) | @TomLous | Production | Data pipelines
 | Nielsen Identity Engine | @roitvt | Evaluation | Data pipelines
+| [Data Mechanics](https://www.datamechanics.co)  | @jrj-d | Production | Managed Spark Platform |


### PR DESCRIPTION
Hey there,
We are [Data Mechanics](https://www.datamechanics.co/), a managed Spark platform deployed on Kubernetes.
We use the spark-operator in the background; congrats for the great work by the way!
We have already made small contributions to the project (see #867) and hope to do more!
Cheers, Julien