### PR TITLE
(#929) support filtering events by namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 	resyncInterval                 = flag.Int("resync-interval", 30, "Informer resync interval in seconds.")
 	namespace                      = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
 	namespaceFilter                = flag.String("namespace-filter", "", "A comma-separated list of regexps to manage specific Kubernetes namespaces. Ignored if namespace if specified")
+	labelsFilter                   = flag.String("labels-filter", "", "A comma-separated list of key=value labels to filter events during Watch and List.")
 	enableWebhook                  = flag.Bool("enable-webhook", false, "Whether to enable the mutating admission webhook for admitting and patching Spark pods.")
 	enableResourceQuotaEnforcement = flag.Bool("enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
 	ingressURLFormat               = flag.String("ingress-url-format", "", "Ingress URL format.")
@@ -163,7 +164,7 @@ func main() {
 	crInformerFactory := buildCustomResourceInformerFactory(crClient)
 	podInformerFactory := buildPodInformerFactory(kubeClient)
 
-	var namespaceFilterConfig = util.NamespaceFilterConfig{
+	var namespaceConfig = &util.NamespaceConfig{
 		Namespace:       *namespace,
 		NamespaceFilter: *namespaceFilter,
 	}
@@ -183,7 +184,7 @@ func main() {
 	}
 
 	applicationController := sparkapplication.NewController(
-		crClient, kubeClient, crInformerFactory, podInformerFactory, metricConfig, *namespace, &namespaceFilterConfig, *ingressURLFormat, batchSchedulerMgr)
+		crClient, kubeClient, crInformerFactory, podInformerFactory, metricConfig, namespaceConfig, *ingressURLFormat, batchSchedulerMgr)
 	scheduledApplicationController := scheduledsparkapplication.NewController(
 		crClient, kubeClient, apiExtensionsClient, crInformerFactory, clock.RealClock{})
 
@@ -199,7 +200,7 @@ func main() {
 		}
 		var err error
 		// Don't deregister webhook on exit if leader election enabled (i.e. multiple webhooks running)
-		hook, err = webhook.New(kubeClient, crInformerFactory, *namespace, !*enableLeaderElection, *enableResourceQuotaEnforcement, coreV1InformerFactory)
+		hook, err = webhook.New(kubeClient, crInformerFactory, namespaceConfig.Namespace, !*enableLeaderElection, *enableResourceQuotaEnforcement, coreV1InformerFactory)
 		if err != nil {
 			glog.Fatal(err)
 		}
@@ -257,6 +258,12 @@ func buildCustomResourceInformerFactory(crClient crclientset.Interface) crinform
 	if *namespace != apiv1.NamespaceAll {
 		factoryOpts = append(factoryOpts, crinformers.WithNamespace(*namespace))
 	}
+	if len(*labelsFilter) > 0 {
+		tweakListOptionsFunc := func(options *metav1.ListOptions) {
+			options.LabelSelector = *labelsFilter
+		}
+		factoryOpts = append(factoryOpts, crinformers.WithTweakListOptions(tweakListOptionsFunc))
+	}
 	return crinformers.NewSharedInformerFactoryWithOptions(
 		crClient,
 		// resyncPeriod. Every resyncPeriod, all resources in the cache will re-trigger events.
@@ -271,6 +278,9 @@ func buildPodInformerFactory(kubeClient clientset.Interface) informers.SharedInf
 	}
 	tweakListOptionsFunc := func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s,%s", operatorConfig.SparkRoleLabel, operatorConfig.LaunchedBySparkOperatorLabel)
+		if len(*labelsFilter) > 0 {
+			options.LabelSelector = options.LabelSelector + *labelsFilter
+		}
 	}
 	podFactoryOpts = append(podFactoryOpts, informers.WithTweakListOptions(tweakListOptionsFunc))
 	return informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Duration(*resyncInterval)*time.Second, podFactoryOpts...)

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -1522,7 +1522,7 @@ func TestFilterSparkEventsByNamespace(t *testing.T) {
 	type testcase struct {
 		name                  string
 		app                   *v1beta2.SparkApplication
-		namespaceFilterConfig *util.NamespaceFilterConfig
+		namespaceFilterConfig *util.NamespaceConfig
 		expectedFilterReturn  bool
 	}
 
@@ -1553,7 +1553,7 @@ func TestFilterSparkEventsByNamespace(t *testing.T) {
 		{
 			name: "Filter with a wildcard does match",
 			app:  app1,
-			namespaceFilterConfig: &util.NamespaceFilterConfig{
+			namespaceFilterConfig: &util.NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: ".*-dev",
 			},
@@ -1562,7 +1562,7 @@ func TestFilterSparkEventsByNamespace(t *testing.T) {
 		{
 			name: "Filter does not match: Extra character",
 			app:  app1,
-			namespaceFilterConfig: &util.NamespaceFilterConfig{
+			namespaceFilterConfig: &util.NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: ".*-deva",
 			},
@@ -1571,7 +1571,7 @@ func TestFilterSparkEventsByNamespace(t *testing.T) {
 		{
 			name: "Filter with digits does match",
 			app:  app2,
-			namespaceFilterConfig: &util.NamespaceFilterConfig{
+			namespaceFilterConfig: &util.NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "staging-[1-9].+",
 			},
@@ -1580,7 +1580,7 @@ func TestFilterSparkEventsByNamespace(t *testing.T) {
 		{
 			name: "Filter does not match: Only 3 digits are allowed",
 			app:  app2,
-			namespaceFilterConfig: &util.NamespaceFilterConfig{
+			namespaceFilterConfig: &util.NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "staging-[1-9]{3}",
 			},

--- a/pkg/util/namespace_filter.go
+++ b/pkg/util/namespace_filter.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 )
 
-type NamespaceFilterConfig struct {
+type NamespaceConfig struct {
 	Namespace       string
 	NamespaceFilter string
 }
 
-func isNamespaceFilterEnabled(namespaceFilterConfig *NamespaceFilterConfig) bool {
+func isNamespaceFilterEnabled(namespaceFilterConfig *NamespaceConfig) bool {
 	if namespaceFilterConfig == nil {
 		glog.Info("No filter on namespaces is applied")
 		return false
@@ -48,7 +48,7 @@ func isNamespaceFilterEnabled(namespaceFilterConfig *NamespaceFilterConfig) bool
 	return false
 }
 
-func GetNamespaceFilter(namespaceFilterConfig *NamespaceFilterConfig) *regexp.Regexp {
+func GetNamespaceFilter(namespaceFilterConfig *NamespaceConfig) *regexp.Regexp {
 	if isNamespaceFilterEnabled(namespaceFilterConfig) == false {
 		return nil
 	}

--- a/pkg/util/namespace_filter.go
+++ b/pkg/util/namespace_filter.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/golang/glog"
+	apiv1 "k8s.io/api/core/v1"
+	"regexp"
+	"strings"
+)
+
+type NamespaceFilterConfig struct {
+	Namespace       string
+	NamespaceFilter string
+}
+
+func isNamespaceFilterEnabled(namespaceFilterConfig *NamespaceFilterConfig) bool {
+	if namespaceFilterConfig == nil {
+		glog.Info("No filter on namespaces is applied")
+		return false
+	}
+	if len(namespaceFilterConfig.Namespace) > 0 {
+		glog.Info("A namespace is specified. namespace-filter will be ignored even if it is specified")
+		return false
+	}
+	if len(namespaceFilterConfig.NamespaceFilter) == 0 && namespaceFilterConfig.Namespace == apiv1.NamespaceAll {
+		glog.Info("Namespace filter is empty. No filter on namespaces is applied")
+		return false
+	}
+	if len(namespaceFilterConfig.NamespaceFilter) > 0 && namespaceFilterConfig.Namespace == apiv1.NamespaceAll {
+		glog.Info("Namespace filter will be applied")
+		return true
+	}
+	return false
+}
+
+func GetNamespaceFilter(namespaceFilterConfig *NamespaceFilterConfig) *regexp.Regexp {
+	if isNamespaceFilterEnabled(namespaceFilterConfig) == false {
+		return nil
+	}
+
+	var returnFilter = namespaceFilterConfig.NamespaceFilter
+	lastChar := returnFilter[len(returnFilter)-1]
+	for ok := true; ok; ok = string(lastChar) == "," {
+		returnFilter = strings.TrimSuffix(returnFilter, ",")
+		lastChar = returnFilter[len(returnFilter)-1]
+	}
+	re := regexp.MustCompile(",+")
+	returnFilter = re.ReplaceAllString(returnFilter, "\\b|")
+	returnFilter = returnFilter + "\\b"
+
+	return regexp.MustCompile(returnFilter)
+}
+
+func IsNamespaceMatchesFilter(regex regexp.Regexp, namespace string) bool {
+	return regex.MatchString(namespace)
+}

--- a/pkg/util/namespace_filter_test.go
+++ b/pkg/util/namespace_filter_test.go
@@ -28,12 +28,12 @@ func TestGetNamespaceFilter(t *testing.T) {
 
 	tests := []struct {
 		name                  string
-		namespaceFilterConfig NamespaceFilterConfig
+		namespaceFilterConfig NamespaceConfig
 		want                  *regexp.Regexp
 	}{
 		{
 			name: "Should replace comma by pipe",
-			namespaceFilterConfig: NamespaceFilterConfig{
+			namespaceFilterConfig: NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: ".*-dev,.*-testing",
 			},
@@ -41,7 +41,7 @@ func TestGetNamespaceFilter(t *testing.T) {
 		},
 		{
 			name: "Should add zero-length word boundry sequence",
-			namespaceFilterConfig: NamespaceFilterConfig{
+			namespaceFilterConfig: NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "dev-*",
 			},
@@ -49,7 +49,7 @@ func TestGetNamespaceFilter(t *testing.T) {
 		},
 		{
 			name: "Filter with multiple commas",
-			namespaceFilterConfig: NamespaceFilterConfig{
+			namespaceFilterConfig: NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "^*-dev,,,^*-testing,",
 			},
@@ -57,7 +57,7 @@ func TestGetNamespaceFilter(t *testing.T) {
 		},
 		{
 			name: "Should use a wildcard as a regex",
-			namespaceFilterConfig: NamespaceFilterConfig{
+			namespaceFilterConfig: NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "",
 			},
@@ -113,12 +113,12 @@ func TestIsNamespaceFilterEnabled(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		namespaceFilterSpec NamespaceFilterConfig
+		namespaceFilterSpec NamespaceConfig
 		want                bool
 	}{
 		{
 			name: "namespace is sepcified should not apply filter",
-			namespaceFilterSpec: NamespaceFilterConfig{
+			namespaceFilterSpec: NamespaceConfig{
 				Namespace:       "test-prod",
 				NamespaceFilter: "\\*.-dev",
 			},
@@ -126,7 +126,7 @@ func TestIsNamespaceFilterEnabled(t *testing.T) {
 		},
 		{
 			name: "namespace is not sepcified and namespaceFilter is not empty: should apply the filter",
-			namespaceFilterSpec: NamespaceFilterConfig{
+			namespaceFilterSpec: NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "\\*.-dev",
 			},
@@ -134,7 +134,7 @@ func TestIsNamespaceFilterEnabled(t *testing.T) {
 		},
 		{
 			name: "namespaceFilter is empty should not apply filter",
-			namespaceFilterSpec: NamespaceFilterConfig{
+			namespaceFilterSpec: NamespaceConfig{
 				Namespace:       apiv1.NamespaceAll,
 				NamespaceFilter: "",
 			},

--- a/pkg/util/namespace_filter_test.go
+++ b/pkg/util/namespace_filter_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func TestGetNamespaceFilter(t *testing.T) {
+
+	tests := []struct {
+		name                  string
+		namespaceFilterConfig NamespaceFilterConfig
+		want                  *regexp.Regexp
+	}{
+		{
+			name: "Should replace comma by pipe",
+			namespaceFilterConfig: NamespaceFilterConfig{
+				Namespace:       apiv1.NamespaceAll,
+				NamespaceFilter: ".*-dev,.*-testing",
+			},
+			want: regexp.MustCompile(".*-dev\\b|.*-testing\\b"),
+		},
+		{
+			name: "Should add zero-length word boundry sequence",
+			namespaceFilterConfig: NamespaceFilterConfig{
+				Namespace:       apiv1.NamespaceAll,
+				NamespaceFilter: "dev-*",
+			},
+			want: regexp.MustCompile("dev-*\\b"),
+		},
+		{
+			name: "Filter with multiple commas",
+			namespaceFilterConfig: NamespaceFilterConfig{
+				Namespace:       apiv1.NamespaceAll,
+				NamespaceFilter: "^*-dev,,,^*-testing,",
+			},
+			want: regexp.MustCompile("^*-dev\\b|^*-testing\\b"),
+		},
+		{
+			name: "Should use a wildcard as a regex",
+			namespaceFilterConfig: NamespaceFilterConfig{
+				Namespace:       apiv1.NamespaceAll,
+				NamespaceFilter: "",
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetNamespaceFilter(&tt.namespaceFilterConfig); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getNamespaceFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNamespaceMatch(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		regex     *regexp.Regexp
+		namespace string
+		want      bool
+	}{
+		{
+			name:      "namespace matches filter",
+			regex:     regexp.MustCompile("^*.-dev\\b"),
+			namespace: "test1-dev",
+			want:      true,
+		},
+		{
+			name:      "namespace does not matche filter",
+			regex:     regexp.MustCompile("^*.-prod\\b"),
+			namespace: "test1-pro",
+			want:      false,
+		},
+		{
+			name:      "namespace should match one of the regex",
+			regex:     regexp.MustCompile("^*-dev\\b|^*-testing\\b|^*-staging\\b"),
+			namespace: "test1-testing",
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNamespaceMatchesFilter(*tt.regex, tt.namespace); got != tt.want {
+				t.Errorf("isNamespaceMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNamespaceFilterEnabled(t *testing.T) {
+
+	tests := []struct {
+		name                string
+		namespaceFilterSpec NamespaceFilterConfig
+		want                bool
+	}{
+		{
+			name: "namespace is sepcified should not apply filter",
+			namespaceFilterSpec: NamespaceFilterConfig{
+				Namespace:       "test-prod",
+				NamespaceFilter: "\\*.-dev",
+			},
+			want: false,
+		},
+		{
+			name: "namespace is not sepcified and namespaceFilter is not empty: should apply the filter",
+			namespaceFilterSpec: NamespaceFilterConfig{
+				Namespace:       apiv1.NamespaceAll,
+				NamespaceFilter: "\\*.-dev",
+			},
+			want: true,
+		},
+		{
+			name: "namespaceFilter is empty should not apply filter",
+			namespaceFilterSpec: NamespaceFilterConfig{
+				Namespace:       apiv1.NamespaceAll,
+				NamespaceFilter: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNamespaceFilterEnabled(&tt.namespaceFilterSpec); got != tt.want {
+				t.Errorf("isNamsepaceShouldBeFiltered() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related to [#929](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/929).

In this PR we make it possible to users to specify on which namespace(s) the operator would run/manage spark applications. The k8s client, allows listing/watching either on one single namespace or all namespaces. Though, we use a `FilteringResourceEventHandler` handler to filter on a specific namespaces using compiled regexp supplied to the operator. This is similar to the behavior of `predicates` in `kubebuilder`. This fits well the requirement if we want to separate logically our kubernetes cluster assuming that it must run both `dev` and `uat` environments within the same cluster. Or, if we want to test different releases of the operator within the same cluster. Hence, running two instances of the same operator with different `namespace-filter` option becomes possible (i.e. one to cover *-uat and the other *-dev).

If the PR is fine, I can update the documentation as well and explains how we can have seperate instances of the operator running within the same cluster and make sure that the webhook1 of operator1 does not handle mutation of Pods handled by operator2.

If `namespace-filter` is not specified or `namespace` is specified, then we should have the same behavior as before.

