### PR TITLE
[WIP] k8s.io version up to v0.18.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ replace (
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.3
 	k8s.io/kubectl => k8s.io/kubectl v0.18.3
 	k8s.io/kubelet => k8s.io/kubelet v0.18.3
-	k8s.io/kubernetes => k8s.io/kubernetes v1.16.6
+	k8s.io/kubernetes => k8s.io/kubernetes v1.18.3
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.3
 	k8s.io/metrics => k8s.io/metrics v0.18.3
 	k8s.io/node-api => k8s.io/node-api v0.18.3

--- a/go.mod
+++ b/go.mod
@@ -17,48 +17,48 @@ require (
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v0.9.3
-	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
+	github.com/prometheus/client_golang v1.0.0
+	github.com/prometheus/client_model v0.2.0
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	k8s.io/api v0.16.6
+	k8s.io/api v0.18.3
 	k8s.io/apiextensions-apiserver v0.0.0
-	k8s.io/apimachinery v0.16.9-beta.0
-	k8s.io/client-go v0.16.9-beta.0
+	k8s.io/apimachinery v0.18.3
+	k8s.io/client-go v0.18.3
 	k8s.io/kubectl v0.0.0
-	k8s.io/kubernetes v1.16.2
+	k8s.io/kubernetes v1.18.3
 	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 // indirect
-	volcano.sh/volcano v0.4.0
+	volcano.sh/volcano v1.1.0
 )
 
 replace (
-	k8s.io/api => k8s.io/api v0.16.6
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.6
-	k8s.io/apimachinery => k8s.io/apimachinery v0.16.6
-	k8s.io/apiserver => k8s.io/apiserver v0.16.6
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.16.6
-	k8s.io/client-go => k8s.io/client-go v0.16.6
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.16.6
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.16.6
-	k8s.io/code-generator => k8s.io/code-generator v0.16.6
-	k8s.io/component-base => k8s.io/component-base v0.16.6
-	k8s.io/cri-api => k8s.io/cri-api v0.16.6
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.16.6
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.6
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.16.6
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.16.6
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.16.6
-	k8s.io/kubectl => k8s.io/kubectl v0.16.6
-	k8s.io/kubelet => k8s.io/kubelet v0.16.6
+	k8s.io/api => k8s.io/api v0.18.3
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.3
+	k8s.io/apimachinery => k8s.io/apimachinery v0.18.3
+	k8s.io/apiserver => k8s.io/apiserver v0.18.3
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.3
+	k8s.io/client-go => k8s.io/client-go v0.18.3
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.3
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.3
+	k8s.io/code-generator => k8s.io/code-generator v0.18.3
+	k8s.io/component-base => k8s.io/component-base v0.18.3
+	k8s.io/cri-api => k8s.io/cri-api v0.18.3
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.3
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.3
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.3
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.3
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.3
+	k8s.io/kubectl => k8s.io/kubectl v0.18.3
+	k8s.io/kubelet => k8s.io/kubelet v0.18.3
 	k8s.io/kubernetes => k8s.io/kubernetes v1.16.6
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.16.6
-	k8s.io/metrics => k8s.io/metrics v0.16.6
-	k8s.io/node-api => k8s.io/node-api v0.16.6
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.16.6
-	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.16.6
-	k8s.io/sample-controller => k8s.io/sample-controller v0.16.6
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.3
+	k8s.io/metrics => k8s.io/metrics v0.18.3
+	k8s.io/node-api => k8s.io/node-api v0.18.3
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.3
+	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.18.3
+	k8s.io/sample-controller => k8s.io/sample-controller v0.18.3
 )

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -956,6 +956,11 @@ func (in *SparkUIConfiguration) DeepCopyInto(out *SparkUIConfiguration) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ServiceType != nil {
+		in, out := &in.ServiceType, &out.ServiceType
+		*out = new(v1.ServiceType)
+		**out = **in
+	}
 	if in.IngressAnnotations != nil {
 		in, out := &in.IngressAnnotations, &out.IngressAnnotations
 		*out = make(map[string]string, len(*in))

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volcano
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -116,7 +117,7 @@ func (v *VolcanoBatchScheduler) getAppPodGroupName(app *v1beta2.SparkApplication
 func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size int32, minResource corev1.ResourceList) error {
 	var err error
 	podGroupName := v.getAppPodGroupName(app)
-	if pg, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(podGroupName, metav1.GetOptions{}); err != nil {
+	if pg, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(context.TODO(), podGroupName, metav1.GetOptions{}); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
@@ -147,11 +148,11 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size
 				podGroup.Spec.PriorityClassName = *app.Spec.BatchSchedulerOptions.PriorityClassName
 			}
 		}
-		_, err = v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Create(&podGroup)
+		_, err = v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Create(context.TODO(), &podGroup, metav1.CreateOptions{})
 	} else {
 		if pg.Spec.MinMember != size {
 			pg.Spec.MinMember = size
-			_, err = v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Update(pg)
+			_, err = v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Update(context.TODO(), pg, metav1.UpdateOptions{})
 		}
 	}
 	if err != nil {
@@ -170,8 +171,8 @@ func New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {
 		return nil, fmt.Errorf("failed to initialize k8s extension client with error %v", err)
 	}
 
-	if _, err := extClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
-		PodGroupName, metav1.GetOptions{}); err != nil {
+	if _, err := extClient.ApiextensionsV1().CustomResourceDefinitions().Get(
+		context.TODO(), PodGroupName, metav1.GetOptions{}); err != nil {
 		return nil, fmt.Errorf("podGroup CRD is required to exists in current cluster error: %s", err)
 	}
 	return &VolcanoBatchScheduler{

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -69,7 +69,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
-			return nil, fmt.Errorf("Burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_scheduledsparkapplication.go
@@ -21,6 +21,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -41,7 +43,7 @@ var scheduledsparkapplicationsResource = schema.GroupVersionResource{Group: "spa
 var scheduledsparkapplicationsKind = schema.GroupVersionKind{Group: "sparkoperator.k8s.io", Version: "v1beta1", Kind: "ScheduledSparkApplication"}
 
 // Get takes name of the scheduledSparkApplication, and returns the corresponding scheduledSparkApplication object, and an error if there is any.
-func (c *FakeScheduledSparkApplications) Get(name string, options v1.GetOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(scheduledsparkapplicationsResource, c.ns, name), &v1beta1.ScheduledSparkApplication{})
 
@@ -52,7 +54,7 @@ func (c *FakeScheduledSparkApplications) Get(name string, options v1.GetOptions)
 }
 
 // List takes label and field selectors, and returns the list of ScheduledSparkApplications that match those selectors.
-func (c *FakeScheduledSparkApplications) List(opts v1.ListOptions) (result *v1beta1.ScheduledSparkApplicationList, err error) {
+func (c *FakeScheduledSparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ScheduledSparkApplicationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(scheduledsparkapplicationsResource, scheduledsparkapplicationsKind, c.ns, opts), &v1beta1.ScheduledSparkApplicationList{})
 
@@ -74,14 +76,14 @@ func (c *FakeScheduledSparkApplications) List(opts v1.ListOptions) (result *v1be
 }
 
 // Watch returns a watch.Interface that watches the requested scheduledSparkApplications.
-func (c *FakeScheduledSparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeScheduledSparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(scheduledsparkapplicationsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a scheduledSparkApplication and creates it.  Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *FakeScheduledSparkApplications) Create(scheduledSparkApplication *v1beta1.ScheduledSparkApplication) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Create(ctx context.Context, scheduledSparkApplication *v1beta1.ScheduledSparkApplication, opts v1.CreateOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(scheduledsparkapplicationsResource, c.ns, scheduledSparkApplication), &v1beta1.ScheduledSparkApplication{})
 
@@ -92,7 +94,7 @@ func (c *FakeScheduledSparkApplications) Create(scheduledSparkApplication *v1bet
 }
 
 // Update takes the representation of a scheduledSparkApplication and updates it. Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *FakeScheduledSparkApplications) Update(scheduledSparkApplication *v1beta1.ScheduledSparkApplication) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Update(ctx context.Context, scheduledSparkApplication *v1beta1.ScheduledSparkApplication, opts v1.UpdateOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(scheduledsparkapplicationsResource, c.ns, scheduledSparkApplication), &v1beta1.ScheduledSparkApplication{})
 
@@ -103,7 +105,7 @@ func (c *FakeScheduledSparkApplications) Update(scheduledSparkApplication *v1bet
 }
 
 // Delete takes name of the scheduledSparkApplication and deletes it. Returns an error if one occurs.
-func (c *FakeScheduledSparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeScheduledSparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(scheduledsparkapplicationsResource, c.ns, name), &v1beta1.ScheduledSparkApplication{})
 
@@ -111,15 +113,15 @@ func (c *FakeScheduledSparkApplications) Delete(name string, options *v1.DeleteO
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeScheduledSparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(scheduledsparkapplicationsResource, c.ns, listOptions)
+func (c *FakeScheduledSparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(scheduledsparkapplicationsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ScheduledSparkApplicationList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched scheduledSparkApplication.
-func (c *FakeScheduledSparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(scheduledsparkapplicationsResource, c.ns, name, pt, data, subresources...), &v1beta1.ScheduledSparkApplication{})
 

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/fake/fake_sparkapplication.go
@@ -21,6 +21,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -41,7 +43,7 @@ var sparkapplicationsResource = schema.GroupVersionResource{Group: "sparkoperato
 var sparkapplicationsKind = schema.GroupVersionKind{Group: "sparkoperator.k8s.io", Version: "v1beta1", Kind: "SparkApplication"}
 
 // Get takes name of the sparkApplication, and returns the corresponding sparkApplication object, and an error if there is any.
-func (c *FakeSparkApplications) Get(name string, options v1.GetOptions) (result *v1beta1.SparkApplication, err error) {
+func (c *FakeSparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(sparkapplicationsResource, c.ns, name), &v1beta1.SparkApplication{})
 
@@ -52,7 +54,7 @@ func (c *FakeSparkApplications) Get(name string, options v1.GetOptions) (result 
 }
 
 // List takes label and field selectors, and returns the list of SparkApplications that match those selectors.
-func (c *FakeSparkApplications) List(opts v1.ListOptions) (result *v1beta1.SparkApplicationList, err error) {
+func (c *FakeSparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.SparkApplicationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(sparkapplicationsResource, sparkapplicationsKind, c.ns, opts), &v1beta1.SparkApplicationList{})
 
@@ -74,14 +76,14 @@ func (c *FakeSparkApplications) List(opts v1.ListOptions) (result *v1beta1.Spark
 }
 
 // Watch returns a watch.Interface that watches the requested sparkApplications.
-func (c *FakeSparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeSparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(sparkapplicationsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a sparkApplication and creates it.  Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *FakeSparkApplications) Create(sparkApplication *v1beta1.SparkApplication) (result *v1beta1.SparkApplication, err error) {
+func (c *FakeSparkApplications) Create(ctx context.Context, sparkApplication *v1beta1.SparkApplication, opts v1.CreateOptions) (result *v1beta1.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(sparkapplicationsResource, c.ns, sparkApplication), &v1beta1.SparkApplication{})
 
@@ -92,7 +94,7 @@ func (c *FakeSparkApplications) Create(sparkApplication *v1beta1.SparkApplicatio
 }
 
 // Update takes the representation of a sparkApplication and updates it. Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *FakeSparkApplications) Update(sparkApplication *v1beta1.SparkApplication) (result *v1beta1.SparkApplication, err error) {
+func (c *FakeSparkApplications) Update(ctx context.Context, sparkApplication *v1beta1.SparkApplication, opts v1.UpdateOptions) (result *v1beta1.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(sparkapplicationsResource, c.ns, sparkApplication), &v1beta1.SparkApplication{})
 
@@ -103,7 +105,7 @@ func (c *FakeSparkApplications) Update(sparkApplication *v1beta1.SparkApplicatio
 }
 
 // Delete takes name of the sparkApplication and deletes it. Returns an error if one occurs.
-func (c *FakeSparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeSparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(sparkapplicationsResource, c.ns, name), &v1beta1.SparkApplication{})
 
@@ -111,15 +113,15 @@ func (c *FakeSparkApplications) Delete(name string, options *v1.DeleteOptions) e
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeSparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(sparkapplicationsResource, c.ns, listOptions)
+func (c *FakeSparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(sparkapplicationsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.SparkApplicationList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched sparkApplication.
-func (c *FakeSparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.SparkApplication, err error) {
+func (c *FakeSparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(sparkapplicationsResource, c.ns, name, pt, data, subresources...), &v1beta1.SparkApplication{})
 

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
@@ -39,14 +40,14 @@ type ScheduledSparkApplicationsGetter interface {
 
 // ScheduledSparkApplicationInterface has methods to work with ScheduledSparkApplication resources.
 type ScheduledSparkApplicationInterface interface {
-	Create(*v1beta1.ScheduledSparkApplication) (*v1beta1.ScheduledSparkApplication, error)
-	Update(*v1beta1.ScheduledSparkApplication) (*v1beta1.ScheduledSparkApplication, error)
-	Delete(name string, options *v1.DeleteOptions) error
-	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
-	Get(name string, options v1.GetOptions) (*v1beta1.ScheduledSparkApplication, error)
-	List(opts v1.ListOptions) (*v1beta1.ScheduledSparkApplicationList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ScheduledSparkApplication, err error)
+	Create(ctx context.Context, scheduledSparkApplication *v1beta1.ScheduledSparkApplication, opts v1.CreateOptions) (*v1beta1.ScheduledSparkApplication, error)
+	Update(ctx context.Context, scheduledSparkApplication *v1beta1.ScheduledSparkApplication, opts v1.UpdateOptions) (*v1beta1.ScheduledSparkApplication, error)
+	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.ScheduledSparkApplication, error)
+	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.ScheduledSparkApplicationList, error)
+	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ScheduledSparkApplication, err error)
 	ScheduledSparkApplicationExpansion
 }
 
@@ -65,20 +66,20 @@ func newScheduledSparkApplications(c *SparkoperatorV1beta1Client, namespace stri
 }
 
 // Get takes name of the scheduledSparkApplication, and returns the corresponding scheduledSparkApplication object, and an error if there is any.
-func (c *scheduledSparkApplications) Get(name string, options v1.GetOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
 	result = &v1beta1.ScheduledSparkApplication{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // List takes label and field selectors, and returns the list of ScheduledSparkApplications that match those selectors.
-func (c *scheduledSparkApplications) List(opts v1.ListOptions) (result *v1beta1.ScheduledSparkApplicationList, err error) {
+func (c *scheduledSparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ScheduledSparkApplicationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -89,13 +90,13 @@ func (c *scheduledSparkApplications) List(opts v1.ListOptions) (result *v1beta1.
 		Resource("scheduledsparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested scheduledSparkApplications.
-func (c *scheduledSparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *scheduledSparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -106,71 +107,74 @@ func (c *scheduledSparkApplications) Watch(opts v1.ListOptions) (watch.Interface
 		Resource("scheduledsparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(ctx)
 }
 
 // Create takes the representation of a scheduledSparkApplication and creates it.  Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *scheduledSparkApplications) Create(scheduledSparkApplication *v1beta1.ScheduledSparkApplication) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Create(ctx context.Context, scheduledSparkApplication *v1beta1.ScheduledSparkApplication, opts v1.CreateOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
 	result = &v1beta1.ScheduledSparkApplication{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(scheduledSparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Update takes the representation of a scheduledSparkApplication and updates it. Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *scheduledSparkApplications) Update(scheduledSparkApplication *v1beta1.ScheduledSparkApplication) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Update(ctx context.Context, scheduledSparkApplication *v1beta1.ScheduledSparkApplication, opts v1.UpdateOptions) (result *v1beta1.ScheduledSparkApplication, err error) {
 	result = &v1beta1.ScheduledSparkApplication{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(scheduledSparkApplication.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(scheduledSparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Delete takes name of the scheduledSparkApplication and deletes it. Returns an error if one occurs.
-func (c *scheduledSparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *scheduledSparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(name).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *scheduledSparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *scheduledSparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
 	var timeout time.Duration
-	if listOptions.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // Patch applies the patch and returns the patched scheduledSparkApplication.
-func (c *scheduledSparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ScheduledSparkApplication, err error) {
 	result = &v1beta1.ScheduledSparkApplication{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
-		SubResource(subresources...).
 		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(data).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta1/sparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
@@ -39,14 +40,14 @@ type SparkApplicationsGetter interface {
 
 // SparkApplicationInterface has methods to work with SparkApplication resources.
 type SparkApplicationInterface interface {
-	Create(*v1beta1.SparkApplication) (*v1beta1.SparkApplication, error)
-	Update(*v1beta1.SparkApplication) (*v1beta1.SparkApplication, error)
-	Delete(name string, options *v1.DeleteOptions) error
-	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
-	Get(name string, options v1.GetOptions) (*v1beta1.SparkApplication, error)
-	List(opts v1.ListOptions) (*v1beta1.SparkApplicationList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.SparkApplication, err error)
+	Create(ctx context.Context, sparkApplication *v1beta1.SparkApplication, opts v1.CreateOptions) (*v1beta1.SparkApplication, error)
+	Update(ctx context.Context, sparkApplication *v1beta1.SparkApplication, opts v1.UpdateOptions) (*v1beta1.SparkApplication, error)
+	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.SparkApplication, error)
+	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.SparkApplicationList, error)
+	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.SparkApplication, err error)
 	SparkApplicationExpansion
 }
 
@@ -65,20 +66,20 @@ func newSparkApplications(c *SparkoperatorV1beta1Client, namespace string) *spar
 }
 
 // Get takes name of the sparkApplication, and returns the corresponding sparkApplication object, and an error if there is any.
-func (c *sparkApplications) Get(name string, options v1.GetOptions) (result *v1beta1.SparkApplication, err error) {
+func (c *sparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.SparkApplication, err error) {
 	result = &v1beta1.SparkApplication{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // List takes label and field selectors, and returns the list of SparkApplications that match those selectors.
-func (c *sparkApplications) List(opts v1.ListOptions) (result *v1beta1.SparkApplicationList, err error) {
+func (c *sparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.SparkApplicationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -89,13 +90,13 @@ func (c *sparkApplications) List(opts v1.ListOptions) (result *v1beta1.SparkAppl
 		Resource("sparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested sparkApplications.
-func (c *sparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *sparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -106,71 +107,74 @@ func (c *sparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) 
 		Resource("sparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(ctx)
 }
 
 // Create takes the representation of a sparkApplication and creates it.  Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *sparkApplications) Create(sparkApplication *v1beta1.SparkApplication) (result *v1beta1.SparkApplication, err error) {
+func (c *sparkApplications) Create(ctx context.Context, sparkApplication *v1beta1.SparkApplication, opts v1.CreateOptions) (result *v1beta1.SparkApplication, err error) {
 	result = &v1beta1.SparkApplication{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("sparkapplications").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(sparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Update takes the representation of a sparkApplication and updates it. Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *sparkApplications) Update(sparkApplication *v1beta1.SparkApplication) (result *v1beta1.SparkApplication, err error) {
+func (c *sparkApplications) Update(ctx context.Context, sparkApplication *v1beta1.SparkApplication, opts v1.UpdateOptions) (result *v1beta1.SparkApplication, err error) {
 	result = &v1beta1.SparkApplication{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(sparkApplication.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(sparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Delete takes name of the sparkApplication and deletes it. Returns an error if one occurs.
-func (c *sparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *sparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(name).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *sparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *sparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
 	var timeout time.Duration
-	if listOptions.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("sparkapplications").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // Patch applies the patch and returns the patched sparkApplication.
-func (c *sparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.SparkApplication, err error) {
+func (c *sparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.SparkApplication, err error) {
 	result = &v1beta1.SparkApplication{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("sparkapplications").
-		SubResource(subresources...).
 		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(data).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/fake/fake_scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/fake/fake_scheduledsparkapplication.go
@@ -21,6 +21,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -41,7 +43,7 @@ var scheduledsparkapplicationsResource = schema.GroupVersionResource{Group: "spa
 var scheduledsparkapplicationsKind = schema.GroupVersionKind{Group: "sparkoperator.k8s.io", Version: "v1beta2", Kind: "ScheduledSparkApplication"}
 
 // Get takes name of the scheduledSparkApplication, and returns the corresponding scheduledSparkApplication object, and an error if there is any.
-func (c *FakeScheduledSparkApplications) Get(name string, options v1.GetOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(scheduledsparkapplicationsResource, c.ns, name), &v1beta2.ScheduledSparkApplication{})
 
@@ -52,7 +54,7 @@ func (c *FakeScheduledSparkApplications) Get(name string, options v1.GetOptions)
 }
 
 // List takes label and field selectors, and returns the list of ScheduledSparkApplications that match those selectors.
-func (c *FakeScheduledSparkApplications) List(opts v1.ListOptions) (result *v1beta2.ScheduledSparkApplicationList, err error) {
+func (c *FakeScheduledSparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.ScheduledSparkApplicationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(scheduledsparkapplicationsResource, scheduledsparkapplicationsKind, c.ns, opts), &v1beta2.ScheduledSparkApplicationList{})
 
@@ -74,14 +76,14 @@ func (c *FakeScheduledSparkApplications) List(opts v1.ListOptions) (result *v1be
 }
 
 // Watch returns a watch.Interface that watches the requested scheduledSparkApplications.
-func (c *FakeScheduledSparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeScheduledSparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(scheduledsparkapplicationsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a scheduledSparkApplication and creates it.  Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *FakeScheduledSparkApplications) Create(scheduledSparkApplication *v1beta2.ScheduledSparkApplication) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Create(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.CreateOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(scheduledsparkapplicationsResource, c.ns, scheduledSparkApplication), &v1beta2.ScheduledSparkApplication{})
 
@@ -92,7 +94,7 @@ func (c *FakeScheduledSparkApplications) Create(scheduledSparkApplication *v1bet
 }
 
 // Update takes the representation of a scheduledSparkApplication and updates it. Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *FakeScheduledSparkApplications) Update(scheduledSparkApplication *v1beta2.ScheduledSparkApplication) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Update(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.UpdateOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(scheduledsparkapplicationsResource, c.ns, scheduledSparkApplication), &v1beta2.ScheduledSparkApplication{})
 
@@ -104,7 +106,7 @@ func (c *FakeScheduledSparkApplications) Update(scheduledSparkApplication *v1bet
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeScheduledSparkApplications) UpdateStatus(scheduledSparkApplication *v1beta2.ScheduledSparkApplication) (*v1beta2.ScheduledSparkApplication, error) {
+func (c *FakeScheduledSparkApplications) UpdateStatus(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.UpdateOptions) (*v1beta2.ScheduledSparkApplication, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(scheduledsparkapplicationsResource, "status", c.ns, scheduledSparkApplication), &v1beta2.ScheduledSparkApplication{})
 
@@ -115,7 +117,7 @@ func (c *FakeScheduledSparkApplications) UpdateStatus(scheduledSparkApplication 
 }
 
 // Delete takes name of the scheduledSparkApplication and deletes it. Returns an error if one occurs.
-func (c *FakeScheduledSparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeScheduledSparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(scheduledsparkapplicationsResource, c.ns, name), &v1beta2.ScheduledSparkApplication{})
 
@@ -123,15 +125,15 @@ func (c *FakeScheduledSparkApplications) Delete(name string, options *v1.DeleteO
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeScheduledSparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(scheduledsparkapplicationsResource, c.ns, listOptions)
+func (c *FakeScheduledSparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(scheduledsparkapplicationsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta2.ScheduledSparkApplicationList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched scheduledSparkApplication.
-func (c *FakeScheduledSparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *FakeScheduledSparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.ScheduledSparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(scheduledsparkapplicationsResource, c.ns, name, pt, data, subresources...), &v1beta2.ScheduledSparkApplication{})
 

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/fake/fake_sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/fake/fake_sparkapplication.go
@@ -21,6 +21,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	v1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -41,7 +43,7 @@ var sparkapplicationsResource = schema.GroupVersionResource{Group: "sparkoperato
 var sparkapplicationsKind = schema.GroupVersionKind{Group: "sparkoperator.k8s.io", Version: "v1beta2", Kind: "SparkApplication"}
 
 // Get takes name of the sparkApplication, and returns the corresponding sparkApplication object, and an error if there is any.
-func (c *FakeSparkApplications) Get(name string, options v1.GetOptions) (result *v1beta2.SparkApplication, err error) {
+func (c *FakeSparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(sparkapplicationsResource, c.ns, name), &v1beta2.SparkApplication{})
 
@@ -52,7 +54,7 @@ func (c *FakeSparkApplications) Get(name string, options v1.GetOptions) (result 
 }
 
 // List takes label and field selectors, and returns the list of SparkApplications that match those selectors.
-func (c *FakeSparkApplications) List(opts v1.ListOptions) (result *v1beta2.SparkApplicationList, err error) {
+func (c *FakeSparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.SparkApplicationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(sparkapplicationsResource, sparkapplicationsKind, c.ns, opts), &v1beta2.SparkApplicationList{})
 
@@ -74,14 +76,14 @@ func (c *FakeSparkApplications) List(opts v1.ListOptions) (result *v1beta2.Spark
 }
 
 // Watch returns a watch.Interface that watches the requested sparkApplications.
-func (c *FakeSparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeSparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(sparkapplicationsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a sparkApplication and creates it.  Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *FakeSparkApplications) Create(sparkApplication *v1beta2.SparkApplication) (result *v1beta2.SparkApplication, err error) {
+func (c *FakeSparkApplications) Create(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.CreateOptions) (result *v1beta2.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(sparkapplicationsResource, c.ns, sparkApplication), &v1beta2.SparkApplication{})
 
@@ -92,7 +94,7 @@ func (c *FakeSparkApplications) Create(sparkApplication *v1beta2.SparkApplicatio
 }
 
 // Update takes the representation of a sparkApplication and updates it. Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *FakeSparkApplications) Update(sparkApplication *v1beta2.SparkApplication) (result *v1beta2.SparkApplication, err error) {
+func (c *FakeSparkApplications) Update(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.UpdateOptions) (result *v1beta2.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(sparkapplicationsResource, c.ns, sparkApplication), &v1beta2.SparkApplication{})
 
@@ -104,7 +106,7 @@ func (c *FakeSparkApplications) Update(sparkApplication *v1beta2.SparkApplicatio
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeSparkApplications) UpdateStatus(sparkApplication *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
+func (c *FakeSparkApplications) UpdateStatus(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.UpdateOptions) (*v1beta2.SparkApplication, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(sparkapplicationsResource, "status", c.ns, sparkApplication), &v1beta2.SparkApplication{})
 
@@ -115,7 +117,7 @@ func (c *FakeSparkApplications) UpdateStatus(sparkApplication *v1beta2.SparkAppl
 }
 
 // Delete takes name of the sparkApplication and deletes it. Returns an error if one occurs.
-func (c *FakeSparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeSparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(sparkapplicationsResource, c.ns, name), &v1beta2.SparkApplication{})
 
@@ -123,15 +125,15 @@ func (c *FakeSparkApplications) Delete(name string, options *v1.DeleteOptions) e
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeSparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(sparkapplicationsResource, c.ns, listOptions)
+func (c *FakeSparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(sparkapplicationsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta2.SparkApplicationList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched sparkApplication.
-func (c *FakeSparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.SparkApplication, err error) {
+func (c *FakeSparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.SparkApplication, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(sparkapplicationsResource, c.ns, name, pt, data, subresources...), &v1beta2.SparkApplication{})
 

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/scheduledsparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/scheduledsparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
@@ -39,15 +40,15 @@ type ScheduledSparkApplicationsGetter interface {
 
 // ScheduledSparkApplicationInterface has methods to work with ScheduledSparkApplication resources.
 type ScheduledSparkApplicationInterface interface {
-	Create(*v1beta2.ScheduledSparkApplication) (*v1beta2.ScheduledSparkApplication, error)
-	Update(*v1beta2.ScheduledSparkApplication) (*v1beta2.ScheduledSparkApplication, error)
-	UpdateStatus(*v1beta2.ScheduledSparkApplication) (*v1beta2.ScheduledSparkApplication, error)
-	Delete(name string, options *v1.DeleteOptions) error
-	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
-	Get(name string, options v1.GetOptions) (*v1beta2.ScheduledSparkApplication, error)
-	List(opts v1.ListOptions) (*v1beta2.ScheduledSparkApplicationList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.ScheduledSparkApplication, err error)
+	Create(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.CreateOptions) (*v1beta2.ScheduledSparkApplication, error)
+	Update(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.UpdateOptions) (*v1beta2.ScheduledSparkApplication, error)
+	UpdateStatus(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.UpdateOptions) (*v1beta2.ScheduledSparkApplication, error)
+	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta2.ScheduledSparkApplication, error)
+	List(ctx context.Context, opts v1.ListOptions) (*v1beta2.ScheduledSparkApplicationList, error)
+	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.ScheduledSparkApplication, err error)
 	ScheduledSparkApplicationExpansion
 }
 
@@ -66,20 +67,20 @@ func newScheduledSparkApplications(c *SparkoperatorV1beta2Client, namespace stri
 }
 
 // Get takes name of the scheduledSparkApplication, and returns the corresponding scheduledSparkApplication object, and an error if there is any.
-func (c *scheduledSparkApplications) Get(name string, options v1.GetOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	result = &v1beta2.ScheduledSparkApplication{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // List takes label and field selectors, and returns the list of ScheduledSparkApplications that match those selectors.
-func (c *scheduledSparkApplications) List(opts v1.ListOptions) (result *v1beta2.ScheduledSparkApplicationList, err error) {
+func (c *scheduledSparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.ScheduledSparkApplicationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -90,13 +91,13 @@ func (c *scheduledSparkApplications) List(opts v1.ListOptions) (result *v1beta2.
 		Resource("scheduledsparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested scheduledSparkApplications.
-func (c *scheduledSparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *scheduledSparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -107,87 +108,90 @@ func (c *scheduledSparkApplications) Watch(opts v1.ListOptions) (watch.Interface
 		Resource("scheduledsparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(ctx)
 }
 
 // Create takes the representation of a scheduledSparkApplication and creates it.  Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *scheduledSparkApplications) Create(scheduledSparkApplication *v1beta2.ScheduledSparkApplication) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Create(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.CreateOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	result = &v1beta2.ScheduledSparkApplication{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(scheduledSparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Update takes the representation of a scheduledSparkApplication and updates it. Returns the server's representation of the scheduledSparkApplication, and an error, if there is any.
-func (c *scheduledSparkApplications) Update(scheduledSparkApplication *v1beta2.ScheduledSparkApplication) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Update(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.UpdateOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	result = &v1beta2.ScheduledSparkApplication{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(scheduledSparkApplication.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(scheduledSparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-
-func (c *scheduledSparkApplications) UpdateStatus(scheduledSparkApplication *v1beta2.ScheduledSparkApplication) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) UpdateStatus(ctx context.Context, scheduledSparkApplication *v1beta2.ScheduledSparkApplication, opts v1.UpdateOptions) (result *v1beta2.ScheduledSparkApplication, err error) {
 	result = &v1beta2.ScheduledSparkApplication{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(scheduledSparkApplication.Name).
 		SubResource("status").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(scheduledSparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Delete takes name of the scheduledSparkApplication and deletes it. Returns an error if one occurs.
-func (c *scheduledSparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *scheduledSparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
 		Name(name).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *scheduledSparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *scheduledSparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
 	var timeout time.Duration
-	if listOptions.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // Patch applies the patch and returns the patched scheduledSparkApplication.
-func (c *scheduledSparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.ScheduledSparkApplication, err error) {
+func (c *scheduledSparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.ScheduledSparkApplication, err error) {
 	result = &v1beta2.ScheduledSparkApplication{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("scheduledsparkapplications").
-		SubResource(subresources...).
 		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(data).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/sparkapplication.go
+++ b/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2/sparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
@@ -39,15 +40,15 @@ type SparkApplicationsGetter interface {
 
 // SparkApplicationInterface has methods to work with SparkApplication resources.
 type SparkApplicationInterface interface {
-	Create(*v1beta2.SparkApplication) (*v1beta2.SparkApplication, error)
-	Update(*v1beta2.SparkApplication) (*v1beta2.SparkApplication, error)
-	UpdateStatus(*v1beta2.SparkApplication) (*v1beta2.SparkApplication, error)
-	Delete(name string, options *v1.DeleteOptions) error
-	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
-	Get(name string, options v1.GetOptions) (*v1beta2.SparkApplication, error)
-	List(opts v1.ListOptions) (*v1beta2.SparkApplicationList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.SparkApplication, err error)
+	Create(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.CreateOptions) (*v1beta2.SparkApplication, error)
+	Update(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.UpdateOptions) (*v1beta2.SparkApplication, error)
+	UpdateStatus(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.UpdateOptions) (*v1beta2.SparkApplication, error)
+	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta2.SparkApplication, error)
+	List(ctx context.Context, opts v1.ListOptions) (*v1beta2.SparkApplicationList, error)
+	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.SparkApplication, err error)
 	SparkApplicationExpansion
 }
 
@@ -66,20 +67,20 @@ func newSparkApplications(c *SparkoperatorV1beta2Client, namespace string) *spar
 }
 
 // Get takes name of the sparkApplication, and returns the corresponding sparkApplication object, and an error if there is any.
-func (c *sparkApplications) Get(name string, options v1.GetOptions) (result *v1beta2.SparkApplication, err error) {
+func (c *sparkApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.SparkApplication, err error) {
 	result = &v1beta2.SparkApplication{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // List takes label and field selectors, and returns the list of SparkApplications that match those selectors.
-func (c *sparkApplications) List(opts v1.ListOptions) (result *v1beta2.SparkApplicationList, err error) {
+func (c *sparkApplications) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.SparkApplicationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -90,13 +91,13 @@ func (c *sparkApplications) List(opts v1.ListOptions) (result *v1beta2.SparkAppl
 		Resource("sparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested sparkApplications.
-func (c *sparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *sparkApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -107,87 +108,90 @@ func (c *sparkApplications) Watch(opts v1.ListOptions) (watch.Interface, error) 
 		Resource("sparkapplications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(ctx)
 }
 
 // Create takes the representation of a sparkApplication and creates it.  Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *sparkApplications) Create(sparkApplication *v1beta2.SparkApplication) (result *v1beta2.SparkApplication, err error) {
+func (c *sparkApplications) Create(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.CreateOptions) (result *v1beta2.SparkApplication, err error) {
 	result = &v1beta2.SparkApplication{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("sparkapplications").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(sparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Update takes the representation of a sparkApplication and updates it. Returns the server's representation of the sparkApplication, and an error, if there is any.
-func (c *sparkApplications) Update(sparkApplication *v1beta2.SparkApplication) (result *v1beta2.SparkApplication, err error) {
+func (c *sparkApplications) Update(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.UpdateOptions) (result *v1beta2.SparkApplication, err error) {
 	result = &v1beta2.SparkApplication{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(sparkApplication.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(sparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-
-func (c *sparkApplications) UpdateStatus(sparkApplication *v1beta2.SparkApplication) (result *v1beta2.SparkApplication, err error) {
+func (c *sparkApplications) UpdateStatus(ctx context.Context, sparkApplication *v1beta2.SparkApplication, opts v1.UpdateOptions) (result *v1beta2.SparkApplication, err error) {
 	result = &v1beta2.SparkApplication{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(sparkApplication.Name).
 		SubResource("status").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(sparkApplication).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Delete takes name of the sparkApplication and deletes it. Returns an error if one occurs.
-func (c *sparkApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *sparkApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("sparkapplications").
 		Name(name).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *sparkApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *sparkApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
 	var timeout time.Duration
-	if listOptions.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("sparkapplications").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // Patch applies the patch and returns the patched sparkApplication.
-func (c *sparkApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.SparkApplication, err error) {
+func (c *sparkApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.SparkApplication, err error) {
 	result = &v1beta2.SparkApplication{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("sparkapplications").
-		SubResource(subresources...).
 		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(data).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/scheduledsparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	time "time"
 
 	sparkoperatork8siov1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
@@ -63,13 +64,13 @@ func NewFilteredScheduledSparkApplicationInformer(client versioned.Interface, na
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta1().ScheduledSparkApplications(namespace).List(options)
+				return client.SparkoperatorV1beta1().ScheduledSparkApplications(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta1().ScheduledSparkApplications(namespace).Watch(options)
+				return client.SparkoperatorV1beta1().ScheduledSparkApplications(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&sparkoperatork8siov1beta1.ScheduledSparkApplication{},

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/sparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta1/sparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	time "time"
 
 	sparkoperatork8siov1beta1 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
@@ -63,13 +64,13 @@ func NewFilteredSparkApplicationInformer(client versioned.Interface, namespace s
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta1().SparkApplications(namespace).List(options)
+				return client.SparkoperatorV1beta1().SparkApplications(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta1().SparkApplications(namespace).Watch(options)
+				return client.SparkoperatorV1beta1().SparkApplications(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&sparkoperatork8siov1beta1.SparkApplication{},

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta2/scheduledsparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta2/scheduledsparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	time "time"
 
 	sparkoperatork8siov1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
@@ -63,13 +64,13 @@ func NewFilteredScheduledSparkApplicationInformer(client versioned.Interface, na
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta2().ScheduledSparkApplications(namespace).List(options)
+				return client.SparkoperatorV1beta2().ScheduledSparkApplications(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta2().ScheduledSparkApplications(namespace).Watch(options)
+				return client.SparkoperatorV1beta2().ScheduledSparkApplications(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&sparkoperatork8siov1beta2.ScheduledSparkApplication{},

--- a/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta2/sparkapplication.go
+++ b/pkg/client/informers/externalversions/sparkoperator.k8s.io/v1beta2/sparkapplication.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	time "time"
 
 	sparkoperatork8siov1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
@@ -63,13 +64,13 @@ func NewFilteredSparkApplicationInformer(client versioned.Interface, namespace s
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta2().SparkApplications(namespace).List(options)
+				return client.SparkoperatorV1beta2().SparkApplications(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SparkoperatorV1beta2().SparkApplications(namespace).Watch(options)
+				return client.SparkoperatorV1beta2().SparkApplications(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&sparkoperatork8siov1beta2.SparkApplication{},

--- a/pkg/controller/scheduledsparkapplication/controller.go
+++ b/pkg/controller/scheduledsparkapplication/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduledsparkapplication
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -255,7 +256,7 @@ func (c *Controller) createSparkApplication(
 		app.ObjectMeta.Labels[key] = value
 	}
 	app.ObjectMeta.Labels[config.ScheduledSparkAppNameLabel] = scheduledApp.Name
-	_, err := c.crdClient.SparkoperatorV1beta2().SparkApplications(scheduledApp.Namespace).Create(app)
+	_, err := c.crdClient.SparkoperatorV1beta2().SparkApplications(scheduledApp.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -308,8 +309,8 @@ func (c *Controller) killLastRunIfNotFinished(app *v1beta2.SparkApplication) err
 	}
 
 	// Delete the SparkApplication object of the last run.
-	if err := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(app.Name,
-		metav1.NewDeleteOptions(0)); err != nil {
+	if err := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(context.TODO(), app.Name,
+		*metav1.NewDeleteOptions(0)); err != nil {
 		return err
 	}
 
@@ -337,11 +338,11 @@ func (c *Controller) checkAndUpdatePastRuns(
 	var toDelete []string
 	status.PastSuccessfulRunNames, toDelete = bookkeepPastRuns(completedRuns, app.Spec.SuccessfulRunHistoryLimit)
 	for _, name := range toDelete {
-		c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(name, metav1.NewDeleteOptions(0))
+		c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(context.TODO(), name, *metav1.NewDeleteOptions(0))
 	}
 	status.PastFailedRunNames, toDelete = bookkeepPastRuns(failedRuns, app.Spec.FailedRunHistoryLimit)
 	for _, name := range toDelete {
-		c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(name, metav1.NewDeleteOptions(0))
+		c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(context.TODO(), name, *metav1.NewDeleteOptions(0))
 	}
 
 	return nil
@@ -359,13 +360,13 @@ func (c *Controller) updateScheduledSparkApplicationStatus(
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		toUpdate.Status = *newStatus
 		_, updateErr := c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(toUpdate.Namespace).UpdateStatus(
-			toUpdate)
+			context.TODO(), toUpdate, metav1.UpdateOptions{})
 		if updateErr == nil {
 			return nil
 		}
 
 		result, err := c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(toUpdate.Namespace).Get(
-			toUpdate.Name, metav1.GetOptions{})
+			context.TODO(), toUpdate.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/scheduledsparkapplication/controller_test.go
+++ b/pkg/controller/scheduledsparkapplication/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduledsparkapplication
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 		},
 	}
 	c, clk := newFakeController()
-	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(app)
+	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 
 	key, _ := cache.MetaNamespaceKeyFunc(app)
 	options := metav1.GetOptions{}
@@ -56,7 +57,7 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, v1beta2.ScheduledState, app.Status.ScheduleState)
 	// The first run should not have been triggered.
 	assert.True(t, app.Status.LastRunName == "")
@@ -66,14 +67,14 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	firstRunName := app.Status.LastRunName
 	// The first run should have been triggered.
 	assert.True(t, firstRunName != "")
 	assert.False(t, app.Status.LastRun.IsZero())
 	assert.True(t, app.Status.NextRun.Time.After(app.Status.LastRun.Time))
 	// The first run exists.
-	run, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	run, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.NotNil(t, run)
 
 	clk.Step(5 * time.Second)
@@ -81,31 +82,31 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	// Next run is not due, so LastRunName should stay the same.
 	assert.Equal(t, firstRunName, app.Status.LastRunName)
 
 	// Simulate completion of the first run.
 	run.Status.AppState.State = v1beta2.CompletedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(run)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(context.TODO(), run, metav1.UpdateOptions{})
 	// This sync should not start any new run, but update Status.PastSuccessfulRunNames.
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, 1, len(app.Status.PastSuccessfulRunNames))
 	assert.Equal(t, firstRunName, app.Status.PastSuccessfulRunNames[0])
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.NotNil(t, run)
 
 	// This sync should not start any new run, nor update Status.PastSuccessfulRunNames.
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, 1, len(app.Status.PastSuccessfulRunNames))
 	assert.Equal(t, firstRunName, app.Status.PastSuccessfulRunNames[0])
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.NotNil(t, run)
 
 	// Advance the clock to trigger the second run.
@@ -114,43 +115,43 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, v1beta2.ScheduledState, app.Status.ScheduleState)
 	// The second run should have a different name.
 	secondRunName := app.Status.LastRunName
 	assert.NotEqual(t, firstRunName, secondRunName)
 	assert.True(t, app.Status.NextRun.Time.After(app.Status.LastRun.Time))
 	// The second run exists.
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(secondRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), secondRunName, options)
 	assert.NotNil(t, run)
 
 	// Simulate completion of the second run.
 	run.Status.AppState.State = v1beta2.CompletedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(run)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(context.TODO(), run, metav1.UpdateOptions{})
 	// This sync should not start any new run, but update Status.PastSuccessfulRunNames.
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, 1, len(app.Status.PastSuccessfulRunNames))
 	// The first run should have been deleted due to the completion of the second run.
-	firstRun, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	firstRun, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.Nil(t, firstRun)
 
 	// This sync should not start any new run, nor update Status.PastSuccessfulRunNames.
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, 1, len(app.Status.PastSuccessfulRunNames))
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(secondRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), secondRunName, options)
 	assert.NotNil(t, run)
 
 	// Test the case where we update the schedule to be more frequent
 	app.Spec.Schedule = "@every 2m"
 	recentRunName := app.Status.LastRunName
 	recentRunTime := app.Status.LastRun.Time
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Update(app)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Update(context.TODO(), app, metav1.UpdateOptions{})
 	// sync our update
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
@@ -160,15 +161,15 @@ func TestSyncScheduledSparkApplication_Allow(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	// A run should have been triggered
 	assert.NotEqual(t, recentRunName, app.Status.LastRunName)
 	assert.True(t, recentRunTime.Before(app.Status.LastRun.Time))
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(app.Status.LastRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), app.Status.LastRunName, options)
 	assert.NotNil(t, run)
 	// Simulate completion of the last run
 	run.Status.AppState.State = v1beta2.CompletedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(run)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(context.TODO(), run, metav1.UpdateOptions{})
 	// This sync should not start any new run, but update Status.PastSuccessfulRunNames.
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
@@ -187,7 +188,7 @@ func TestSyncScheduledSparkApplication_Forbid(t *testing.T) {
 		},
 	}
 	c, clk := newFakeController()
-	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(app)
+	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 
 	key, _ := cache.MetaNamespaceKeyFunc(app)
 	options := metav1.GetOptions{}
@@ -195,7 +196,7 @@ func TestSyncScheduledSparkApplication_Forbid(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, v1beta2.ScheduledState, app.Status.ScheduleState)
 	// The first run should not have been triggered.
 	assert.True(t, app.Status.LastRunName == "")
@@ -205,7 +206,7 @@ func TestSyncScheduledSparkApplication_Forbid(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, v1beta2.ScheduledState, app.Status.ScheduleState)
 	firstRunName := app.Status.LastRunName
 	// The first run should have been triggered.
@@ -213,7 +214,7 @@ func TestSyncScheduledSparkApplication_Forbid(t *testing.T) {
 	assert.False(t, app.Status.LastRun.IsZero())
 	assert.True(t, app.Status.NextRun.Time.After(app.Status.LastRun.Time))
 	// The first run exists.
-	run, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	run, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.NotNil(t, run)
 
 	clk.SetTime(app.Status.NextRun.Time.Add(5 * time.Second))
@@ -221,23 +222,23 @@ func TestSyncScheduledSparkApplication_Forbid(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, firstRunName, app.Status.LastRunName)
 
 	// Simulate completion of the first run.
 	run.Status.AppState.State = v1beta2.CompletedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(run)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(context.TODO(), run, metav1.UpdateOptions{})
 	// This sync should start the next run because the first run has completed.
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	secondRunName := app.Status.LastRunName
 	assert.NotEqual(t, firstRunName, secondRunName)
 	assert.Equal(t, 1, len(app.Status.PastSuccessfulRunNames))
 	assert.Equal(t, firstRunName, app.Status.PastSuccessfulRunNames[0])
 	// The second run exists.
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(secondRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), secondRunName, options)
 	assert.NotNil(t, run)
 }
 
@@ -256,7 +257,7 @@ func TestSyncScheduledSparkApplication_Replace(t *testing.T) {
 		},
 	}
 	c, clk := newFakeController()
-	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(app)
+	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 	key, _ := cache.MetaNamespaceKeyFunc(app)
 
 	options := metav1.GetOptions{}
@@ -264,7 +265,7 @@ func TestSyncScheduledSparkApplication_Replace(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, v1beta2.ScheduledState, app.Status.ScheduleState)
 	// The first run should not have been triggered.
 	assert.True(t, app.Status.LastRunName == "")
@@ -274,7 +275,7 @@ func TestSyncScheduledSparkApplication_Replace(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	assert.Equal(t, v1beta2.ScheduledState, app.Status.ScheduleState)
 	firstRunName := app.Status.LastRunName
 	// The first run should have been triggered.
@@ -282,7 +283,7 @@ func TestSyncScheduledSparkApplication_Replace(t *testing.T) {
 	assert.False(t, app.Status.LastRun.IsZero())
 	assert.True(t, app.Status.NextRun.Time.After(app.Status.LastRun.Time))
 	// The first run exists.
-	run, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	run, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.NotNil(t, run)
 
 	clk.SetTime(app.Status.NextRun.Time.Add(5 * time.Second))
@@ -290,14 +291,14 @@ func TestSyncScheduledSparkApplication_Replace(t *testing.T) {
 	if err := c.syncScheduledSparkApplication(key); err != nil {
 		t.Fatal(err)
 	}
-	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(app.Name, options)
+	app, _ = c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Get(context.TODO(), app.Name, options)
 	secondRunName := app.Status.LastRunName
 	assert.NotEqual(t, firstRunName, secondRunName)
 	// The first run should have been deleted.
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(firstRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), firstRunName, options)
 	assert.Nil(t, run)
 	// The second run exists.
-	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(secondRunName, options)
+	run, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), secondRunName, options)
 	assert.NotNil(t, run)
 }
 
@@ -315,7 +316,7 @@ func TestShouldStartNextRun(t *testing.T) {
 		},
 	}
 	c, _ := newFakeController()
-	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(app)
+	c.crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 
 	run1 := &v1beta2.SparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
@@ -324,11 +325,11 @@ func TestShouldStartNextRun(t *testing.T) {
 			Labels:    map[string]string{config.ScheduledSparkAppNameLabel: app.Name},
 		},
 	}
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Create(run1)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Create(context.TODO(), run1, metav1.CreateOptions{})
 
 	// ConcurrencyAllow with a running run.
 	run1.Status.AppState.State = v1beta2.RunningState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Update(run1)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Update(context.TODO(), run1, metav1.UpdateOptions{})
 	app.Spec.ConcurrencyPolicy = v1beta2.ConcurrencyAllow
 	ok, _ := c.shouldStartNextRun(app)
 	assert.True(t, ok)
@@ -339,7 +340,7 @@ func TestShouldStartNextRun(t *testing.T) {
 	assert.False(t, ok)
 	// ConcurrencyForbid with a completed run.
 	run1.Status.AppState.State = v1beta2.CompletedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Update(run1)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Update(context.TODO(), run1, metav1.UpdateOptions{})
 	ok, _ = c.shouldStartNextRun(app)
 	assert.True(t, ok)
 
@@ -349,11 +350,11 @@ func TestShouldStartNextRun(t *testing.T) {
 	assert.True(t, ok)
 	// ConcurrencyReplace with a running run.
 	run1.Status.AppState.State = v1beta2.RunningState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Update(run1)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Update(context.TODO(), run1, metav1.UpdateOptions{})
 	ok, _ = c.shouldStartNextRun(app)
 	assert.True(t, ok)
 	// The previous running run should have been deleted.
-	existing, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Get(run1.Name,
+	existing, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(run1.Namespace).Get(context.TODO(), run1.Name,
 		metav1.GetOptions{})
 	assert.Nil(t, existing)
 }
@@ -385,7 +386,7 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 			},
 		},
 	}
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(run1)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), run1, metav1.CreateOptions{})
 
 	// The first completed run should have been recorded.
 	status := app.Status.DeepCopy()
@@ -398,13 +399,13 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 	run2.CreationTimestamp.Time = run1.CreationTimestamp.Add(10 * time.Second)
 	run2.Name = "run2"
 	run2.Status.AppState.State = v1beta2.RunningState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(run2)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), run2, metav1.CreateOptions{})
 	c.checkAndUpdatePastRuns(app, status)
 	assert.Equal(t, 1, len(status.PastSuccessfulRunNames))
 	assert.Equal(t, run1.Name, status.PastSuccessfulRunNames[0])
 	// The second completed run should have been recorded.
 	run2.Status.AppState.State = v1beta2.CompletedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(run2)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Update(context.TODO(), run2, metav1.UpdateOptions{})
 	c.checkAndUpdatePastRuns(app, status)
 	assert.Equal(t, 2, len(status.PastSuccessfulRunNames))
 	assert.Equal(t, run2.Name, status.PastSuccessfulRunNames[0])
@@ -415,10 +416,10 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 	assert.Equal(t, run2.Name, status.PastSuccessfulRunNames[0])
 	assert.Equal(t, run1.Name, status.PastSuccessfulRunNames[1])
 	// SparkApplications of both of the first two completed runs should exist.
-	existing, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run2.Name,
+	existing, _ := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run2.Name,
 		metav1.GetOptions{})
 	assert.NotNil(t, existing)
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run1.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run1.Name,
 		metav1.GetOptions{})
 	assert.NotNil(t, existing)
 
@@ -426,20 +427,20 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 	run3 := run1.DeepCopy()
 	run3.CreationTimestamp.Time = run2.CreationTimestamp.Add(10 * time.Second)
 	run3.Name = "run3"
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(run3)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), run3, metav1.CreateOptions{})
 	c.checkAndUpdatePastRuns(app, status)
 	assert.Equal(t, 2, len(status.PastSuccessfulRunNames))
 	assert.Equal(t, run3.Name, status.PastSuccessfulRunNames[0])
 	assert.Equal(t, run2.Name, status.PastSuccessfulRunNames[1])
 	// SparkApplications of the last two completed runs should still exist,
 	// but the one of the first completed run should have been deleted.
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run3.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run3.Name,
 		metav1.GetOptions{})
 	assert.NotNil(t, existing)
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run2.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run2.Name,
 		metav1.GetOptions{})
 	assert.NotNil(t, existing)
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run1.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run1.Name,
 		metav1.GetOptions{})
 	assert.Nil(t, existing)
 
@@ -448,7 +449,7 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 	run4.CreationTimestamp.Time = run3.CreationTimestamp.Add(10 * time.Second)
 	run4.Name = "run4"
 	run4.Status.AppState.State = v1beta2.FailedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(run4)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), run4, metav1.CreateOptions{})
 	c.checkAndUpdatePastRuns(app, status)
 	assert.Equal(t, 1, len(status.PastFailedRunNames))
 	assert.Equal(t, run4.Name, status.PastFailedRunNames[0])
@@ -458,7 +459,7 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 	run5.CreationTimestamp.Time = run4.CreationTimestamp.Add(10 * time.Second)
 	run5.Name = "run5"
 	run5.Status.AppState.State = v1beta2.FailedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(run5)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), run5, metav1.CreateOptions{})
 	c.checkAndUpdatePastRuns(app, status)
 	assert.Equal(t, 2, len(status.PastFailedRunNames))
 	assert.Equal(t, run5.Name, status.PastFailedRunNames[0])
@@ -469,20 +470,20 @@ func TestCheckAndUpdatePastRuns(t *testing.T) {
 	run6.CreationTimestamp.Time = run5.CreationTimestamp.Add(10 * time.Second)
 	run6.Name = "run6"
 	run6.Status.AppState.State = v1beta2.FailedState
-	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(run6)
+	c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), run6, metav1.CreateOptions{})
 	c.checkAndUpdatePastRuns(app, status)
 	assert.Equal(t, 2, len(status.PastFailedRunNames))
 	assert.Equal(t, run6.Name, status.PastFailedRunNames[0])
 	assert.Equal(t, run5.Name, status.PastFailedRunNames[1])
 	// SparkApplications of the last two failed runs should still exist,
 	// but the one of the first failed run should have been deleted.
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run6.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run6.Name,
 		metav1.GetOptions{})
 	assert.NotNil(t, existing)
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run5.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run5.Name,
 		metav1.GetOptions{})
 	assert.NotNil(t, existing)
-	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(run4.Name,
+	existing, _ = c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), run4.Name,
 		metav1.GetOptions{})
 	assert.Nil(t, existing)
 }

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,7 +51,7 @@ func newFakeController(app *v1beta2.SparkApplication, pods ...*apiv1.Pod) (*Cont
 	informerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0*time.Second)
 	recorder := record.NewFakeRecorder(3)
 
-	kubeClient.CoreV1().Nodes().Create(&apiv1.Node{
+	kubeClient.CoreV1().Nodes().Create(context.TODO(), &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 		},
@@ -62,7 +63,7 @@ func newFakeController(app *v1beta2.SparkApplication, pods ...*apiv1.Pod) (*Cont
 				},
 			},
 		},
-	})
+	}, metav1.CreateOptions{})
 
 	podInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0*time.Second)
 	controller := newSparkApplicationController(crdClient, kubeClient, informerFactory, podInformerFactory, recorder,
@@ -151,7 +152,7 @@ func TestOnUpdate(t *testing.T) {
 	assert.True(t, strings.Contains(event, "SparkApplicationSpecUpdateFailed"))
 
 	// Case3: Spec update successful.
-	ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(appTemplate.Namespace).Create(appTemplate)
+	ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(appTemplate.Namespace).Create(context.TODO(), appTemplate, metav1.CreateOptions{})
 	ctrl.onUpdate(appTemplate, copyWithSpecUpdate)
 
 	// Verify App was enqueued.
@@ -168,7 +169,7 @@ func TestOnUpdate(t *testing.T) {
 	assert.True(t, strings.Contains(event, "SparkApplicationSpecUpdateProcessed"))
 
 	// Verify the SparkApplication state was updated to InvalidatingState.
-	app, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(appTemplate.Namespace).Get(appTemplate.Name, metav1.GetOptions{})
+	app, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(appTemplate.Namespace).Get(context.TODO(), appTemplate.Name, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, v1beta2.InvalidatingState, app.Status.AppState.State)
 }
@@ -259,7 +260,7 @@ func TestSyncSparkApplication_SubmissionFailed(t *testing.T) {
 	}
 
 	ctrl, recorder := newFakeController(app)
-	_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(app)
+	_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +275,7 @@ func TestSyncSparkApplication_SubmissionFailed(t *testing.T) {
 
 	// Attempt 1
 	err = ctrl.syncSparkApplication("default/foo")
-	updatedApp, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(app.Name, metav1.GetOptions{})
+	updatedApp, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), app.Name, metav1.GetOptions{})
 
 	assert.Equal(t, v1beta2.FailedSubmissionState, updatedApp.Status.AppState.State)
 	assert.Equal(t, int32(1), updatedApp.Status.SubmissionAttempts)
@@ -290,14 +291,14 @@ func TestSyncSparkApplication_SubmissionFailed(t *testing.T) {
 	// Attempt 2: Retry again.
 	updatedApp.Status.LastSubmissionAttemptTime = metav1.Time{Time: metav1.Now().Add(-100 * time.Second)}
 	ctrl, recorder = newFakeController(updatedApp)
-	_, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(updatedApp)
+	_, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), updatedApp, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = ctrl.syncSparkApplication("default/foo")
 
 	// Verify that the application failed again.
-	updatedApp, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(app.Name, metav1.GetOptions{})
+	updatedApp, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), app.Name, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, v1beta2.FailedSubmissionState, updatedApp.Status.AppState.State)
 	assert.Equal(t, int32(2), updatedApp.Status.SubmissionAttempts)
@@ -309,14 +310,14 @@ func TestSyncSparkApplication_SubmissionFailed(t *testing.T) {
 	// Attempt 3: No more retries.
 	updatedApp.Status.LastSubmissionAttemptTime = metav1.Time{Time: metav1.Now().Add(-100 * time.Second)}
 	ctrl, recorder = newFakeController(updatedApp)
-	_, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(updatedApp)
+	_, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), updatedApp, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = ctrl.syncSparkApplication("default/foo")
 
 	// Verify that the application failed again.
-	updatedApp, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(app.Name, metav1.GetOptions{})
+	updatedApp, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), app.Name, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, v1beta2.FailedState, updatedApp.Status.AppState.State)
 	// No more submission attempts made.
@@ -427,7 +428,7 @@ func TestShouldRetry(t *testing.T) {
 	}
 
 	restartPolicyAlways := v1beta2.RestartPolicy{
-		Type:                             v1beta2.Always,
+		Type: v1beta2.Always,
 		OnSubmissionFailureRetryInterval: int64ptr(100),
 		OnFailureRetryInterval:           int64ptr(100),
 	}
@@ -590,7 +591,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 
 	testFn := func(test testcase, t *testing.T) {
 		ctrl, _ := newFakeController(test.app)
-		_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(test.app.Namespace).Create(test.app)
+		_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(test.app.Namespace).Create(context.TODO(), test.app, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -605,7 +606,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 
 		err = ctrl.syncSparkApplication(fmt.Sprintf("%s/%s", test.app.Namespace, test.app.Name))
 		assert.Nil(t, err)
-		updatedApp, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(test.app.Namespace).Get(test.app.Name, metav1.GetOptions{})
+		updatedApp, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(test.app.Namespace).Get(context.TODO(), test.app.Name, metav1.GetOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, test.expectedState, updatedApp.Status.AppState.State)
 		if test.app.Status.AppState.State == v1beta2.NewState {
@@ -617,7 +618,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 	}
 
 	restartPolicyAlways := v1beta2.RestartPolicy{
-		Type:                             v1beta2.Always,
+		Type: v1beta2.Always,
 		OnSubmissionFailureRetryInterval: int64ptr(100),
 		OnFailureRetryInterval:           int64ptr(100),
 	}
@@ -1427,21 +1428,21 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 		app.Name = test.appName
 		app.Status.ExecutionAttempts = 1
 		ctrl, _ := newFakeController(app, test.driverPod, test.executorPod)
-		_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(app)
+		_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		if test.driverPod != nil {
-			ctrl.kubeClient.CoreV1().Pods(app.Namespace).Create(test.driverPod)
+			ctrl.kubeClient.CoreV1().Pods(app.Namespace).Create(context.TODO(), test.driverPod, metav1.CreateOptions{})
 		}
 		if test.executorPod != nil {
-			ctrl.kubeClient.CoreV1().Pods(app.Namespace).Create(test.executorPod)
+			ctrl.kubeClient.CoreV1().Pods(app.Namespace).Create(context.TODO(), test.executorPod, metav1.CreateOptions{})
 		}
 
 		err = ctrl.syncSparkApplication(fmt.Sprintf("%s/%s", app.Namespace, app.Name))
 		assert.Nil(t, err)
 		// Verify application and executor states.
-		updatedApp, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(app.Name, metav1.GetOptions{})
+		updatedApp, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), app.Name, metav1.GetOptions{})
 		assert.Equal(t, test.expectedAppState, updatedApp.Status.AppState.State)
 		assert.Equal(t, test.expectedExecutorState, updatedApp.Status.ExecutorState)
 
@@ -1510,14 +1511,14 @@ func TestSyncSparkApplication_ApplicationExpired(t *testing.T) {
 	}
 
 	ctrl, _ := newFakeController(app)
-	_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(app)
+	_, err := ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = ctrl.syncSparkApplication(fmt.Sprintf("%s/%s", app.Namespace, app.Name))
 	assert.Nil(t, err)
 
-	_, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(app.Name, metav1.GetOptions{})
+	_, err = ctrl.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Get(context.TODO(), app.Name, metav1.GetOptions{})
 	assert.True(t, errors.IsNotFound(err))
 }
 

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -428,7 +428,7 @@ func TestShouldRetry(t *testing.T) {
 	}
 
 	restartPolicyAlways := v1beta2.RestartPolicy{
-		Type: v1beta2.Always,
+		Type:                             v1beta2.Always,
 		OnSubmissionFailureRetryInterval: int64ptr(100),
 		OnFailureRetryInterval:           int64ptr(100),
 	}
@@ -618,7 +618,7 @@ func TestSyncSparkApplication_SubmissionSuccess(t *testing.T) {
 	}
 
 	restartPolicyAlways := v1beta2.RestartPolicy{
-		Type: v1beta2.Always,
+		Type:                             v1beta2.Always,
 		OnSubmissionFailureRetryInterval: int64ptr(100),
 		OnFailureRetryInterval:           int64ptr(100),
 	}

--- a/pkg/controller/sparkapplication/monitoring_config.go
+++ b/pkg/controller/sparkapplication/monitoring_config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -50,9 +51,9 @@ func configPrometheusMonitoring(app *v1beta2.SparkApplication, kubeClient client
 		configMapName := config.GetPrometheusConfigMapName(app)
 		configMap := buildPrometheusConfigMap(app, configMapName)
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			cm, err := kubeClient.CoreV1().ConfigMaps(app.Namespace).Get(configMapName, metav1.GetOptions{})
+			cm, err := kubeClient.CoreV1().ConfigMaps(app.Namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 			if apiErrors.IsNotFound(err) {
-				_, createErr := kubeClient.CoreV1().ConfigMaps(app.Namespace).Create(configMap)
+				_, createErr := kubeClient.CoreV1().ConfigMaps(app.Namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
 				return createErr
 			}
 			if err != nil {
@@ -60,7 +61,7 @@ func configPrometheusMonitoring(app *v1beta2.SparkApplication, kubeClient client
 			}
 
 			cm.Data = configMap.Data
-			_, updateErr := kubeClient.CoreV1().ConfigMaps(app.Namespace).Update(cm)
+			_, updateErr := kubeClient.CoreV1().ConfigMaps(app.Namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
 			return updateErr
 		})
 

--- a/pkg/controller/sparkapplication/monitoring_config_test.go
+++ b/pkg/controller/sparkapplication/monitoring_config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestConfigPrometheusMonitoring(t *testing.T) {
 		}
 
 		configMapName := config.GetPrometheusConfigMapName(test.app)
-		configMap, err := fakeClient.CoreV1().ConfigMaps(test.app.Namespace).Get(configMapName, metav1.GetOptions{})
+		configMap, err := fakeClient.CoreV1().ConfigMaps(test.app.Namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 		if err != nil {
 			t.Errorf("failed to get ConfigMap %s: %v", configMapName, err)
 		}
@@ -224,9 +225,9 @@ func TestConfigPrometheusMonitoring(t *testing.T) {
 				},
 			},
 			metricsPropertiesFile: "/testcase4dummy/metrics.properties",
-			port:                  "8091",
-			driverJavaOptions:     "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
-			executorJavaOptions:   "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
+			port:                "8091",
+			driverJavaOptions:   "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
+			executorJavaOptions: "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
 		},
 		{
 			app: &v1beta2.SparkApplication{

--- a/pkg/controller/sparkapplication/monitoring_config_test.go
+++ b/pkg/controller/sparkapplication/monitoring_config_test.go
@@ -225,9 +225,9 @@ func TestConfigPrometheusMonitoring(t *testing.T) {
 				},
 			},
 			metricsPropertiesFile: "/testcase4dummy/metrics.properties",
-			port:                "8091",
-			driverJavaOptions:   "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
-			executorJavaOptions: "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
+			port:                  "8091",
+			driverJavaOptions:     "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
+			executorJavaOptions:   "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -javaagent:/prometheus/exporter.jar=8091:testcase4dummy.yaml",
 		},
 		{
 			app: &v1beta2.SparkApplication{

--- a/pkg/controller/sparkapplication/sparkapp_metrics_test.go
+++ b/pkg/controller/sparkapplication/sparkapp_metrics_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package sparkapplication
 
 import (
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
 	"net/http"
 	"sync"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -115,7 +116,7 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 		ingress.Spec.TLS = ingressTlsHosts
 	}
 	glog.Infof("Creating an Ingress %s for the Spark UI for application %s", ingress.Name, app.Name)
-	_, err = kubeClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(&ingress)
+	_, err = kubeClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(context.TODO(), &ingress, metav1.CreateOptions{})
 
 	if err != nil {
 		return nil, err
@@ -166,7 +167,7 @@ func createSparkUIService(
 	}
 
 	glog.Infof("Creating a service %s for the Spark UI for application %s", service.Name, app.Name)
-	service, err = kubeClient.CoreV1().Services(app.Namespace).Create(service)
+	service, err = kubeClient.CoreV1().Services(app.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -53,7 +54,7 @@ func TestCreateSparkUIService(t *testing.T) {
 		}
 		service, err := fakeClient.CoreV1().
 			Services(test.app.Namespace).
-			Get(sparkService.serviceName, metav1.GetOptions{})
+			Get(context.TODO(), sparkService.serviceName, metav1.GetOptions{})
 		if err != nil {
 			if test.expectError {
 				return
@@ -259,7 +260,7 @@ func TestCreateSparkUIIngress(t *testing.T) {
 			t.Errorf("Ingress URL wanted %s got %s", test.expectedIngress.ingressURL, sparkIngress.ingressURL)
 		}
 		ingress, err := fakeClient.ExtensionsV1beta1().Ingresses(test.app.Namespace).
-			Get(sparkIngress.ingressName, metav1.GetOptions{})
+			Get(context.TODO(), sparkIngress.ingressName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -403,7 +403,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 	mutatingWebhooks := []v1beta1.MutatingWebhook{mutatingWebhook}
 	validatingWebhooks := []v1beta1.ValidatingWebhook{validatingWebhook}
 
-	mutatingExisting, mutatingGetErr := mwcClient.Get(webhookConfigName, metav1.GetOptions{})
+	mutatingExisting, mutatingGetErr := mwcClient.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
 	if mutatingGetErr != nil {
 		if !errors.IsNotFound(mutatingGetErr) {
 			return mutatingGetErr
@@ -416,7 +416,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 			},
 			Webhooks: mutatingWebhooks,
 		}
-		if _, err := mwcClient.Create(webhookConfig); err != nil {
+		if _, err := mwcClient.Create(context.TODO(), webhookConfig, metav1.CreateOptions{}); err != nil {
 			return err
 		}
 	} else {
@@ -424,14 +424,14 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 		glog.Info("Updating existing MutatingWebhookConfiguration for the Spark pod admission webhook")
 		if !equality.Semantic.DeepEqual(mutatingWebhooks, mutatingExisting.Webhooks) {
 			mutatingExisting.Webhooks = mutatingWebhooks
-			if _, err := mwcClient.Update(mutatingExisting); err != nil {
+			if _, err := mwcClient.Update(context.TODO(), mutatingExisting, metav1.UpdateOptions{}); err != nil {
 				return err
 			}
 		}
 	}
 
 	if wh.enableResourceQuotaEnforcement {
-		validatingExisting, validatingGetErr := vwcClient.Get(webhookConfigName, metav1.GetOptions{})
+		validatingExisting, validatingGetErr := vwcClient.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
 		if validatingGetErr != nil {
 			if !errors.IsNotFound(validatingGetErr) {
 				return validatingGetErr
@@ -444,7 +444,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 				},
 				Webhooks: validatingWebhooks,
 			}
-			if _, err := vwcClient.Create(webhookConfig); err != nil {
+			if _, err := vwcClient.Create(context.TODO(), webhookConfig, metav1.CreateOptions{}); err != nil {
 				return err
 			}
 
@@ -453,7 +453,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 			glog.Info("Updating existing ValidatingWebhookConfiguration for the SparkApplication resource quota enforcement webhook")
 			if !equality.Semantic.DeepEqual(validatingWebhooks, validatingExisting.Webhooks) {
 				validatingExisting.Webhooks = validatingWebhooks
-				if _, err := vwcClient.Update(validatingExisting); err != nil {
+				if _, err := vwcClient.Update(context.TODO(), validatingExisting, metav1.UpdateOptions{}); err != nil {
 					return err
 				}
 			}
@@ -466,12 +466,12 @@ func (wh *WebHook) selfDeregistration(webhookConfigName string) error {
 	mutatingConfigs := wh.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	validatingConfigs := wh.clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 	if wh.enableResourceQuotaEnforcement {
-		err := validatingConfigs.Delete(webhookConfigName, metav1.NewDeleteOptions(0))
+		err := validatingConfigs.Delete(context.TODO(), webhookConfigName, *metav1.NewDeleteOptions(0))
 		if err != nil {
 			return err
 		}
 	}
-	return mutatingConfigs.Delete(webhookConfigName, metav1.NewDeleteOptions(0))
+	return mutatingConfigs.Delete(context.TODO(), webhookConfigName, *metav1.NewDeleteOptions(0))
 }
 
 func admitSparkApplications(review *admissionv1beta1.AdmissionReview, enforcer resourceusage.ResourceQuotaEnforcer) (*admissionv1beta1.AdmissionResponse, error) {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -84,7 +85,7 @@ func TestMutatePod(t *testing.T) {
 			Namespace: "default",
 		},
 	}
-	crdClient.SparkoperatorV1beta2().SparkApplications(app1.Namespace).Create(app1)
+	crdClient.SparkoperatorV1beta2().SparkApplications(app1.Namespace).Create(context.TODO(), app1, metav1.CreateOptions{})
 	informer.Informer().GetIndexer().Add(app1)
 	pod1.Labels = map[string]string{
 		config.SparkRoleLabel:               config.SparkDriverRole,
@@ -160,7 +161,7 @@ func TestMutatePod(t *testing.T) {
 			},
 		},
 	}
-	crdClient.SparkoperatorV1beta2().SparkApplications(app2.Namespace).Update(app2)
+	crdClient.SparkoperatorV1beta2().SparkApplications(app2.Namespace).Update(context.TODO(), app2, metav1.UpdateOptions{})
 	informer.Informer().GetIndexer().Add(app2)
 
 	pod1.Labels[config.SparkAppNameLabel] = app2.Name

--- a/sparkctl/cmd/client.go
+++ b/sparkctl/cmd/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +69,7 @@ func getSparkApplicationClientForConfig(config *rest.Config) (crdclientset.Inter
 }
 
 func getSparkApplication(name string, crdClientset crdclientset.Interface) (*v1beta2.SparkApplication, error) {
-	app, err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Get(name, metav1.GetOptions{})
+	app, err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/sparkctl/cmd/create.go
+++ b/sparkctl/cmd/create.go
@@ -117,7 +117,7 @@ func createFromYaml(yamlFile string, kubeClient clientset.Interface, crdClient c
 }
 
 func createFromScheduledSparkApplication(name string, kubeClient clientset.Interface, crdClient crdclientset.Interface) error {
-	sapp, err := crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(Namespace).Get(From, metav1.GetOptions{})
+	sapp, err := crdClient.SparkoperatorV1beta2().ScheduledSparkApplications(Namespace).Get(context.TODO(), From, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get ScheduledSparkApplication %s: %v", From, err)
 	}
@@ -162,7 +162,7 @@ func createSparkApplication(app *v1beta2.SparkApplication, kubeClient clientset.
 		}
 	}
 
-	if _, err := crdClient.SparkoperatorV1beta2().SparkApplications(Namespace).Create(app); err != nil {
+	if _, err := crdClient.SparkoperatorV1beta2().SparkApplications(Namespace).Create(context.TODO(), app, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
@@ -409,12 +409,12 @@ func handleHadoopConfiguration(
 			hadoopConfDir, err)
 	}
 
-	err = kubeClientset.CoreV1().ConfigMaps(Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
+	err = kubeClientset.CoreV1().ConfigMaps(Namespace).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete existing ConfigMap %s: %v", configMap.Name, err)
 	}
 
-	if configMap, err = kubeClientset.CoreV1().ConfigMaps(Namespace).Create(configMap); err != nil {
+	if configMap, err = kubeClientset.CoreV1().ConfigMaps(Namespace).Create(context.TODO(), configMap, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create ConfigMap %s: %v", configMap.Name, err)
 	}
 

--- a/sparkctl/cmd/delete.go
+++ b/sparkctl/cmd/delete.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -50,7 +51,7 @@ var deleteCmd = &cobra.Command{
 }
 
 func doDelete(name string, crdClientset crdclientset.Interface) error {
-	err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Delete(name, &metav1.DeleteOptions{})
+	err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}

--- a/sparkctl/cmd/event.go
+++ b/sparkctl/cmd/event.go
@@ -83,7 +83,7 @@ func doShowEvents(name string, crdClientset crdclientset.Interface, kubeClientse
 		// watch for all events for this specific SparkApplication name
 		selector := eventsInterface.GetFieldSelector(&app.Name, &app.Namespace, &app.Kind, nil)
 		options := metav1.ListOptions{FieldSelector: selector.String(), Watch: true}
-		events, err := eventsInterface.Watch(options)
+		events, err := eventsInterface.Watch(context.TODO(), options)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func doShowEvents(name string, crdClientset crdclientset.Interface, kubeClientse
 		stringUID := string(app.UID)
 		selector := eventsInterface.GetFieldSelector(&app.Name, &app.Namespace, &app.Kind, &stringUID)
 		options := metav1.ListOptions{FieldSelector: selector.String()}
-		events, err := eventsInterface.List(options)
+		events, err := eventsInterface.List(context.TODO(), options)
 		if err != nil {
 			return err
 		}

--- a/sparkctl/cmd/forward.go
+++ b/sparkctl/cmd/forward.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -152,7 +153,7 @@ func runPortForward(
 	go func() {
 		defer close(stopCh)
 		for {
-			pod, err := kubeClientset.CoreV1().Pods(Namespace).Get(driverPodName, metav1.GetOptions{})
+			pod, err := kubeClientset.CoreV1().Pods(Namespace).Get(context.TODO(), driverPodName, metav1.GetOptions{})
 			if err != nil {
 				break
 			}

--- a/sparkctl/cmd/list.go
+++ b/sparkctl/cmd/list.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -46,7 +47,7 @@ var listCmd = &cobra.Command{
 }
 
 func doList(crdClientset crdclientset.Interface) error {
-	apps, err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).List(metav1.ListOptions{})
+	apps, err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/sparkctl/cmd/log.go
+++ b/sparkctl/cmd/log.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -69,7 +70,7 @@ func init() {
 }
 
 func doLog(name string, kubeClientset clientset.Interface, crdClientset crdclientset.Interface) error {
-	app, err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Get(name, metav1.GetOptions{})
+	app, err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get SparkApplication %s: %v", name, err)
 	}
@@ -102,7 +103,7 @@ func doLog(name string, kubeClientset clientset.Interface, crdClientset crdclien
 
 // printLogs is a one time operation that prints the fetched logs of the given pod.
 func printLogs(out io.Writer, kubeClientset clientset.Interface, podName string) error {
-	rawLogs, err := kubeClientset.CoreV1().Pods(Namespace).GetLogs(podName, &apiv1.PodLogOptions{}).Do().Raw()
+	rawLogs, err := kubeClientset.CoreV1().Pods(Namespace).GetLogs(podName, &apiv1.PodLogOptions{}).Do(context.TODO()).Raw()
 	if err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func printLogs(out io.Writer, kubeClientset clientset.Interface, podName string)
 // streamLogs streams the logs of the given pod until there are no more logs available.
 func streamLogs(out io.Writer, kubeClientset clientset.Interface, podName string) error {
 	request := kubeClientset.CoreV1().Pods(Namespace).GetLogs(podName, &apiv1.PodLogOptions{Follow: true})
-	reader, err := request.Stream()
+	reader, err := request.Stream(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestSubmitSparkPiYaml(t *testing.T) {
 
 	app, _ := appFramework.GetSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, appName)
 	podName := app.Status.DriverInfo.PodName
-	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do().Raw()
+	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, -1, strings.Index(string(rawLogs), "Pi is roughly 3"))
 
@@ -106,7 +107,7 @@ func TestSubmitSparkPiCustomResourceYaml(t *testing.T) {
 
 	app, _ := appFramework.GetSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, appName)
 	podName := app.Status.DriverInfo.PodName
-	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do().Raw()
+	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, -1, strings.Index(string(rawLogs), "Pi is roughly 3"))
 

--- a/test/e2e/framework/cluster_role.go
+++ b/test/e2e/framework/cluster_role.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -34,18 +35,18 @@ func CreateClusterRole(kubeClient kubernetes.Interface, relativePath string) err
 		return err
 	}
 
-	_, err = kubeClient.RbacV1().ClusterRoles().Get(clusterRole.Name, metav1.GetOptions{})
+	_, err = kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), clusterRole.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// ClusterRole already exists -> Update
-		_, err = kubeClient.RbacV1().ClusterRoles().Update(clusterRole)
+		_, err = kubeClient.RbacV1().ClusterRoles().Update(context.TODO(), clusterRole, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
 
 	} else {
 		// ClusterRole doesn't exists -> Create
-		_, err = kubeClient.RbacV1().ClusterRoles().Create(clusterRole)
+		_, err = kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -60,7 +61,7 @@ func DeleteClusterRole(kubeClient kubernetes.Interface, relativePath string) err
 		return err
 	}
 
-	if err := kubeClient.RbacV1().ClusterRoles().Delete(clusterRole.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := kubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), clusterRole.Name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/test/e2e/framework/cluster_role_binding.go
+++ b/test/e2e/framework/cluster_role_binding.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -37,17 +38,17 @@ func CreateClusterRoleBinding(kubeClient kubernetes.Interface, relativePath stri
 		return finalizerFn, err
 	}
 
-	_, err = kubeClient.RbacV1().ClusterRoleBindings().Get(clusterRoleBinding.Name, metav1.GetOptions{})
+	_, err = kubeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), clusterRoleBinding.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// ClusterRoleBinding already exists -> Update
-		_, err = kubeClient.RbacV1().ClusterRoleBindings().Update(clusterRoleBinding)
+		_, err = kubeClient.RbacV1().ClusterRoleBindings().Update(context.TODO(), clusterRoleBinding, metav1.UpdateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
 	} else {
 		// ClusterRoleBinding doesn't exists -> Create
-		_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(clusterRoleBinding)
+		_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
@@ -62,7 +63,7 @@ func DeleteClusterRoleBinding(kubeClient kubernetes.Interface, relativePath stri
 		return err
 	}
 
-	if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(clusterRoleBinding.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), clusterRoleBinding.Name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/test/e2e/framework/config_map.go
+++ b/test/e2e/framework/config_map.go
@@ -17,7 +17,9 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,17 +36,17 @@ func CreateConfigMap(kubeClient kubernetes.Interface, name string, namespace str
 		},
 	}
 
-	_, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+	_, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 
 	if err == nil {
 		// ConfigMap already exists -> Update
-		configMap, err = kubeClient.CoreV1().ConfigMaps(namespace).Update(configMap)
+		configMap, err = kubeClient.CoreV1().ConfigMaps(namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		// ConfigMap doesn't exists -> Create
-		configMap, err = kubeClient.CoreV1().ConfigMaps(namespace).Create(configMap)
+		configMap, err = kubeClient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -57,5 +59,5 @@ func CreateConfigMap(kubeClient kubernetes.Interface, name string, namespace str
 }
 
 func DeleteConfigMap(kubeClient kubernetes.Interface, name string, namespace string) error {
-	return kubeClient.CoreV1().ConfigMaps(namespace).Delete(name, &metav1.DeleteOptions{})
+	return kubeClient.CoreV1().ConfigMaps(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -174,7 +175,7 @@ func (f *Framework) setupOperator(sparkNs, opImage string, opImagePullPolicy str
 		return errors.Wrap(err, "failed to wait for operator to become ready")
 	}
 
-	pl, err := f.KubeClient.CoreV1().Pods(f.Namespace.Name).List(opts)
+	pl, err := f.KubeClient.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), opts)
 	if err != nil {
 		return err
 	}
@@ -192,7 +193,7 @@ func (f *Framework) Teardown() error {
 		return errors.Wrap(err, "failed to delete operator cluster role binding")
 	}
 
-	if err := f.KubeClient.AppsV1().Deployments(f.Namespace.Name).Delete("sparkoperator", nil); err != nil {
+	if err := f.KubeClient.AppsV1().Deployments(f.Namespace.Name).Delete(context.TODO(), "sparkoperator", metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -51,7 +52,7 @@ func PathToOSFile(relativPath string) (*os.File, error) {
 // container to pass its readiness check.
 func WaitForPodsReady(kubeClient kubernetes.Interface, namespace string, timeout time.Duration, expectedReplicas int, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
-		pl, err := kubeClient.CoreV1().Pods(namespace).List(opts)
+		pl, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), opts)
 		if err != nil {
 			return false, err
 		}
@@ -77,7 +78,7 @@ func WaitForPodsReady(kubeClient kubernetes.Interface, namespace string, timeout
 
 func WaitForPodsRunImage(kubeClient kubernetes.Interface, namespace string, expectedReplicas int, image string, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		pl, err := kubeClient.CoreV1().Pods(namespace).List(opts)
+		pl, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), opts)
 		if err != nil {
 			return false, err
 		}
@@ -130,7 +131,7 @@ func GetLogs(kubeClient kubernetes.Interface, namespace string, podName, contain
 		Namespace(namespace).
 		Name(podName).SubResource("log").
 		Param("container", containerName).
-		Do().
+		Do(context.TODO()).
 		Raw()
 	if err != nil {
 		return "", err

--- a/test/e2e/framework/namespace.go
+++ b/test/e2e/framework/namespace.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,11 +28,11 @@ import (
 )
 
 func CreateNamespace(kubeClient kubernetes.Interface, name string) (*v1.Namespace, error) {
-	namespace, err := kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
+	namespace, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-	})
+	}, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to create namespace with name %v", name))
 	}
@@ -57,5 +58,5 @@ func (ctx *TestCtx) CreateNamespace(t *testing.T, kubeClient kubernetes.Interfac
 }
 
 func DeleteNamespace(kubeClient kubernetes.Interface, name string) error {
-	return kubeClient.CoreV1().Namespaces().Delete(name, nil)
+	return kubeClient.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
 }

--- a/test/e2e/framework/role.go
+++ b/test/e2e/framework/role.go
@@ -17,14 +17,16 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"os"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
-	"os"
 )
 
 func CreateRole(kubeClient kubernetes.Interface, ns string, relativePath string) error {
@@ -33,18 +35,18 @@ func CreateRole(kubeClient kubernetes.Interface, ns string, relativePath string)
 		return err
 	}
 
-	_, err = kubeClient.RbacV1().Roles(ns).Get(role.Name, metav1.GetOptions{})
+	_, err = kubeClient.RbacV1().Roles(ns).Get(context.TODO(), role.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// Role already exists -> Update
-		_, err = kubeClient.RbacV1().Roles(ns).Update(role)
+		_, err = kubeClient.RbacV1().Roles(ns).Update(context.TODO(), role, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
 
 	} else {
 		// Role doesn't exists -> Create
-		_, err = kubeClient.RbacV1().Roles(ns).Create(role)
+		_, err = kubeClient.RbacV1().Roles(ns).Create(context.TODO(), role, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -59,7 +61,7 @@ func DeleteRole(kubeClient kubernetes.Interface, ns string, relativePath string)
 		return err
 	}
 
-	if err := kubeClient.RbacV1().Roles(ns).Delete(role.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := kubeClient.RbacV1().Roles(ns).Delete(context.TODO(), role.Name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/test/e2e/framework/role_binding.go
+++ b/test/e2e/framework/role_binding.go
@@ -17,14 +17,16 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"os"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
-	"os"
 )
 
 func CreateRoleBinding(kubeClient kubernetes.Interface, ns string, relativePath string) (finalizerFn, error) {
@@ -38,17 +40,17 @@ func CreateRoleBinding(kubeClient kubernetes.Interface, ns string, relativePath 
 
 	roleBinding.Namespace = ns
 
-	_, err = kubeClient.RbacV1().RoleBindings(ns).Get(roleBinding.Name, metav1.GetOptions{})
+	_, err = kubeClient.RbacV1().RoleBindings(ns).Get(context.TODO(), roleBinding.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// RoleBinding already exists -> Update
-		_, err = kubeClient.RbacV1().RoleBindings(ns).Update(roleBinding)
+		_, err = kubeClient.RbacV1().RoleBindings(ns).Update(context.TODO(), roleBinding, metav1.UpdateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
 	} else {
 		// RoleBinding doesn't exists -> Create
-		_, err = kubeClient.RbacV1().RoleBindings(ns).Create(roleBinding)
+		_, err = kubeClient.RbacV1().RoleBindings(ns).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
@@ -63,7 +65,7 @@ func DeleteRoleBinding(kubeClient kubernetes.Interface, ns string, relativePath 
 		return err
 	}
 
-	if err := kubeClient.RbacV1().RoleBindings(ns).Delete(roleBinding.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := kubeClient.RbacV1().RoleBindings(ns).Delete(context.TODO(), roleBinding.Name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -17,13 +17,15 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"os"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -43,17 +45,17 @@ func CreateService(kubeClient kubernetes.Interface, ns string, relativePath stri
 
 	service.Namespace = ns
 
-	_, err = kubeClient.CoreV1().Services(ns).Get(service.Name, metav1.GetOptions{})
+	_, err = kubeClient.CoreV1().Services(ns).Get(context.TODO(), service.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// Service already exists -> Update
-		_, err = kubeClient.CoreV1().Services(ns).Update(service)
+		_, err = kubeClient.CoreV1().Services(ns).Update(context.TODO(), service, metav1.UpdateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
 	} else {
 		// Service doesn't exists -> Create
-		_, err = kubeClient.CoreV1().Services(ns).Create(service)
+		_, err = kubeClient.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
@@ -77,7 +79,7 @@ func WaitForServiceReady(kubeClient kubernetes.Interface, namespace string, serv
 }
 
 func getEndpoints(kubeClient kubernetes.Interface, namespace, serviceName string) (*v1.Endpoints, error) {
-	endpoints, err := kubeClient.CoreV1().Endpoints(namespace).Get(serviceName, metav1.GetOptions{})
+	endpoints, err := kubeClient.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("requesting endpoints for servce %v failed", serviceName))
 	}
@@ -117,5 +119,5 @@ func parseServiceYaml(relativePath string) (*v1.Service, error) {
 }
 
 func DeleteService(kubeClient kubernetes.Interface, name string, namespace string) error {
-	return kubeClient.CoreV1().Services(namespace).Delete(name, &metav1.DeleteOptions{})
+	return kubeClient.CoreV1().Services(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }

--- a/test/e2e/framework/service_account.go
+++ b/test/e2e/framework/service_account.go
@@ -17,11 +17,13 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
@@ -37,7 +39,7 @@ func CreateServiceAccount(kubeClient kubernetes.Interface, namespace string, rel
 		return finalizerFn, err
 	}
 	serviceAccount.Namespace = namespace
-	_, err = kubeClient.CoreV1().ServiceAccounts(namespace).Create(serviceAccount)
+	_, err = kubeClient.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
 	if err != nil {
 		return finalizerFn, err
 	}
@@ -83,5 +85,5 @@ func DeleteServiceAccount(kubeClient kubernetes.Interface, namespace string, rel
 		return err
 	}
 
-	return kubeClient.CoreV1().ServiceAccounts(namespace).Delete(serviceAccount.Name, nil)
+	return kubeClient.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), serviceAccount.Name, metav1.DeleteOptions{})
 }

--- a/test/e2e/framework/sparkapplication.go
+++ b/test/e2e/framework/sparkapplication.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -42,7 +43,7 @@ func MakeSparkApplicationFromYaml(pathToYaml string) (*v1beta2.SparkApplication,
 }
 
 func CreateSparkApplication(crdclientset crdclientset.Interface, namespace string, sa *v1beta2.SparkApplication) error {
-	_, err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Create(sa)
+	_, err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to create SparkApplication %s", sa.Name))
 	}
@@ -50,7 +51,7 @@ func CreateSparkApplication(crdclientset crdclientset.Interface, namespace strin
 }
 
 func UpdateSparkApplication(crdclientset crdclientset.Interface, namespace string, sa *v1beta2.SparkApplication) error {
-	_, err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Update(sa)
+	_, err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Update(context.TODO(), sa, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to update SparkApplication %s", sa.Name))
 	}
@@ -58,7 +59,7 @@ func UpdateSparkApplication(crdclientset crdclientset.Interface, namespace strin
 }
 
 func GetSparkApplication(crdclientset crdclientset.Interface, namespace, name string) (*v1beta2.SparkApplication, error) {
-	sa, err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Get(name, metav1.GetOptions{})
+	sa, err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +67,7 @@ func GetSparkApplication(crdclientset crdclientset.Interface, namespace, name st
 }
 
 func DeleteSparkApplication(crdclientset crdclientset.Interface, namespace, name string) error {
-	err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Delete(name, &metav1.DeleteOptions{})
+	err := crdclientset.SparkoperatorV1beta2().SparkApplications(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"container/list"
+	"context"
 	"strings"
 	"testing"
 
@@ -94,7 +95,7 @@ func runApp(t *testing.T, appName string, states *list.List) *v1beta2.SparkAppli
 
 	app, _ := appFramework.GetSparkApplication(framework.SparkApplicationClient, appFramework.SparkTestNamespace, appName)
 	podName := app.Status.DriverInfo.PodName
-	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do().Raw()
+	rawLogs, err := framework.KubeClient.CoreV1().Pods(appFramework.SparkTestNamespace).GetLogs(podName, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, -1, strings.Index(string(rawLogs), "Pi is roughly 3"))
 

--- a/test/e2e/volume_mount_test.go
+++ b/test/e2e/volume_mount_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/describe"
-	"k8s.io/kubectl/pkg/describe/versioned"
 
 	appFramework "github.com/GoogleCloudPlatform/spark-on-k8s-operator/test/e2e/framework"
 )
@@ -79,7 +78,7 @@ func TestMountConfigMap(t *testing.T) {
 	podName := app.Status.DriverInfo.PodName
 
 	describeClient := &describeClient{T: t, Namespace: appFramework.SparkTestNamespace, Interface: framework.KubeClient}
-	describer := versioned.PodDescriber{describeClient}
+	describer := describe.PodDescriber{describeClient}
 
 	podDesc, err := describer.Describe(appFramework.SparkTestNamespace, podName, describe.DescriberSettings{ShowEvents: true})
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
- Add context to k8s and crd API templates
- Volcano client version up to v1.1.0
- Prometheus client version up to v1.0.0

In this version, `context` must be entered as a parameter to call k8s client.
Currently I used `context.TODO()`, if any better opinions on this, please review

I'm using kubernetes v1.19.2 and I have checked this operator working.
But I need more check running in older cluster.
Let me know any checklist according to the version change, I will test it. 