### PR TITLE
Add scheduler func for clearing batch scheduling on completed

### DIFF
--- a/pkg/batchscheduler/interface/interface.go
+++ b/pkg/batchscheduler/interface/interface.go
@@ -25,4 +25,5 @@ type BatchScheduler interface {
 
 	ShouldSchedule(app *v1beta2.SparkApplication) bool
 	DoBatchSchedulingOnSubmission(app *v1beta2.SparkApplication) error
+	ClearBatchSchedulingOnCompleted(app *v1beta2.SparkApplication) error
 }

--- a/pkg/batchscheduler/interface/interface.go
+++ b/pkg/batchscheduler/interface/interface.go
@@ -25,5 +25,5 @@ type BatchScheduler interface {
 
 	ShouldSchedule(app *v1beta2.SparkApplication) bool
 	DoBatchSchedulingOnSubmission(app *v1beta2.SparkApplication) error
-	CleanupOnCompleted(app *v1beta2.SparkApplication) error
+	CleanupOnCompletion(app *v1beta2.SparkApplication) error
 }

--- a/pkg/batchscheduler/interface/interface.go
+++ b/pkg/batchscheduler/interface/interface.go
@@ -25,5 +25,5 @@ type BatchScheduler interface {
 
 	ShouldSchedule(app *v1beta2.SparkApplication) bool
 	DoBatchSchedulingOnSubmission(app *v1beta2.SparkApplication) error
-	ClearBatchSchedulingOnCompleted(app *v1beta2.SparkApplication) error
+	CleanupOnCompleted(app *v1beta2.SparkApplication) error
 }

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -160,6 +160,15 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 	return nil
 }
 
+func (v *VolcanoBatchScheduler) ClearBatchSchedulingOnCompleted(app *v1beta2.SparkApplication) error {
+	// remove pod group
+	podGroupName := v.getAppPodGroupName(app)
+	if err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Delete(podGroupName, &metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
 func New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {
 	vkClient, err := volcanoclient.NewForConfig(config)
 	if err != nil {

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -160,13 +160,10 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 	return nil
 }
 
-func (v *VolcanoBatchScheduler) ClearBatchSchedulingOnCompleted(app *v1beta2.SparkApplication) error {
-	// remove pod group
+func (v *VolcanoBatchScheduler) CleanupOnCompleted(app *v1beta2.SparkApplication) error {
 	podGroupName := v.getAppPodGroupName(app)
-	if err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Delete(podGroupName, &metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-	return nil
+	//Remove pod group for Spark Application
+	return v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Delete(podGroupName, &metav1.DeleteOptions{})
 }
 
 func New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -160,7 +160,7 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 	return nil
 }
 
-func (v *VolcanoBatchScheduler) CleanupOnCompleted(app *v1beta2.SparkApplication) error {
+func (v *VolcanoBatchScheduler) CleanupOnCompletion(app *v1beta2.SparkApplication) error {
 	podGroupName := v.getAppPodGroupName(app)
 	//Remove pod group for Spark Application
 	return v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Delete(podGroupName, &metav1.DeleteOptions{})

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -162,8 +162,11 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 
 func (v *VolcanoBatchScheduler) CleanupOnCompletion(app *v1beta2.SparkApplication) error {
 	podGroupName := v.getAppPodGroupName(app)
-	//Remove pod group for Spark Application
-	return v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Delete(podGroupName, &metav1.DeleteOptions{})
+	err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Delete(podGroupName, &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -1013,11 +1013,8 @@ func (c *Controller) hasApplicationExpired(app *v1beta2.SparkApplication) bool {
 // Clean up when the spark application is terminated.
 func (c *Controller) cleanUpOnTermination(oldApp, newApp *v1beta2.SparkApplication) error {
 	if needScheduling, scheduler := c.shouldDoBatchScheduling(newApp); needScheduling {
-		// batch schduler is cleaned up only when state is changed to completion state
-		if newApp.Status.AppState.State != oldApp.Status.AppState.State {
-			if err := scheduler.CleanupOnCompletion(newApp); err != nil {
-				return err
-			}
+		if err := scheduler.CleanupOnCompletion(newApp); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -1010,11 +1010,10 @@ func (c *Controller) hasApplicationExpired(app *v1beta2.SparkApplication) bool {
 	return false
 }
 
-// Clean up resources such as batch scheduler config if applicable.
+// Clean up when the spark application is terminated.
 func (c *Controller) cleanUpOnTermination(oldApp, newApp *v1beta2.SparkApplication) error {
 	if needScheduling, scheduler := c.shouldDoBatchScheduling(newApp); needScheduling {
-		// If new app state is completed or failed, no more app is running,
-		// and only once needs to clean up on completed or failed
+		// batch schduler is cleaned up only when state is changed to completion state
 		if newApp.Status.AppState.State != oldApp.Status.AppState.State {
 			if err := scheduler.CleanupOnCompletion(newApp); err != nil {
 				return err


### PR DESCRIPTION
Related to issue https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1062

The spark application injected with the volcano scheduler does not delete the pod group when the state of the spark application is changed to a completed or failed.
It can only be removed from the volcano queue by spark application deletion command or TTL timeout.
This will cause new pod groups to be scheduled to get stuck(pending) in the queue until spark application removed with ownerReference.
In my opinion, it would be better to remove the pod group when the spark application is changed to a completed or failed state.

