### PR TITLE
doc: Include Typeform as a K8s user

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -24,4 +24,5 @@
 | [PUBG](https://careers.pubg.com/#/en/) | @jacobhjkim | Production | ML & Data Infrastructure |
 | [Beeline](https://beeline.ru) | @spestua | Evaluation | ML & Data Infrastructure |
 | [Stitch Fix](https://multithreaded.stitchfix.com/) | @nssalian | Evaluation | Data pipelines |
+| [Typeform](https://typeform.com/) | @afranzi | Production | Data & ML pipelines |
 


### PR DESCRIPTION
This PR aims to include Typeform as a Spark Operator user - Article [Spark Structured Streaming in K8s](https://medium.com/albert-franzi/spark-structured-streaming-in-k8s-with-argo-cd-de4942846161).