### PR TITLE
Fix crds to add defaults for k8s 1.18+

### DIFF
--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -793,6 +795,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -1575,6 +1578,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2590,6 +2594,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -3264,6 +3269,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -779,6 +781,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1561,6 +1564,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2576,6 +2580,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -3250,6 +3255,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -795,6 +795,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -1577,6 +1578,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2592,6 +2594,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -3266,6 +3269,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -781,6 +781,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1563,6 +1564,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2578,6 +2580,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -3252,6 +3255,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:


### PR DESCRIPTION
PR #1045 [1] appears to have accidentally reverted #986 [2] which added
defaults to the protocol field to work with versions of k8s 1.18+

This PR also draws on https://github.com/kudobuilder/operators/pull/297 [3]


[1] https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1045

[2] https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/986

[3] https://github.com/kudobuilder/operators/pull/297