### PR TITLE
add hostAliases for SparkPodSpec

### DIFF
--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -508,6 +508,17 @@ spec:
                       - name
                       - quantity
                       type: object
+                    hostAliases:
+                      items:
+                        properties:
+                          hostnames:
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            type: string
+                        type: object
+                      type: array
                     hostNetwork:
                       type: boolean
                     image:
@@ -2307,6 +2318,17 @@ spec:
                       - name
                       - quantity
                       type: object
+                    hostAliases:
+                      items:
+                        properties:
+                          hostnames:
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            type: string
+                        type: object
+                      type: array
                     hostNetwork:
                       type: boolean
                     image:

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -494,6 +494,17 @@ spec:
                   - name
                   - quantity
                   type: object
+                hostAliases:
+                  items:
+                    properties:
+                      hostnames:
+                        items:
+                          type: string
+                        type: array
+                      ip:
+                        type: string
+                    type: object
+                  type: array
                 hostNetwork:
                   type: boolean
                 image:
@@ -2293,6 +2304,17 @@ spec:
                   - name
                   - quantity
                   type: object
+                hostAliases:
+                  items:
+                    properties:
+                      hostnames:
+                        items:
+                          type: string
+                        type: array
+                      ip:
+                        type: string
+                    type: object
+                  type: array
                 hostNetwork:
                   type: boolean
                 image:

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2780,6 +2780,20 @@ string
 <p>ServiceAccount is the name of the custom Kubernetes service account used by the pod.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>hostAliases</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#hostalias-v1-core">
+[]Kubernetes core/v1.HostAlias
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HostAliases settings for the pod, following the Kubernetes specifications.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.SparkUIConfiguration">SparkUIConfiguration

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -515,6 +515,9 @@ type SparkPodSpec struct {
 	// ServiceAccount is the name of the custom Kubernetes service account used by the pod.
 	// +optional
 	ServiceAccount *string `json:"serviceAccount,omitempty"`
+	// HostAliases settings for the pod, following the Kubernetes specifications.
+	// +optional
+	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty"`
 }
 
 // DriverSpec is specification of the driver.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -940,6 +940,13 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Hello,

This PR addresses issue #981

Since I didn't know which CRDs are now actively maintained between the one in `charts/spark-operator-chart` and `manifest`
I've decided to prioritized the one in `charts`, don't hesitate to tell me if it's not the correct choice