### PR TITLE
Change certification CN to service domain

### DIFF
--- a/hack/gencerts.sh
+++ b/hack/gencerts.sh
@@ -105,7 +105,7 @@ EOF
 touch ${TMP_DIR}/.rnd
 export RANDFILE=${TMP_DIR}/.rnd
 openssl genrsa -out ${TMP_DIR}/ca-key.pem 2048
-openssl req -x509 -new -nodes -key ${TMP_DIR}/ca-key.pem -days 100000 -out ${TMP_DIR}/ca-cert.pem -subj "/CN=${SERVICE}_ca"
+openssl req -x509 -new -nodes -key ${TMP_DIR}/ca-key.pem -days 100000 -out ${TMP_DIR}/ca-cert.pem -subj "/CN=${SERVICE}.${NAMESPACE}.svc"
 
 # Create a server certificate.
 openssl genrsa -out ${TMP_DIR}/server-key.pem 2048


### PR DESCRIPTION
when enable webhook for mutating admission control, occurred x.509 error from k8s api server.

in k8s api server error log
```
E1111 03:13:43.508139       1 dispatcher.go:171] failed calling webhook "webhook.sparkoperator.k8s.io": Post "https://spark-operator-webhook.spark-operator.svc:443/webhook?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

in spark-operator error log
```
2020/11/10 11:05:56 http: TLS handshake error from xxx.xxx.xx.x:37154: remote error: tls: bad certificate
```

so, fixed `CN` from `${SERVICE}_ca` to operator service DNS name `${SERVICE}.${NAMESPACE}.svc`