### PR TITLE
Allow any tag not just annotated tags in gitlab builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,12 +17,12 @@ build:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY ;
     - >
       if [ "${SPARK_REGISTRY}" != "" -a "${SPARK_VERSION}" != "" ] ; then
-        tagStamp=$(git describe --dirty)_${SPARK_VERSION}
+        tagStamp=$(git describe --tags --dirty)_${SPARK_VERSION}
         echo Using SPARK_IMAGE ${SPARK_REGISTRY}:${SPARK_VERSION}
         echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
         docker build --build-arg SPARK_IMAGE=${SPARK_REGISTRY}:${SPARK_VERSION} -t ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp} .
       else
-        tagStamp=$(git describe --dirty) ; echo tagStamp is ${tagStamp} ;
+        tagStamp=$(git describe --tags --dirty) ; echo tagStamp is ${tagStamp} ;
         echo CI_REGISTRY_IMAGE_TAG is ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp}
         docker build -t ${CI_REGISTRY_IMAGE}/spark-operator:${tagStamp} .
       fi


### PR DESCRIPTION
Change the use of git describe to allow any tag including non-annotated
tags.