### PR TITLE
Fix the error of hostAliases when there are more than 2 hostnames

### DIFF
--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -796,5 +796,8 @@ func addHostAliases(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOpera
 	}
 
 	var ops []patchOperation
-	return append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases", Value: hostAliases})
+	if len(hostAliases) > 0 {
+		ops = append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases", Value: hostAliases})
+	}
+	return ops
 }

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -795,19 +795,6 @@ func addHostAliases(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOpera
 		hostAliases = app.Spec.Executor.HostAliases
 	}
 
-	first := false
-	if len(pod.Spec.HostAliases) == 0 {
-		first = true
-	}
-
 	var ops []patchOperation
-	for _, v := range hostAliases {
-		if first {
-			ops = append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases", Value: []corev1.HostAlias{v}})
-			first = false
-		} else {
-			ops = append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases/-", Value: &v})
-		}
-	}
-	return ops
+	return append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases", Value: hostAliases})
 }

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -795,9 +795,18 @@ func addHostAliases(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOpera
 		hostAliases = app.Spec.Executor.HostAliases
 	}
 
+	first := false
+	if len(pod.Spec.HostAliases) == 0 {
+		first = true
+	}
+
 	var ops []patchOperation
 	if len(hostAliases) > 0 {
-		ops = append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases", Value: hostAliases})
+		if first {
+			ops = append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases", Value: hostAliases})
+		} else {
+			ops = append(ops, patchOperation{Op: "add", Path: "/spec/hostAliases/-", Value: hostAliases})
+		}
 	}
 	return ops
 }

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -1833,6 +1833,14 @@ func TestPatchSparkPod_HostAliases(t *testing.T) {
 							IP:        "192.168.0.1",
 							Hostnames: []string{"test.com", "test2.com"},
 						},
+						{
+							IP:        "192.168.0.2",
+							Hostnames: []string{"test3.com"},
+						},
+						{
+							IP:        "192.168.0.3",
+							Hostnames: []string{"test4.com"},
+						},
 					},
 				},
 			},
@@ -1875,9 +1883,11 @@ func TestPatchSparkPod_HostAliases(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 2, len(modifiedDriverPod.Spec.HostAliases))
+	assert.Equal(t, 4, len(modifiedDriverPod.Spec.HostAliases))
 	assert.Equal(t, "127.0.0.1", modifiedDriverPod.Spec.HostAliases[0].IP)
 	assert.Equal(t, "192.168.0.1", modifiedDriverPod.Spec.HostAliases[1].IP)
+	assert.Equal(t, "192.168.0.2", modifiedDriverPod.Spec.HostAliases[2].IP)
+	assert.Equal(t, "192.168.0.3", modifiedDriverPod.Spec.HostAliases[3].IP)
 
 	executorPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
If there are more than 2 hostnames in `hostAliases` path, `spec/hostAliases` will only show the first and many last hostname. Like this:
```yaml
hostAliases:
- ip: "10.1.1.1"
  hostnames:
  - "hostname1"
- ip: "10.1.1.3"
  hostnames:
  - "hostname3"
- ip: "10.1.1.3"
  hostnames:
  - "hostname3"
```
Now fix this problem.