### PR TITLE
fix: remove preemptionPolicy when priority class name is used

### DIFF
--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -560,6 +560,7 @@ func addPriorityClassName(pod *corev1.Pod, app *v1beta2.SparkApplication) []patc
 
 		if pod.Spec.Priority != nil {
 			ops = append(ops, patchOperation{Op: "remove", Path: "/spec/priority"})
+			ops = append(ops, patchOperation{Op: "remove", Path: "/spec/preemptionPolicy"})
 		}
 	}
 

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -823,6 +823,7 @@ func TestPatchSparkPod_PriorityClassName(t *testing.T) {
 	assert.Equal(t, priorityClassName, modifiedDriverPod.Spec.PriorityClassName)
 
 	var defaultPriority int32 = 0
+	var defaultPolicy corev1.PreemptionPolicy = corev1.PreemptLowerPriority
 	executorPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "spark-executor",
@@ -838,7 +839,8 @@ func TestPatchSparkPod_PriorityClassName(t *testing.T) {
 					Image: "spark-executor:latest",
 				},
 			},
-			Priority: &defaultPriority,
+			Priority:         &defaultPriority,
+			PreemptionPolicy: &defaultPolicy,
 		},
 	}
 
@@ -849,6 +851,7 @@ func TestPatchSparkPod_PriorityClassName(t *testing.T) {
 	//Executor priorityClassName should also be populated when specified in SparkApplicationSpec
 	assert.Equal(t, priorityClassName, modifiedExecutorPod.Spec.PriorityClassName)
 	assert.Nil(t, modifiedExecutorPod.Spec.Priority)
+	assert.Nil(t, modifiedExecutorPod.Spec.PreemptionPolicy)
 }
 
 func TestPatchSparkPod_Sidecars(t *testing.T) {


### PR DESCRIPTION
Fixes #1233 

Starting at kubernetes 1.19, a PriorityClass can now define a
PreemptionPolicy. By default a pod will have a PreemptionPolicy set to
PreemptLowerPriority.

If the PriorityClass defines a different PreemptionPolicy, there will be
a conflict, so the patcher has to remove the PreemptionPolicy on the
pod. By default a PriorityClass will have a PreemptionPolicy set to
PreemptLowerPriority too, so it's safe to always remove it from the pod
when the priorityClassName is specified for the sparkapplication.