### PR TITLE
Add support to expose custom ports

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.0.7
+version: 1.0.8
 appVersion: v1beta2-1.2.0-3.0.0
 keywords:
   - spark

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2946,5 +2946,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>1947244</code>.
+on git commit <code>2b4a398</code>.
 </em></p>

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1046,6 +1046,20 @@ map[string]string
 executors to connect to the driver.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#sparkoperator.k8s.io/v1beta2.Port">
+[]Port
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ports settings for the pods, following the Kubernetes specifications.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.DriverState">DriverState
@@ -1214,6 +1228,20 @@ bool
 <em>(Optional)</em>
 <p>DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination.
 Maps to <code>spark.kubernetes.executor.deleteOnTermination</code> that is available since Spark 3.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#sparkoperator.k8s.io/v1beta2.Port">
+[]Port
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ports settings for the pods, following the Kubernetes specifications.</p>
 </td>
 </tr>
 </tbody>
@@ -1430,7 +1458,8 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sparkoperator.k8s.io/v1beta2.SparkPodSpec">SparkPodSpec</a>)
+<a href="#sparkoperator.k8s.io/v1beta2.DriverSpec">DriverSpec</a>, 
+<a href="#sparkoperator.k8s.io/v1beta2.ExecutorSpec">ExecutorSpec</a>)
 </p>
 <p>
 <p>Port represents the port definition in the pods objects.</p>
@@ -2855,20 +2884,6 @@ string
 <p>HostAliases settings for the pod, following the Kubernetes specifications.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>ports</code></br>
-<em>
-<a href="#sparkoperator.k8s.io/v1beta2.Port">
-[]Port
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Ports settings for the pods, following the Kubernetes specifications.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.SparkUIConfiguration">SparkUIConfiguration
@@ -2946,5 +2961,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>2b4a398</code>.
+on git commit <code>2f6a3f9</code>.
 </em></p>

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -719,8 +719,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>PriorityClassName stands for the name of k8s PriorityClass resource, it&rsquo;s being used for job scheduling and 
-preemption, whether with the Volcano batch scheduler or the Kubernetes default scheduler.</p>
+<p>PriorityClassName stands for the name of k8s PriorityClass resource, it&rsquo;s being used in Volcano batch scheduler.</p>
 </td>
 </tr>
 <tr>
@@ -1427,6 +1426,55 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="sparkoperator.k8s.io/v1beta2.Port">Port
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sparkoperator.k8s.io/v1beta2.SparkPodSpec">SparkPodSpec</a>)
+</p>
+<p>
+<p>Port represents the port definition in the pods objects.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="sparkoperator.k8s.io/v1beta2.PrometheusSpec">PrometheusSpec
 </h3>
 <p>
@@ -1467,6 +1515,19 @@ int32
 <em>(Optional)</em>
 <p>Port is the port of the HTTP server run by the Prometheus JMX exporter.
 If not specified, 8090 will be used as the default.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>portName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PortName is the port name of prometheus JMX exporter port.
+If not specified, jmx-exporter will be used as the default.</p>
 </td>
 </tr>
 <tr>
@@ -2794,6 +2855,20 @@ string
 <p>HostAliases settings for the pod, following the Kubernetes specifications.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#sparkoperator.k8s.io/v1beta2.Port">
+[]Port
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ports settings for the pods, following the Kubernetes specifications.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.SparkUIConfiguration">SparkUIConfiguration
@@ -2828,6 +2903,20 @@ TargetPort should be the same as the one defined in spark.ui.port</p>
 </tr>
 <tr>
 <td>
+<code>serviceType</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicetype-v1-core">
+Kubernetes core/v1.ServiceType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceType allows configuring the type of the service. Defaults to ClusterIP.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ingressAnnotations</code></br>
 <em>
 map[string]string
@@ -2857,5 +2946,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>cf34460</code>.
+on git commit <code>1947244</code>.
 </em></p>

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -518,9 +518,6 @@ type SparkPodSpec struct {
 	// HostAliases settings for the pod, following the Kubernetes specifications.
 	// +optional
 	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty"`
-	// Ports settings for the pods, following the Kubernetes specifications.
-	// +optional
-	Ports []Port `json:"ports,omitempty"`
 }
 
 // DriverSpec is specification of the driver.
@@ -552,6 +549,9 @@ type DriverSpec struct {
 	// executors to connect to the driver.
 	// +optional
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
+	// Ports settings for the pods, following the Kubernetes specifications.
+	// +optional
+	Ports []Port `json:"ports,omitempty"`
 }
 
 // ExecutorSpec is specification of the executor.
