### PR TITLE
Upgrade the Chart version to 1.0.4

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.0.3
+version: 1.0.4
 appVersion: v1beta2-1.2.0-3.0.0
 keywords:
   - spark


### PR DESCRIPTION
Upgraded the Chart version missed in [PR #1112](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1112).