### PR TITLE
Update executor state after completed or failed app state

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -396,10 +396,10 @@ func (c *Controller) getAndUpdateExecutorState(app *v1beta2.SparkApplication) er
 	for name, oldStatus := range app.Status.ExecutorState {
 		_, exists := executorStateMap[name]
 		if !isExecutorTerminated(oldStatus) && !exists && !isDriverRunning(app) {
-			// If ApplicationState is SUCCEEDING, in other words, the driver pod has been completed
+			// If ApplicationState is COMPLETED, in other words, the driver pod has been completed
 			// successfully. The executor pods terminate and are cleaned up, so we could not found
 			// the executor pod, under this circumstances, we assume the executor pod are completed.
-			if app.Status.AppState.State == v1beta2.SucceedingState {
+			if app.Status.AppState.State == v1beta2.CompletedState {
 				app.Status.ExecutorState[name] = v1beta2.ExecutorCompletedState
 			} else {
 				glog.Infof("Executor pod %s not found, assuming it was deleted.", name)
@@ -585,6 +585,9 @@ func (c *Controller) syncSparkApplication(key string) error {
 				return err
 			}
 			return nil
+		}
+		if err := c.getAndUpdateExecutorState(appCopy); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -1394,6 +1394,31 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			expectedAppMetrics:      metrics{},
 			expectedExecutorMetrics: executorMetrics{},
 		},
+		{
+			appName:           appName,
+			oldAppStatus:      v1beta2.CompletedState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorPendingState},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodSucceeded,
+				},
+			},
+			expectedAppState:      v1beta2.CompletedState,
+			expectedExecutorState: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorCompletedState},
+			expectedAppMetrics:    metrics{},
+			expectedExecutorMetrics: executorMetrics{
+				successMetricCount: 1,
+			},
+		},
 	}
 
 	testFn := func(test testcase, t *testing.T) {


### PR DESCRIPTION
the states of executors never going to COMPLETED although the spark application was completed.
```sh
$ sparkctl status spark-pi-volcano -n spark-job
application state:
+-----------+----------------+----------------+-------------------------+------------------+--------------------+-------------------+
|   STATE   | SUBMISSION AGE | COMPLETION AGE |       DRIVER POD        |    DRIVER UI     | SUBMISSIONATTEMPTS | EXECUTIONATTEMPTS |
+-----------+----------------+----------------+-------------------------+------------------+--------------------+-------------------+
| COMPLETED | 25m            | 25m            | spark-pi-volcano-driver | xx.xx.x.xxx:4040 |                  1 |                 1 |
+-----------+----------------+----------------+-------------------------+------------------+--------------------+-------------------+
executor state:
+----------------------------------+---------+
|           EXECUTOR POD           |  STATE  |
+----------------------------------+---------+
| spark-pi-7d51c975ddd3c6b6-exec-1 | RUNNING |
+----------------------------------+---------+
```

current logic intends that executor pod state is changed to COMPLETED when the app state is SUCCEEDING.
but in SUCCEEDING, executor pods are not terminated, then this pods are read by `podLister`
then, need to update executor states when app is completed or failed state

After commit
```sh
$ sparkctl status spark-pi-volcano -n spark-job
application state:
+-----------+----------------+----------------+-------------------------+-------------------+--------------------+-------------------+
|   STATE   | SUBMISSION AGE | COMPLETION AGE |       DRIVER POD        |     DRIVER UI     | SUBMISSIONATTEMPTS | EXECUTIONATTEMPTS |
+-----------+----------------+----------------+-------------------------+-------------------+--------------------+-------------------+
| COMPLETED | 39m            | 38m            | spark-pi-volcano-driver | xx.xx.x.xxx:4040 |                  1 |                 1 |
+-----------+----------------+----------------+-------------------------+-------------------+--------------------+-------------------+
executor state:
+----------------------------------+-----------+
|           EXECUTOR POD           |   STATE   |
+----------------------------------+-----------+
| spark-pi-71479c75de46d00b-exec-1 | COMPLETED |
+----------------------------------+-----------+
```