@@ -573,6 +573,9 @@ type ExecutorSpec struct {
 	// Maps to `spark.kubernetes.executor.deleteOnTermination` that is available since Spark 3.0.
 	// +optional
 	DeleteOnTermination *bool `json:"deleteOnTermination,omitempty"`
+	// Ports settings for the pods, following the Kubernetes specifications.
+	// +optional
+	Ports []Port `json:"ports,omitempty"`
 }
 
 // NamePath is a pair of a name and a path to which the named objects should be mounted to.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -518,6 +518,9 @@ type SparkPodSpec struct {
 	// HostAliases settings for the pod, following the Kubernetes specifications.
 	// +optional
 	HostAliases []apiv1.HostAlias `json:"hostAliases,omitempty"`
+	// Ports settings for the pods, following the Kubernetes specifications.
+	// +optional
+	Ports []Port `json:"ports,omitempty"`
 }
 
 // DriverSpec is specification of the driver.
@@ -616,6 +619,13 @@ type SecretInfo struct {
 type NameKey struct {
 	Name string `json:"name"`
 	Key  string `json:"key"`
+}
+
+// Port represents the port definition in the pods objects.
+type Port struct {
+	Name          string `json:"name"`
+	Protocol      string `json:"protocol"`
+	ContainerPort int32  `json:"containerPort"`
 }
 
 // MonitoringSpec defines the monitoring specification.

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -395,19 +395,20 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 }
 
 func addContainerPorts(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation {
-	var portMaps []v1beta2.Port
+	var ports []v1beta2.Port
 
 	if util.IsDriverPod(pod) {
-		portMaps = app.Spec.Driver.Ports
+		ports = app.Spec.Driver.Ports
 	} else if util.IsExecutorPod(pod) {
-		portMaps = app.Spec.Executor.Ports
+		ports = app.Spec.Executor.Ports
 	}
 
 	var patchOps []patchOperation
-	for _, p := range portMaps {
+	for _, p := range ports {
 		portPatchOp := addContainerPort(pod, p.ContainerPort, p.Protocol, p.Name)
 		if portPatchOp == nil {
 			glog.Warningf("could not expose port named %s", p.Name)
+			continue
 		}
 		patchOps = append(patchOps, *portPatchOp)
 	}

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -395,19 +395,19 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 }
 
 func addContainerPorts(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation {
-	var PortMaps []v1beta2.Port
+	var portMaps []v1beta2.Port
 
 	if util.IsDriverPod(pod) {
-		PortMaps = app.Spec.Driver.Ports
+		portMaps = app.Spec.Driver.Ports
 	} else if util.IsExecutorPod(pod) {
-		PortMaps = app.Spec.Executor.Ports
+		portMaps = app.Spec.Executor.Ports
 	}
 
 	var patchOps []patchOperation
-	for _, p := range PortMaps {
+	for _, p := range portMaps {
 		portPatchOp := addContainerPort(pod, p.ContainerPort, p.Protocol, p.Name)
 		if portPatchOp == nil {
-			return nil
+			glog.Warningf("could not expose port named %s", p.Name)
 		}
 		patchOps = append(patchOps, *portPatchOp)
 	}

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -63,6 +63,7 @@ func patchSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperat
 	patchOps = append(patchOps, addEnvVars(pod, app)...)
 	patchOps = append(patchOps, addEnvFrom(pod, app)...)
 	patchOps = append(patchOps, addHostAliases(pod, app)...)
+	patchOps = append(patchOps, addPorts(pod, app)...)
 
 	op := addSchedulerName(pod, app)
 	if op != nil {
@@ -371,14 +372,14 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 	name := config.GetPrometheusConfigMapName(app)
 	volumeName := name + "-vol"
 	mountPath := config.PrometheusConfigMapMountPath
-	port := config.DefaultPrometheusJavaAgentPort
+	promPort := config.DefaultPrometheusJavaAgentPort
 	if app.Spec.Monitoring.Prometheus.Port != nil {
-		port = *app.Spec.Monitoring.Prometheus.Port
+		promPort = *app.Spec.Monitoring.Prometheus.Port
 	}
-	protocol := config.DefaultPrometheusPortProtocol
-	portName := config.DefaultPrometheusPortName
+	promProtocol := config.DefaultPrometheusPortProtocol
+	promPortName := config.DefaultPrometheusPortName
 	if app.Spec.Monitoring.Prometheus.PortName != nil {
-		portName = *app.Spec.Monitoring.Prometheus.PortName
+		promPortName = *app.Spec.Monitoring.Prometheus.PortName
 	}
 
 	patchOps = append(patchOps, addConfigMapVolume(pod, name, volumeName))
@@ -388,17 +389,36 @@ func getPrometheusConfigPatches(pod *corev1.Pod, app *v1beta2.SparkApplication) 
 		return nil
 	}
 	patchOps = append(patchOps, *vmPatchOp)
-	portPatchOp := addContainerPort(pod, port, protocol, portName)
-	if portPatchOp == nil {
-		glog.Warningf("could not expose port %d to scrape metrics outside the pod", port)
+	promPortPatchOp := addPort(pod, promPort, promProtocol, promPortName)
+	if promPortPatchOp == nil {
+		glog.Warningf("could not expose port %d to scrape metrics outside the pod", promPort)
 		return nil
 	}
-	patchOps = append(patchOps, *portPatchOp)
-
+	patchOps = append(patchOps, *promPortPatchOp)
 	return patchOps
 }
 
-func addContainerPort(pod *corev1.Pod, port int32, protocol string, portName string) *patchOperation {
+func addPorts(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation {
+	var PortMaps []v1beta2.Port
+
+	if util.IsDriverPod(pod) {
+		PortMaps = app.Spec.Driver.Ports
+	} else if util.IsExecutorPod(pod) {
+		PortMaps = app.Spec.Executor.Ports
+	}
+
+	var patchOps []patchOperation
+	for _, p := range PortMaps {
+		portPatchOp := addPort(pod, p.ContainerPort, p.Protocol, p.Name)
+		if portPatchOp == nil {
+			return nil
+		}
+		patchOps = append(patchOps, *portPatchOp)
+	}
+	return patchOps
+}
+
+func addPort(pod *corev1.Pod, port int32, protocol string, portName string) *patchOperation {
 	i := findContainer(pod)
 	if i < 0 {
 		glog.Warningf("not able to add containerPort %d as Spark container was not found in pod %s", port, pod.Name)

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -1911,17 +1911,21 @@ func TestPatchSparkPod_Ports(t *testing.T) {
 		},
 		Spec: v1beta2.SparkApplicationSpec{
 			Driver: v1beta2.DriverSpec{
-				SparkPodSpec: v1beta2.SparkPodSpec{
-					Ports: []v1beta2.Port{
-						{Name: "port1", ContainerPort: 8080, Protocol: "TCP"},
-						{Name: "port2", ContainerPort: 8081, Protocol: "TCP"},
-					},
+				Ports: []v1beta2.Port{
+					{Name: "driverPort1", ContainerPort: 8080, Protocol: "TCP"},
+					{Name: "driverPort2", ContainerPort: 8081, Protocol: "TCP"},
+				},
+			},
+			Executor: v1beta2.ExecutorSpec{
+				Ports: []v1beta2.Port{
+					{Name: "executorPort1", ContainerPort: 8082, Protocol: "TCP"},
+					{Name: "executorPort2", ContainerPort: 8083, Protocol: "TCP"},
 				},
 			},
 		},
 	}
 
-	pod := &corev1.Pod{
+	driverPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "spark-driver",
 			Labels: map[string]string{
@@ -1939,14 +1943,42 @@ func TestPatchSparkPod_Ports(t *testing.T) {
 		},
 	}
 
-	modifiedPod, err := getModifiedPod(pod, app)
+	modifiedDriverPod, err := getModifiedPod(driverPod, app)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 2, len(modifiedPod.Spec.Containers[0].Ports))
-	assert.Equal(t, "port1", modifiedPod.Spec.Containers[0].Ports[0].Name)
-	assert.Equal(t, "port2", modifiedPod.Spec.Containers[0].Ports[1].Name)
-	assert.Equal(t, int32(8080), modifiedPod.Spec.Containers[0].Ports[0].ContainerPort)
-	assert.Equal(t, int32(8081), modifiedPod.Spec.Containers[0].Ports[1].ContainerPort)
+	assert.Equal(t, 2, len(modifiedDriverPod.Spec.Containers[0].Ports))
+	assert.Equal(t, "driverPort1", modifiedDriverPod.Spec.Containers[0].Ports[0].Name)
+	assert.Equal(t, "driverPort2", modifiedDriverPod.Spec.Containers[0].Ports[1].Name)
+	assert.Equal(t, int32(8080), modifiedDriverPod.Spec.Containers[0].Ports[0].ContainerPort)
+	assert.Equal(t, int32(8081), modifiedDriverPod.Spec.Containers[0].Ports[1].ContainerPort)
+
+	executorPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-executor",
+			Labels: map[string]string{
+				config.SparkRoleLabel:               config.SparkExecutorRole,
+				config.LaunchedBySparkOperatorLabel: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  config.SparkExecutorContainerName,
+					Image: "spark-executor:latest",
+				},
+			},
+		},
+	}
+
+	modifiedExecutorPod, err := getModifiedPod(executorPod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(modifiedExecutorPod.Spec.Containers[0].Ports))
+	assert.Equal(t, "executorPort1", modifiedExecutorPod.Spec.Containers[0].Ports[0].Name)
+	assert.Equal(t, "executorPort2", modifiedExecutorPod.Spec.Containers[0].Ports[1].Name)
+	assert.Equal(t, int32(8082), modifiedExecutorPod.Spec.Containers[0].Ports[0].ContainerPort)
+	assert.Equal(t, int32(8083), modifiedExecutorPod.Spec.Containers[0].Ports[1].ContainerPort)
 }


### PR DESCRIPTION
I'd like to expose other ports in my spark app, similar to what the spark-operator already has done to prometheus.

Its related to: 

https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1202 
https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1120

