### PR TITLE
Support Prometheus PodMonitor Deployment (#1106)

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -66,10 +66,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | metrics.enable | bool | `true` | Enable prometheus mertic scraping |
 | metrics.endpoint | string | `"/metrics"` | Metrics serving endpoint |
 | metrics.port | int | `10254` | Metrics port |
+| metrics.portName | string | `metrics` | Metrics port name |
 | metrics.prefix | string | `""` | Metric prefix, will be added to all exported metrics |
 | nameOverride | string | `""` | String to partially override `spark-operator.fullname` template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Additional annotations to add to the pod |
+| podMonitor.enable | bool| `false` | Submit a prometheus pod monitor for operator's pod. Note that prometheus metrics should be enabled as well.|
+| podMonitor.labels | object | `{}` | Pod monitor labels |
+| podMonitor.jobLabel | string | `spark-operator-podmonitor` | The label to use to retrieve the job name from |
+| podMonitor.podMetricsEndpoint.scheme | string | `http` | Prometheus metrics endpoint scheme |
+| podMonitor.podMetricsEndpoint.interval | string | `5s` | Interval at which metrics should be scraped |
 | podSecurityContext | object | `{}` | Pod security context |
 | rbac.create | bool | `true` | Create and use `rbac` resources |
 | replicaCount | int | `1` | Desired number of pods, leaderElection will be enabled if this is greater than 1 |

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           {{- toYaml .Values.securityContext | nindent 10 }}
         {{- if .Values.metrics.enable }}
         ports:
-          - name: metrics
+          - name: {{ .Values.metrics.portName | quote }}
             containerPort: {{ .Values.metrics.port }}
         {{ end }}
         args:

--- a/charts/spark-operator-chart/templates/prometheus-podmonitor.yaml
+++ b/charts/spark-operator-chart/templates/prometheus-podmonitor.yaml
@@ -1,0 +1,19 @@
+{{ if and .Values.metrics.enable .Values.podMonitor.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "spark-operator.name" . -}}-podmonitor
+  labels: {{ toYaml .Values.podMonitor.labels | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+    - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
+      port: {{ .Values.metrics.portName | quote }}
+      scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
+  jobLabel: {{ .Values.podMonitor.jobLabel }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "spark-operator.selectorLabels" . | nindent 6 }}
+{{ end }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -75,10 +75,25 @@ metrics:
   enable: true
   # -- Metrics port
   port: 10254
+  # -- Metrics port name
+  portName: metrics
   # -- Metrics serving endpoint
   endpoint: /metrics
   # -- Metric prefix, will be added to all exported metrics
   prefix: ""
+
+# -- Prometheus pod monitor for operator's pod.
+podMonitor:
+  # -- If enabled, a pod monitor for operator's pod will be submitted. Note that prometheus metrics should be enabled as well.
+  enable: false
+  # -- Pod monitor labels
+  labels: {}
+  # -- The label to use to retrieve the job name from
+  jobLabel: spark-operator-podmonitor
+  # -- Prometheus metrics endpoint properties. `metrics.portName` will be used as a port
+  podMetricsEndpoint:
+    scheme: http
+    interval: 5s
 
 # nodeSelector -- Node labels for pod assignment
 nodeSelector: {}

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -173,7 +173,7 @@ A Spark driver pod need a Kubernetes service account in the pod's namespace that
 
 ## Enable Metric Exporting to Prometheus
 
-The operator exposes a set of metrics via the metric endpoint to be scraped by `Prometheus`. The Helm chart by default installs the operator with the additional flag to enable metrics (`-enable-metrics=true`) as well as other annotations used by Prometheus to scrape the metric endpoint. To install the operator  **without** metrics enabled, pass the appropriate flag during `helm install`:
+The operator exposes a set of metrics via the metric endpoint to be scraped by `Prometheus`. The Helm chart by default installs the operator with the additional flag to enable metrics (`-enable-metrics=true`) as well as other annotations used by Prometheus to scrape the metric endpoint. If `podMonitor.enable` is enabled, the helm chart will submit a pod monitor for the operator's pod. To install the operator  **without** metrics enabled, pass the appropriate flag during `helm install`:
 
 ```bash
 $ helm install my-release spark-operator/spark-operator --namespace spark-operator --set metrics.enable=false


### PR DESCRIPTION
* Supported Prometheus monitoring via pod monitor for the Spark operator's pod.
* Added Prometheus `metrics.portName` to use it for `podMonitor.podMetricsEndpoint` configuration, becuse `targetPort` has been deprecated by Prometheus.