### PR TITLE
support filtering resources on custom labels

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ var (
 	controllerThreads              = flag.Int("controller-threads", 10, "Number of worker threads used by the SparkApplication controller.")
 	resyncInterval                 = flag.Int("resync-interval", 30, "Informer resync interval in seconds.")
 	namespace                      = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
+	labelSelectorFilter            = flag.String("label-selector-filter", "", "A comma-separated list of key=value, or key labels to filter resources during watch and list based on the specified labels.")
 	enableWebhook                  = flag.Bool("enable-webhook", false, "Whether to enable the mutating admission webhook for admitting and patching Spark pods.")
 	enableResourceQuotaEnforcement = flag.Bool("enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
 	ingressURLFormat               = flag.String("ingress-url-format", "", "Ingress URL format.")
@@ -251,6 +252,12 @@ func buildCustomResourceInformerFactory(crClient crclientset.Interface) crinform
 	if *namespace != apiv1.NamespaceAll {
 		factoryOpts = append(factoryOpts, crinformers.WithNamespace(*namespace))
 	}
+	if len(*labelSelectorFilter) > 0 {
+		tweakListOptionsFunc := func(options *metav1.ListOptions) {
+			options.LabelSelector = *labelSelectorFilter
+		}
+		factoryOpts = append(factoryOpts, crinformers.WithTweakListOptions(tweakListOptionsFunc))
+	}
 	return crinformers.NewSharedInformerFactoryWithOptions(
 		crClient,
 		// resyncPeriod. Every resyncPeriod, all resources in the cache will re-trigger events.
@@ -265,6 +272,9 @@ func buildPodInformerFactory(kubeClient clientset.Interface) informers.SharedInf
 	}
 	tweakListOptionsFunc := func(options *metav1.ListOptions) {
 		options.LabelSelector = fmt.Sprintf("%s,%s", operatorConfig.SparkRoleLabel, operatorConfig.LaunchedBySparkOperatorLabel)
+		if len(*labelSelectorFilter) > 0 {
+			options.LabelSelector = options.LabelSelector + "," + *labelSelectorFilter
+		}
 	}
 	podFactoryOpts = append(podFactoryOpts, informers.WithTweakListOptions(tweakListOptionsFunc))
 	return informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Duration(*resyncInterval)*time.Second, podFactoryOpts...)
@@ -274,6 +284,12 @@ func buildCoreV1InformerFactory(kubeClient clientset.Interface) informers.Shared
 	var coreV1FactoryOpts []informers.SharedInformerOption
 	if *namespace != apiv1.NamespaceAll {
 		coreV1FactoryOpts = append(coreV1FactoryOpts, informers.WithNamespace(*namespace))
+	}
+	if len(*labelSelectorFilter) > 0 {
+		tweakListOptionsFunc := func(options *metav1.ListOptions) {
+			options.LabelSelector = *labelSelectorFilter
+		}
+		coreV1FactoryOpts = append(coreV1FactoryOpts, informers.WithTweakListOptions(tweakListOptionsFunc))
 	}
 	return informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Duration(*resyncInterval)*time.Second, coreV1FactoryOpts...)
 }


### PR DESCRIPTION
Related to [#929](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/929).

As discussed in a previous PR. This allows to define some custom labels on which the operator will list and watch resources. For instance, this is useful if we want to run multiple instances of the operator.