### PR TITLE
fixes typo in PodSecurityContext and SecurityContext in SparkPodSpec

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2609,7 +2609,7 @@ Kubernetes core/v1.Affinity
 </tr>
 <tr>
 <td>
-<code>securityContext</code></br>
+<code>podSecurityContext</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podsecuritycontext-v1-core">
 Kubernetes core/v1.PodSecurityContext
@@ -2618,7 +2618,21 @@ Kubernetes core/v1.PodSecurityContext
 </td>
 <td>
 <em>(Optional)</em>
-<p>SecurityContenxt specifies the PodSecurityContext to apply.</p>
+<p>PodSecurityContext specifies the PodSecurityContext to apply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext specifies the container&rsquo;s SecurityContext to apply.</p>
 </td>
 </tr>
 <tr>
@@ -2787,5 +2801,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>bc7bbd0</code>.
+on git commit <code>6e9e689</code>.
 </em></p>

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -467,12 +467,12 @@ type SparkPodSpec struct {
 	// Tolerations specifies the tolerations listed in ".spec.tolerations" to be applied to the pod.
 	// +optional
 	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"`
-	// PodSecurityContenxt specifies the PodSecurityContext to apply.
+	// PodSecurityContext specifies the PodSecurityContext to apply.
 	// +optional
-	PodSecurityContenxt *apiv1.PodSecurityContext `json:"podSecurityContext,omitempty"`
-	// SecurityContenxt specifies the container's SecurityContext to apply.
+	PodSecurityContext *apiv1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	// SecurityContext specifies the container's SecurityContext to apply.
 	// +optional
-	SecurityContenxt *apiv1.SecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *apiv1.SecurityContext `json:"securityContext,omitempty"`
 	// SchedulerName specifies the scheduler that will be used for scheduling
 	// +optional
 	SchedulerName *string `json:"schedulerName,omitempty"`

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -864,13 +864,13 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.PodSecurityContenxt != nil {
-		in, out := &in.PodSecurityContenxt, &out.PodSecurityContenxt
+	if in.PodSecurityContext != nil {
+		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SecurityContenxt != nil {
-		in, out := &in.SecurityContenxt, &out.SecurityContenxt
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -534,9 +534,9 @@ func addToleration(pod *corev1.Pod, toleration corev1.Toleration, first bool) pa
 func addPodSecurityContext(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOperation {
 	var secContext *corev1.PodSecurityContext
 	if util.IsDriverPod(pod) {
-		secContext = app.Spec.Driver.PodSecurityContenxt
+		secContext = app.Spec.Driver.PodSecurityContext
 	} else if util.IsExecutorPod(pod) {
-		secContext = app.Spec.Executor.PodSecurityContenxt
+		secContext = app.Spec.Executor.PodSecurityContext
 	}
 
 	if secContext == nil {
@@ -548,9 +548,9 @@ func addPodSecurityContext(pod *corev1.Pod, app *v1beta2.SparkApplication) *patc
 func addSecurityContext(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOperation {
 	var secContext *corev1.SecurityContext
 	if util.IsDriverPod(pod) {
-		secContext = app.Spec.Driver.SecurityContenxt
+		secContext = app.Spec.Driver.SecurityContext
 	} else if util.IsExecutorPod(pod) {
-		secContext = app.Spec.Executor.SecurityContenxt
+		secContext = app.Spec.Executor.SecurityContext
 	}
 
 	if secContext == nil {

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -624,10 +624,10 @@ func TestPatchSparkPod_SecurityContext(t *testing.T) {
 		Spec: v1beta2.SparkApplicationSpec{
 			Driver: v1beta2.DriverSpec{
 				SparkPodSpec: v1beta2.SparkPodSpec{
-					PodSecurityContenxt: &corev1.PodSecurityContext{
+					PodSecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &user,
 					},
-					SecurityContenxt: &corev1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &AllowPrivilegeEscalation,
 						RunAsUser:                &user2,
 					},
@@ -635,10 +635,10 @@ func TestPatchSparkPod_SecurityContext(t *testing.T) {
 			},
 			Executor: v1beta2.ExecutorSpec{
 				SparkPodSpec: v1beta2.SparkPodSpec{
-					PodSecurityContenxt: &corev1.PodSecurityContext{
+					PodSecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &user,
 					},
-					SecurityContenxt: &corev1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &AllowPrivilegeEscalation,
 						RunAsUser:                &user2,
 					},
@@ -669,8 +669,8 @@ func TestPatchSparkPod_SecurityContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, app.Spec.Driver.PodSecurityContenxt, modifiedDriverPod.Spec.SecurityContext)
-	assert.Equal(t, app.Spec.Driver.SecurityContenxt, modifiedDriverPod.Spec.Containers[0].SecurityContext)
+	assert.Equal(t, app.Spec.Driver.PodSecurityContext, modifiedDriverPod.Spec.SecurityContext)
+	assert.Equal(t, app.Spec.Driver.SecurityContext, modifiedDriverPod.Spec.Containers[0].SecurityContext)
 
 	executorPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -694,8 +694,8 @@ func TestPatchSparkPod_SecurityContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, app.Spec.Executor.PodSecurityContenxt, modifiedExecutorPod.Spec.SecurityContext)
-	assert.Equal(t, app.Spec.Executor.SecurityContenxt, modifiedExecutorPod.Spec.Containers[0].SecurityContext)
+	assert.Equal(t, app.Spec.Executor.PodSecurityContext, modifiedExecutorPod.Spec.SecurityContext)
+	assert.Equal(t, app.Spec.Executor.SecurityContext, modifiedExecutorPod.Spec.Containers[0].SecurityContext)
 }
 
 func TestPatchSparkPod_SchedulerName(t *testing.T) {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -153,7 +153,7 @@ func TestMutatePod(t *testing.T) {
 							Effect:   "NoEffect",
 						},
 					},
-					SecurityContenxt: &corev1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: &user,
 					},
 				},


### PR DESCRIPTION
This PR fixes typo in SparkPodSpec assuming that it's not intentional.

Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>