### PR TITLE
Update gencerts.sh

### DIFF
--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -98,6 +98,7 @@ distinguished_name = req_distinguished_name
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
+subjectAltName = DNS:${SERVICE}.${NAMESPACE}.svc
 EOF
 
 # Create a certificate authority.


### PR DESCRIPTION
Add subjectAltName in v3_req section for ssl certificate of sparkoperator webhook. Without this webhook is not called and we see following errors in api-server logs

`W0924 16:57:59.918135       1 dispatcher.go:170] Failed calling webhook, failing open webhook.sparkoperator.k8s.io: failed calling webhook "webhook.sparkoperator.k8s.io": Post "https://sparkoperator-webhook.sparkoperator.svc:443/webhook?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0`
