### PR TITLE
[#1239] Custom service port name for spark application UI

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2918,6 +2918,20 @@ TargetPort should be the same as the one defined in spark.ui.port</p>
 </tr>
 <tr>
 <td>
+<code>ServicePortName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServicePortName allows configuring the name of the service port.
+This may be useful for sidecar proxies like Envoy injected by Istio which require specific ports names to treat traffic as proper HTTP.
+Defaults to spark-driver-ui-port.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>serviceType</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicetype-v1-core">
@@ -2961,5 +2975,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>2f6a3f9</code>.
+on git commit <code>eb07ee0</code>.
 </em></p>

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3672,6 +3672,8 @@ spec:
                 servicePort:
                   format: int32
                   type: integer
+                servicePortName:
+                  type: string
                 serviceType:
                   type: string
               type: object

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -306,6 +306,11 @@ type SparkUIConfiguration struct {
 	// TargetPort should be the same as the one defined in spark.ui.port
 	// +optional
 	ServicePort *int32 `json:"servicePort"`
+	// ServicePortName allows configuring the name of the service port.
+	// This may be useful for sidecar proxies like Envoy injected by Istio which require specific ports names to treat traffic as proper HTTP.
+	// Defaults to spark-driver-ui-port.
+	// +optional
+	ServicePortName *string `json:"servicePortName"`
 	// ServiceType allows configuring the type of the service. Defaults to ClusterIP.
 	// +optional
 	ServiceType *apiv1.ServiceType `json:"serviceType"`

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	sparkUIPortConfigurationKey       = "spark.ui.port"
-	defaultSparkWebUIPort       int32 = 4040
+	sparkUIPortConfigurationKey        = "spark.ui.port"
+	defaultSparkWebUIPort       int32  = 4040
+	defaultSparkWebUIPortName   string = "spark-driver-ui-port"
 )
 
 var ingressAppNameURLRegex = regexp.MustCompile("{{\\s*[$]appName\\s*}}")
@@ -49,11 +50,12 @@ func getSparkUIingressURL(ingressURLFormat string, appName string, appNamespace 
 
 // SparkService encapsulates information about the driver UI service.
 type SparkService struct {
-	serviceName string
-	serviceType apiv1.ServiceType
-	servicePort int32
-	targetPort  intstr.IntOrString
-	serviceIP   string
+	serviceName     string
+	serviceType     apiv1.ServiceType
+	servicePort     int32
+	servicePortName string
+	targetPort      intstr.IntOrString
+	serviceIP       string
 }
 
 // SparkIngress encapsulates information about the driver UI ingress.
@@ -132,6 +134,10 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 func createSparkUIService(
 	app *v1beta2.SparkApplication,
 	kubeClient clientset.Interface) (*SparkService, error) {
+	portName, err := getUIServicePortName(app)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Spark UI servicePortName: %s", portName)
+	}
 	port, err := getUIServicePort(app)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Spark UI servicePort: %d", port)
@@ -150,7 +156,7 @@ func createSparkUIService(
 		Spec: apiv1.ServiceSpec{
 			Ports: []apiv1.ServicePort{
 				{
-					Name: "spark-driver-ui-port",
+					Name: portName,
 					Port: port,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
@@ -173,11 +179,12 @@ func createSparkUIService(
 	}
 
 	return &SparkService{
-		serviceName: service.Name,
-		serviceType: service.Spec.Type,
-		servicePort: service.Spec.Ports[0].Port,
-		targetPort:  service.Spec.Ports[0].TargetPort,
-		serviceIP:   service.Spec.ClusterIP,
+		serviceName:     service.Name,
+		serviceType:     service.Spec.Type,
+		servicePort:     service.Spec.Ports[0].Port,
+		servicePortName: service.Spec.Ports[0].Name,
+		targetPort:      service.Spec.Ports[0].TargetPort,
+		serviceIP:       service.Spec.ClusterIP,
 	}, nil
 }
 
@@ -203,4 +210,16 @@ func getUIServicePort(app *v1beta2.SparkApplication) (int32, error) {
 		return *port, nil
 	}
 	return defaultSparkWebUIPort, nil
+}
+
+func getUIServicePortName(app *v1beta2.SparkApplication) (string, error) {
+
+	if app.Spec.SparkUIOptions == nil {
+		return defaultSparkWebUIPortName, nil
+	}
+	portName := app.Spec.SparkUIOptions.ServicePortName
+	if portName != nil {
+		return *portName, nil
+	}
+	return defaultSparkWebUIPortName, nil
 }

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -134,10 +134,7 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 func createSparkUIService(
 	app *v1beta2.SparkApplication,
 	kubeClient clientset.Interface) (*SparkService, error) {
-	portName, err := getUIServicePortName(app)
-	if err != nil {
-		return nil, fmt.Errorf("invalid Spark UI servicePortName: %s", portName)
-	}
+	portName := getUIServicePortName(app)
 	port, err := getUIServicePort(app)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Spark UI servicePort: %d", port)
@@ -201,7 +198,6 @@ func getUITargetPort(app *v1beta2.SparkApplication) (int32, error) {
 }
 
 func getUIServicePort(app *v1beta2.SparkApplication) (int32, error) {
-
 	if app.Spec.SparkUIOptions == nil {
 		return getUITargetPort(app)
 	}
@@ -212,14 +208,13 @@ func getUIServicePort(app *v1beta2.SparkApplication) (int32, error) {
 	return defaultSparkWebUIPort, nil
 }
 
-func getUIServicePortName(app *v1beta2.SparkApplication) (string, error) {
-
+func getUIServicePortName(app *v1beta2.SparkApplication) string {
 	if app.Spec.SparkUIOptions == nil {
-		return defaultSparkWebUIPortName, nil
+		return defaultSparkWebUIPortName
 	}
 	portName := app.Spec.SparkUIOptions.ServicePortName
 	if portName != nil {
-		return *portName, nil
+		return *portName
 	}
-	return defaultSparkWebUIPortName, nil
+	return defaultSparkWebUIPortName
 }


### PR DESCRIPTION
A proposal for solving https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1239 .
This PR makes it possible to specify the service port name for exposing the spark UI.