### PR TITLE
fix: do not remove preemptionPolicy in patcher when not present

### DIFF
--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -560,6 +560,8 @@ func addPriorityClassName(pod *corev1.Pod, app *v1beta2.SparkApplication) []patc
 
 		if pod.Spec.Priority != nil {
 			ops = append(ops, patchOperation{Op: "remove", Path: "/spec/priority"})
+		}
+		if pod.Spec.PreemptionPolicy != nil {
 			ops = append(ops, patchOperation{Op: "remove", Path: "/spec/preemptionPolicy"})
 		}
 	}


### PR DESCRIPTION
Introduced a bug in 3090b2abb80a6703a24423b76d144911a6891e2d. I
incorrectly assumed the preemptionPolicy was always set to a default on
pods, which is not the case in K8s versions prior to 1.19.