### PR TITLE
Add incrmntal to who-is-using.md

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -25,4 +25,4 @@
 | [Beeline](https://beeline.ru) | @spestua | Evaluation | ML & Data Infrastructure |
 | [Stitch Fix](https://multithreaded.stitchfix.com/) | @nssalian | Evaluation | Data pipelines |
 | [Typeform](https://typeform.com/) | @afranzi | Production | Data & ML pipelines |
-
+| incrmntal(https://incrmntal.com/) | @scravy | Production | ML & Data Infrastructure | 


### PR DESCRIPTION
This adds incrmntal to the list of users of spark-on-k8s-operator. We are using the operator in production on EKS to operate spark without the needs for Hadoop and using cloud filesystems directly (using s3a output committer).

Best