### PR TITLE
Add prometheus containr port name

### DIFF
--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3614,6 +3614,8 @@ spec:
                           maximum: 49151
                           minimum: 1024
                           type: integer
+                        portName:
+                          type: string
                       required:
                       - jmxExporterJar
                       type: object

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3600,6 +3600,8 @@ spec:
                       maximum: 49151
                       minimum: 1024
                       type: integer
+                    portName:
+                      type: string
                   required:
                   - jmxExporterJar
                   type: object

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -642,6 +642,10 @@ type PrometheusSpec struct {
 	// +kubebuilder:validation:Maximum=49151
 	// +optional
 	Port *int32 `json:"port,omitempty"`
+	// PortName is the port name of prometheus JMX exporter port.
+	// If not specified, jmx-exporter will be used as the default.
+	// +optional
+	PortName *string `json:"portName,omitempty"`
 	// ConfigFile is the path to the custom Prometheus configuration file provided in the Spark image.
 	// ConfigFile takes precedence over Configuration, which is shown below.
 	// +optional

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -348,6 +348,11 @@ func (in *PrometheusSpec) DeepCopyInto(out *PrometheusSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PortName != nil {
+		in, out := &in.PortName, &out.PortName
+		*out = new(string)
+		**out = **in
+	}
 	if in.ConfigFile != nil {
 		in, out := &in.ConfigFile, &out.ConfigFile
 		*out = new(string)

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -296,6 +296,9 @@ const DefaultPrometheusJavaAgentPort int32 = 8090
 // DefaultPrometheusPortProtocol is the default protocol used by the Prometheus JMX exporter.
 const DefaultPrometheusPortProtocol string = "TCP"
 
+// DefaultPrometheusPortName is the default port name used by the Prometheus JMX exporter.
+const DefaultPrometheusPortName string = "jmx-exporter"
+
 const (
 	// SparkDriverContainerName is name of driver container in spark driver pod
 	SparkDriverContainerName = "spark-kubernetes-driver"

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -375,6 +375,11 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 		port = *app.Spec.Monitoring.Prometheus.Port
 	}
 	protocol := config.DefaultPrometheusPortProtocol
+	portName := config.DefaultPrometheusPortName
+	if app.Spec.Monitoring.Prometheus.PortName != nil {
+		portName = *app.Spec.Monitoring.Prometheus.PortName
+	}
+
 	patchOps = append(patchOps, addConfigMapVolume(pod, name, volumeName))
 	vmPatchOp := addConfigMapVolumeMount(pod, volumeName, mountPath)
 	if vmPatchOp == nil {
@@ -382,7 +387,7 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 		return nil
 	}
 	patchOps = append(patchOps, *vmPatchOp)
-	portPatchOp := addContainerPort(pod, port, protocol)
+	portPatchOp := addContainerPort(pod, port, protocol, portName)
 	if portPatchOp == nil {
 		glog.Warningf("could not expose port %d to scrape metrics outside the pod", port)
 		return nil
@@ -392,7 +397,7 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 	return patchOps
 }
 
-func addContainerPort(pod *corev1.Pod, port int32, protocol string) *patchOperation {
+func addContainerPort(pod *corev1.Pod, port int32, protocol string, portName string) *patchOperation {
 	i := findContainer(pod)
 	if i < 0 {
 		glog.Warningf("not able to add containerPort %d as Spark container was not found in pod %s", port, pod.Name)
@@ -401,7 +406,7 @@ func addContainerPort(pod *corev1.Pod, port int32, protocol string) *patchOperat
 
 	path := fmt.Sprintf("/spec/containers/%d/ports", i)
 	containerPort := corev1.ContainerPort{
-		Name:          "metrics",
+		Name:          portName,
 		ContainerPort: port,
 		Protocol:      corev1.Protocol(protocol),
 	}

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -401,6 +401,7 @@ func addContainerPort(pod *corev1.Pod, port int32, protocol string) *patchOperat
 
 	path := fmt.Sprintf("/spec/containers/%d/ports", i)
 	containerPort := corev1.ContainerPort{
+		Name:          "metrics",
 		ContainerPort: port,
 		Protocol:      corev1.Protocol(protocol),
 	}

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -499,6 +499,7 @@ func TestPatchSparkPod_HadoopConfigMap(t *testing.T) {
 
 func TestPatchSparkPod_PrometheusConfigMaps(t *testing.T) {
 	var appPort int32 = 9999
+	appPortName := "jmx-exporter"
 	app := &v1beta2.SparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "spark-test",
@@ -509,6 +510,7 @@ func TestPatchSparkPod_PrometheusConfigMaps(t *testing.T) {
 				Prometheus: &v1beta2.PrometheusSpec{
 					JmxExporterJar: "",
 					Port:           &appPort,
+					PortName:       &appPortName,
 					ConfigFile:     nil,
 					Configuration:  nil,
 				},
@@ -543,6 +545,7 @@ func TestPatchSparkPod_PrometheusConfigMaps(t *testing.T) {
 	expectedConfigMapName := config.GetPrometheusConfigMapName(app)
 	expectedVolumeName := expectedConfigMapName + "-vol"
 	expectedContainerPort := *app.Spec.Monitoring.Prometheus.Port
+	expectedContainerPortName := *app.Spec.Monitoring.Prometheus.PortName
 	assert.Equal(t, 1, len(modifiedPod.Spec.Volumes))
 	assert.Equal(t, expectedVolumeName, modifiedPod.Spec.Volumes[0].Name)
 	assert.True(t, modifiedPod.Spec.Volumes[0].ConfigMap != nil)
@@ -551,6 +554,7 @@ func TestPatchSparkPod_PrometheusConfigMaps(t *testing.T) {
 	assert.Equal(t, expectedVolumeName, modifiedPod.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.Equal(t, config.PrometheusConfigMapMountPath, modifiedPod.Spec.Containers[0].VolumeMounts[0].MountPath)
 	assert.Equal(t, expectedContainerPort, modifiedPod.Spec.Containers[0].Ports[0].ContainerPort)
+	assert.Equal(t, expectedContainerPortName, modifiedPod.Spec.Containers[0].Ports[0].Name)
 	assert.Equal(t, corev1.Protocol(config.DefaultPrometheusPortProtocol), modifiedPod.Spec.Containers[0].Ports[0].Protocol)
 }
 


### PR DESCRIPTION
`PodMonitor` is one of [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) CRDs, and it collects metrics from pod selector.
For collecting, it requires port name of metrics
https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint
port | Name of the pod port this endpoint refers to. Mutually exclusive with targetPort. | string
-- | -- | --

then, I have added metrics port name when mutating pod

it's example of `PodMonitor`
```yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: spark-pod-monitor
  labels:
    foo: bar
spec:
  selector:
    matchLabels:
      foo: bar
  podMetricsEndpoints:
  - port: metrics
    interval: 10s
```