### PR TITLE
Higher spark-submit pod memory limit

### DIFF
--- a/pkg/controller/sparkapplication/job.go
+++ b/pkg/controller/sparkapplication/job.go
@@ -39,7 +39,7 @@ import (
 const (
 	sparkSubmitPodMemoryRequest = "100Mi"
 	sparkSubmitPodCpuRequest    = "100m"
-	sparkSubmitPodMemoryLimit   = "256Mi"
+	sparkSubmitPodMemoryLimit   = "512Mi"
 	sparkSubmitPodCpuLimit      = "250m"
 )
 


### PR DESCRIPTION
@liyinan926 - This is critical for the image I'm using.
Should we allow propagation of the driver resources limits to the submit job too?