### PR TITLE
Helm: Put service account into pre-install hook.

### DIFF
--- a/charts/spark-operator-chart/templates/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/serviceaccount.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-operator.serviceAccountName" . }}
+  annotations:
+    "helm.sh/hook": pre-install
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This enables users to install the chart using ArgoCD without setting special values.

This solves #1143 without requiring setting special undocumented values in values.yaml like the PR #1145 requires.