### PR TITLE
fix: Remove priority from the spec when using priority class

### DIFF
--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -822,6 +822,7 @@ func TestPatchSparkPod_PriorityClassName(t *testing.T) {
 	//Driver priorityClassName should be populated when specified
 	assert.Equal(t, priorityClassName, modifiedDriverPod.Spec.PriorityClassName)
 
+	var defaultPriority int32 = 0
 	executorPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "spark-executor",
@@ -837,6 +838,7 @@ func TestPatchSparkPod_PriorityClassName(t *testing.T) {
 					Image: "spark-executor:latest",
 				},
 			},
+			Priority: &defaultPriority,
 		},
 	}
 
@@ -846,6 +848,7 @@ func TestPatchSparkPod_PriorityClassName(t *testing.T) {
 	}
 	//Executor priorityClassName should also be populated when specified in SparkApplicationSpec
 	assert.Equal(t, priorityClassName, modifiedExecutorPod.Spec.PriorityClassName)
+	assert.Nil(t, modifiedExecutorPod.Spec.Priority)
 }
 
 func TestPatchSparkPod_Sidecars(t *testing.T) {


### PR DESCRIPTION
By default pods created by kube will have a priority of 0 set in their
spec, or the value of the PriorityClass acting as a `globalDefault`.
When using the `batchSchedulerOptions.priorityClassName` the spec was
mutated by adding the `priorityClassName` to the spec, but the
`priority` was left unchanged.

This caused an error 
```
the integer value of priority (0) must not be
provided in pod spec; priority admission controller computed X from
the given PriorityClass name.
```
(where X is the priority associated to the PrioritClass kube object)

The patcher now properly remove the existing priority when a
priorityClassName is applied, letting kube apply the correct priority to 
the executor and driver pods.

See https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1054