### PR TITLE
Add GitHub Action to Release Chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
To use this chart as a Helm 3 dependancy the chart needs to be released.

This PR adds a GitHub Action to do the following:
* Check for changes in the chart
* Lint the chart
* Create a kind cluster to test if there are changes
* Creates a release in the gh_pages branch

NOTE: A `gh-pages` branch will need to be created and [GitHub Pages enabled](https://guides.github.com/features/pages/) for this to complete. 

In my [test repo](https://github.com/jgardner04/spark-on-k8s-operator/tree/gh-pages) I created and orphaned branch and just added an index.html. the GitHub Action will then publish the index.yaml and the release as seen on that branch.  