### PR TITLE
update executor status if pod is lost while app is still running

### DIFF
--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -1419,6 +1419,29 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 				successMetricCount: 1,
 			},
 		},
+		{
+			appName:           appName,
+			oldAppStatus:      v1beta2.RunningState,
+			oldExecutorStatus: map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorRunningState},
+			driverPod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverPodName,
+					Namespace: "test",
+					Labels: map[string]string{
+						config.SparkRoleLabel:    config.SparkDriverRole,
+						config.SparkAppNameLabel: appName,
+					},
+					ResourceVersion: "1",
+				},
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodRunning,
+				},
+			},
+			expectedAppState:        v1beta2.RunningState,
+			expectedExecutorState:   map[string]v1beta2.ExecutorState{"exec-1": v1beta2.ExecutorUnknownState},
+			expectedAppMetrics:      metrics{},
+			expectedExecutorMetrics: executorMetrics{},
+		},
 	}
 
 	testFn := func(test testcase, t *testing.T) {


### PR DESCRIPTION
Hello,

This PR is related to issue #1076

Following the discussion on this issue, it seems that we can change the status of lost pods to `unknown` while the app is still `running`
Then once the driver pod is terminated, we fall back to the current implementation 
