### PR TITLE
Default Logic: Add SparkConf check

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/defaults.go
@@ -43,32 +43,33 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 		}
 	}
 
-	setDriverSpecDefaults(app.Spec.Driver)
-	setExecutorSpecDefaults(app.Spec.Executor)
-}
+	setDriverSpecDefaults(&app.Spec.Driver, app.Spec.SparkConf)
+	setExecutorSpecDefaults(&app.Spec.Executor, app.Spec.SparkConf)}
 
-func setDriverSpecDefaults(spec DriverSpec) {
-	if spec.Cores == nil {
+
+func setDriverSpecDefaults(spec *DriverSpec, sparkConf map[string]string) {
+	if _, exists := sparkConf["spark.driver.cores"]; !exists && spec.Cores == nil  {
 		spec.Cores = new(float32)
 		*spec.Cores = 1
 	}
-	if spec.Memory == nil {
+	if _, exists := sparkConf["spark.driver.memory"]; !exists && spec.Memory == nil  {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
 }
 
-func setExecutorSpecDefaults(spec ExecutorSpec) {
-	if spec.Cores == nil {
+func setExecutorSpecDefaults(spec *ExecutorSpec, sparkConf map[string]string) {
+	if _, exists := sparkConf["spark.executor.cores"]; !exists && spec.Cores == nil  {
 		spec.Cores = new(float32)
 		*spec.Cores = 1
 	}
-	if spec.Memory == nil {
+	if _, exists := sparkConf["spark.executor.memory"]; !exists && spec.Memory == nil  {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
-	if spec.Instances == nil {
+	if _, exists := sparkConf["spark.executor.instances"]; !exists && spec.Instances == nil  {
 		spec.Instances = new(int32)
 		*spec.Instances = 1
 	}
 }
+

--- a/pkg/apis/sparkoperator.k8s.io/v1beta1/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta1/defaults.go
@@ -44,32 +44,31 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 	}
 
 	setDriverSpecDefaults(&app.Spec.Driver, app.Spec.SparkConf)
-	setExecutorSpecDefaults(&app.Spec.Executor, app.Spec.SparkConf)}
-
+	setExecutorSpecDefaults(&app.Spec.Executor, app.Spec.SparkConf)
+}
 
 func setDriverSpecDefaults(spec *DriverSpec, sparkConf map[string]string) {
-	if _, exists := sparkConf["spark.driver.cores"]; !exists && spec.Cores == nil  {
+	if _, exists := sparkConf["spark.driver.cores"]; !exists && spec.Cores == nil {
 		spec.Cores = new(float32)
 		*spec.Cores = 1
 	}
-	if _, exists := sparkConf["spark.driver.memory"]; !exists && spec.Memory == nil  {
+	if _, exists := sparkConf["spark.driver.memory"]; !exists && spec.Memory == nil {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
 }
 
 func setExecutorSpecDefaults(spec *ExecutorSpec, sparkConf map[string]string) {
-	if _, exists := sparkConf["spark.executor.cores"]; !exists && spec.Cores == nil  {
+	if _, exists := sparkConf["spark.executor.cores"]; !exists && spec.Cores == nil {
 		spec.Cores = new(float32)
 		*spec.Cores = 1
 	}
-	if _, exists := sparkConf["spark.executor.memory"]; !exists && spec.Memory == nil  {
+	if _, exists := sparkConf["spark.executor.memory"]; !exists && spec.Memory == nil {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
-	if _, exists := sparkConf["spark.executor.instances"]; !exists && spec.Instances == nil  {
+	if _, exists := sparkConf["spark.executor.instances"]; !exists && spec.Instances == nil {
 		spec.Instances = new(int32)
 		*spec.Instances = 1
 	}
 }
-

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
@@ -48,26 +48,27 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 }
 
 func setDriverSpecDefaults(spec *DriverSpec, sparkConf map[string]string) {
-	if _, exists := sparkConf["spark.driver.cores"]; !exists && spec.Cores == nil  {
+
+	if _, exists := sparkConf["spark.driver.cores"]; !exists && spec.Cores == nil {
 		spec.Cores = new(int32)
 		*spec.Cores = 1
 	}
-	if _, exists := sparkConf["spark.driver.memory"]; !exists && spec.Memory == nil  {
+	if _, exists := sparkConf["spark.driver.memory"]; !exists && spec.Memory == nil {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
 }
 
 func setExecutorSpecDefaults(spec *ExecutorSpec, sparkConf map[string]string) {
-	if _, exists := sparkConf["spark.executor.cores"]; !exists && spec.Cores == nil  {
+	if _, exists := sparkConf["spark.executor.cores"]; !exists && spec.Cores == nil {
 		spec.Cores = new(int32)
 		*spec.Cores = 1
 	}
-	if _, exists := sparkConf["spark.executor.memory"]; !exists && spec.Memory == nil  {
+	if _, exists := sparkConf["spark.executor.memory"]; !exists && spec.Memory == nil {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
-	if _, exists := sparkConf["spark.executor.instances"]; !exists && spec.Instances == nil  {
+	if _, exists := sparkConf["spark.executor.instances"]; !exists && spec.Instances == nil {
 		spec.Instances = new(int32)
 		*spec.Instances = 1
 	}

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
@@ -43,31 +43,31 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 		}
 	}
 
-	setDriverSpecDefaults(&app.Spec.Driver)
-	setExecutorSpecDefaults(&app.Spec.Executor)
+	setDriverSpecDefaults(&app.Spec.Driver, app.Spec.SparkConf)
+	setExecutorSpecDefaults(&app.Spec.Executor, app.Spec.SparkConf)
 }
 
-func setDriverSpecDefaults(spec *DriverSpec) {
-	if spec.Cores == nil {
+func setDriverSpecDefaults(spec *DriverSpec, sparkConf map[string]string) {
+	if _, exists := sparkConf["spark.driver.cores"]; !exists && spec.Cores == nil  {
 		spec.Cores = new(int32)
 		*spec.Cores = 1
 	}
-	if spec.Memory == nil {
+	if _, exists := sparkConf["spark.driver.memory"]; !exists && spec.Memory == nil  {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
 }
 
-func setExecutorSpecDefaults(spec *ExecutorSpec) {
-	if spec.Cores == nil {
+func setExecutorSpecDefaults(spec *ExecutorSpec, sparkConf map[string]string) {
+	if _, exists := sparkConf["spark.executor.cores"]; !exists && spec.Cores == nil  {
 		spec.Cores = new(int32)
 		*spec.Cores = 1
 	}
-	if spec.Memory == nil {
+	if _, exists := sparkConf["spark.executor.memory"]; !exists && spec.Memory == nil  {
 		spec.Memory = new(string)
 		*spec.Memory = "1g"
 	}
-	if spec.Instances == nil {
+	if _, exists := sparkConf["spark.executor.instances"]; !exists && spec.Instances == nil  {
 		spec.Instances = new(int32)
 		*spec.Instances = 1
 	}

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults_test.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults_test.go
@@ -121,6 +121,8 @@ func TestSetSparkApplicationDefaultsOnFailureRestartPolicyShouldSetDefaultValueF
 }
 
 func TestSetSparkApplicationDefaultslDriverSpecDefaults(t *testing.T) {
+
+	//Case1: Driver config not set.
 	app := &SparkApplication{
 		Spec: SparkApplicationSpec{},
 	}
@@ -138,9 +140,24 @@ func TestSetSparkApplicationDefaultslDriverSpecDefaults(t *testing.T) {
 	} else {
 		assert.Equal(t, "1g", *app.Spec.Driver.Memory)
 	}
+
+	//Case2: Driver config set via SparkConf.
+	app.Spec.SparkConf = map[string]string{
+		"spark.driver.memory":          "200M",
+		"spark.driver.cores":           "1",
+		"spark.executor.cores":         "2",
+		"spark.executor.instances":     "3",
+		"spark.executor.memory":        "500M",
+	}
+
+	SetSparkApplicationDefaults(app)
+
+	assert.Nil(t, app.Spec.Driver.Cores)
+	assert.Nil(t, app.Spec.Driver.Memory)
 }
 
 func TestSetSparkApplicationDefaultslExecutorSpecDefaults(t *testing.T) {
+	//Case1: Executor config not set.
 	app := &SparkApplication{
 		Spec: SparkApplicationSpec{},
 	}
@@ -164,4 +181,19 @@ func TestSetSparkApplicationDefaultslExecutorSpecDefaults(t *testing.T) {
 	} else {
 		assert.Equal(t, int32(1), *app.Spec.Executor.Instances)
 	}
+
+
+	//Case2: Executor config set via SparkConf.
+	app.Spec.SparkConf = map[string]string{
+		"spark.executor.cores":         "2",
+		"spark.executor.memory":        "500M",
+		"spark.executor.instances":     "3",
+	}
+
+	SetSparkApplicationDefaults(app)
+
+	assert.Nil(t, app.Spec.Executor.Cores)
+	assert.Nil(t, app.Spec.Executor.Memory)
+	assert.Nil(t, app.Spec.Executor.Instances)
+
 }

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults_test.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults_test.go
@@ -142,14 +142,14 @@ func TestSetSparkApplicationDefaultslDriverSpecDefaults(t *testing.T) {
 	}
 
 	//Case2: Driver config set via SparkConf.
-	app.Spec.SparkConf = map[string]string{
-		"spark.driver.memory":          "200M",
-		"spark.driver.cores":           "1",
-		"spark.executor.cores":         "2",
-		"spark.executor.instances":     "3",
-		"spark.executor.memory":        "500M",
+	app = &SparkApplication{
+		Spec: SparkApplicationSpec{
+			SparkConf: map[string]string{
+				"spark.driver.memory": "200M",
+				"spark.driver.cores":  "1",
+			},
+		},
 	}
-
 	SetSparkApplicationDefaults(app)
 
 	assert.Nil(t, app.Spec.Driver.Cores)
@@ -182,12 +182,15 @@ func TestSetSparkApplicationDefaultslExecutorSpecDefaults(t *testing.T) {
 		assert.Equal(t, int32(1), *app.Spec.Executor.Instances)
 	}
 
-
 	//Case2: Executor config set via SparkConf.
-	app.Spec.SparkConf = map[string]string{
-		"spark.executor.cores":         "2",
-		"spark.executor.memory":        "500M",
-		"spark.executor.instances":     "3",
+	app = &SparkApplication{
+		Spec: SparkApplicationSpec{
+			SparkConf: map[string]string{
+				"spark.executor.cores":     "2",
+				"spark.executor.memory":    "500M",
+				"spark.executor.instances": "3",
+			},
+		},
 	}
 
 	SetSparkApplicationDefaults(app)


### PR DESCRIPTION
Only default Driver/Executor resources if not set both in Driver/Executor Spec and in SparkConf.

Ref: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1055 for details 