### PR TITLE
Apply total resource when BatchSchedulerOption is not nil

### DIFF
--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -77,11 +77,8 @@ func (v *VolcanoBatchScheduler) syncPodGroupInClientMode(app *v1beta2.SparkAppli
 	if _, ok := app.Spec.Executor.Annotations[v1beta1.KubeGroupNameAnnotationKey]; !ok {
 		totalResource := getExecutorRequestResource(app)
 
-		if app.Spec.BatchSchedulerOptions != nil {
-			requestResources := app.Spec.BatchSchedulerOptions.Resources
-			if len(requestResources) > 0 {
-				totalResource = requestResources
-			}
+		if app.Spec.BatchSchedulerOptions != nil && len(app.Spec.BatchSchedulerOptions.Resources) > 0 {
+			totalResource = app.Spec.BatchSchedulerOptions.Resources
 		}
 		if err := v.syncPodGroup(app, 1, totalResource); err == nil {
 			app.Spec.Executor.Annotations[v1beta1.KubeGroupNameAnnotationKey] = v.getAppPodGroupName(app)
@@ -99,11 +96,8 @@ func (v *VolcanoBatchScheduler) syncPodGroupInClusterMode(app *v1beta2.SparkAppl
 		//Both driver and executor resource will be considered.
 		totalResource := sumResourceList([]corev1.ResourceList{getExecutorRequestResource(app), getDriverRequestResource(app)})
 
-		if app.Spec.BatchSchedulerOptions != nil {
-			requestResources := app.Spec.BatchSchedulerOptions.Resources
-			if len(requestResources) > 0 {
-				totalResource = requestResources
-			}
+		if app.Spec.BatchSchedulerOptions != nil && len(app.Spec.BatchSchedulerOptions.Resources) > 0 {
+			totalResource = app.Spec.BatchSchedulerOptions.Resources
 		}
 		if err := v.syncPodGroup(app, 1, totalResource); err == nil {
 			app.Spec.Executor.Annotations[v1beta1.KubeGroupNameAnnotationKey] = v.getAppPodGroupName(app)

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -75,12 +75,13 @@ func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(app *v1beta2.Spark
 func (v *VolcanoBatchScheduler) syncPodGroupInClientMode(app *v1beta2.SparkApplication) error {
 	// We only care about the executor pods in client mode
 	if _, ok := app.Spec.Executor.Annotations[v1beta1.KubeGroupNameAnnotationKey]; !ok {
-		var totalResource corev1.ResourceList
-		requestResources := app.Spec.BatchSchedulerOptions.Resources
-		if len(requestResources) > 0 {
-			totalResource = requestResources
-		} else {
-			totalResource = getExecutorRequestResource(app)
+		totalResource := getExecutorRequestResource(app)
+
+		if app.Spec.BatchSchedulerOptions != nil {
+			requestResources := app.Spec.BatchSchedulerOptions.Resources
+			if len(requestResources) > 0 {
+				totalResource = requestResources
+			}
 		}
 		if err := v.syncPodGroup(app, 1, totalResource); err == nil {
 			app.Spec.Executor.Annotations[v1beta1.KubeGroupNameAnnotationKey] = v.getAppPodGroupName(app)
@@ -97,9 +98,12 @@ func (v *VolcanoBatchScheduler) syncPodGroupInClusterMode(app *v1beta2.SparkAppl
 	if _, ok := app.Spec.Driver.Annotations[v1beta1.KubeGroupNameAnnotationKey]; !ok {
 		//Both driver and executor resource will be considered.
 		totalResource := sumResourceList([]corev1.ResourceList{getExecutorRequestResource(app), getDriverRequestResource(app)})
-		requestResources := app.Spec.BatchSchedulerOptions.Resources
-		if len(requestResources) > 0 {
-			totalResource = requestResources
+
+		if app.Spec.BatchSchedulerOptions != nil {
+			requestResources := app.Spec.BatchSchedulerOptions.Resources
+			if len(requestResources) > 0 {
+				totalResource = requestResources
+			}
 		}
 		if err := v.syncPodGroup(app, 1, totalResource); err == nil {
 			app.Spec.Executor.Annotations[v1beta1.KubeGroupNameAnnotationKey] = v.getAppPodGroupName(app)


### PR DESCRIPTION
when `BatchSchedulerOption` is nil, requested resource make the operator pod to error state with error message
```
Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
```

The attributes could be nil because volcano batch scheduler accepts empty scheduler queue in `BatchSchedulerOptions`.