### PR TITLE
Propagate Spark app's priorityClassName to pods' spec

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -719,7 +719,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>PriorityClassName stands for the name of k8s PriorityClass resource, it&rsquo;s being used in Volcano batch scheduler.</p>
+<p>PriorityClassName stands for the name of k8s PriorityClass resource, it&rsquo;s being used for job scheduling and 
+preemption, whether with the Volcano batch scheduler or the Kubernetes default scheduler.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -526,7 +526,7 @@ func addSchedulerName(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOper
 func addPriorityClassName(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOperation {
 	var priorityClassName *string
 
-	if app.Spec.BatchSchedulerOptions.PriorityClassName != nil {
+	if app.Spec.BatchSchedulerOptions != nil {
 		priorityClassName = app.Spec.BatchSchedulerOptions.PriorityClassName
 	}
 

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -68,6 +68,11 @@ func patchSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperat
 		patchOps = append(patchOps, *op)
 	}
 
+	op = addPriorityClassName(pod, app)
+	if op != nil {
+		patchOps = append(patchOps, *op)
+	}
+
 	if pod.Spec.Affinity == nil {
 		op := addAffinity(pod, app)
 		if op != nil {
@@ -516,6 +521,19 @@ func addSchedulerName(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOper
 		return nil
 	}
 	return &patchOperation{Op: "add", Path: "/spec/schedulerName", Value: *schedulerName}
+}
+
+func addPriorityClassName(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOperation {
+	var priorityClassName *string
+
+	if app.Spec.BatchSchedulerOptions.PriorityClassName != nil {
+		priorityClassName = app.Spec.BatchSchedulerOptions.PriorityClassName
+	}
+
+	if priorityClassName == nil || *priorityClassName == "" {
+		return nil
+	}
+	return &patchOperation{Op: "add", Path: "/spec/priorityClassName", Value: *priorityClassName}
 }
 
 func addToleration(pod *corev1.Pod, toleration corev1.Toleration, first bool) patchOperation {


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/821 .

Currently, the priority info is only at the `SparkApplication` resource level. This ensures the scheduling order while enqueueing the Spark applications but does not allow for job preemption, as the driver and executor pods all end up with the same priority (no priority actually - 0).

This PR is a straightforward solution: we simply propagate `spec.batchSchedulerOptions.priorityClassName`, if any, to `spec.priorityClassName` in the driver and executor pods (exactly as the priority is propagated to the `PodGroup` for Volcano).

I see no reason to implement it differently:
- The priority should apply to the Spark application as a whole, that means the driver and its executor pods
- As a consequence, the `SparkApplication` only must hold the priority info
- The user is still forbidden to specify a `priorityClassName` directly in the driver or executor spec. This prevents inconsistencies like an executor's priority which would be higher than that of its driver, etc.

Note also that the field `priorityClassName` is valid whether with Volcano or with the default Kubernetes scheduler, contrary to what is suggested in the doc. 

Hope this will help those who needed it.

**Subsidiary question**: I am not proficient with Helm. How can I build the chart to test it locally?