### PR TITLE
Fixed issue (#934)

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -270,6 +270,9 @@ rules:
 // DefaultPrometheusJavaAgentPort is the default port used by the Prometheus JMX exporter.
 const DefaultPrometheusJavaAgentPort int32 = 8090
 
+// DefaultPrometheusPortProtocol is the default protocol used by the Prometheus JMX exporter.
+const DefaultPrometheusPortProtocol string = "TCP"
+
 const (
 	// SparkDriverContainerName is name of driver container in spark driver pod
 	SparkDriverContainerName = "spark-kubernetes-driver"


### PR DESCRIPTION
The issue is related to [#934](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/934). It allows to properly exposing the prometheus exporter to a SeriveMonitor or to Prometheus to scrape metrics. Up to now, we can only see the metrics generated locally but not exposed outside the pod running the JMX exporter.