### PR TITLE
Allow user to specify service annotation on Spark UI service

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.2
+version: 1.1.3
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3695,6 +3695,10 @@ spec:
                   type: string
                 sparkUIOptions:
                   properties:
+                    serviceAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
                     ingressAnnotations:
                       additionalProperties:
                         type: string

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3681,6 +3681,10 @@ spec:
               type: string
             sparkUIOptions:
               properties:
+                serviceAnnotations:
+                  additionalProperties:
+                    type: string
+                  type: object
                 ingressAnnotations:
                   additionalProperties:
                     type: string

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2958,6 +2958,18 @@ Kubernetes core/v1.ServiceType
 </tr>
 <tr>
 <td>
+<code>serviceAnnotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAnnotations is a map of key,value pairs of annotations that might be added to the service object.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ingressAnnotations</code></br>
 <em>
 map[string]string
@@ -2987,5 +2999,5 @@ map[string]string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>e616816</code>.
+on git commit <code>24a8842</code>.
 </em></p>

--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3695,6 +3695,10 @@ spec:
                   type: string
                 sparkUIOptions:
                   properties:
+                    serviceAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
                     ingressAnnotations:
                       additionalProperties:
                         type: string

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3681,6 +3681,10 @@ spec:
               type: string
             sparkUIOptions:
               properties:
+                serviceAnnotations:
+                  additionalProperties:
+                    type: string
+                  type: object
                 ingressAnnotations:
                   additionalProperties:
                     type: string

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -314,6 +314,9 @@ type SparkUIConfiguration struct {
 	// ServiceType allows configuring the type of the service. Defaults to ClusterIP.
 	// +optional
 	ServiceType *apiv1.ServiceType `json:"serviceType"`
+	// ServiceAnnotations is a map of key,value pairs of annotations that might be added to the service object.
+	// +optional
+	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 	// IngressAnnotations is a map of key,value pairs of annotations that might be added to the ingress object. i.e. specify nginx as ingress.class
 	// +optional
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -80,6 +80,16 @@ func getResourceLabels(app *v1beta2.SparkApplication) map[string]string {
 	return labels
 }
 
+func getServiceAnnotations(app *v1beta2.SparkApplication) map[string]string {
+	serviceAnnotations := map[string]string{}
+	if app.Spec.SparkUIOptions != nil && app.Spec.SparkUIOptions.ServiceAnnotations != nil {
+		for key, value := range app.Spec.SparkUIOptions.ServiceAnnotations {
+			serviceAnnotations[key] = value
+		}
+	}
+	return serviceAnnotations
+}
+
 func getIngressResourceAnnotations(app *v1beta2.SparkApplication) map[string]string {
 	ingressAnnotations := map[string]string{}
 	if app.Spec.SparkUIOptions != nil && app.Spec.SparkUIOptions.IngressAnnotations != nil {

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -50,12 +50,13 @@ func getSparkUIingressURL(ingressURLFormat string, appName string, appNamespace 
 
 // SparkService encapsulates information about the driver UI service.
 type SparkService struct {
-	serviceName     string
-	serviceType     apiv1.ServiceType
-	servicePort     int32
-	servicePortName string
-	targetPort      intstr.IntOrString
-	serviceIP       string
+	serviceName        string
+	serviceType        apiv1.ServiceType
+	servicePort        int32
+	servicePortName    string
+	targetPort         intstr.IntOrString
+	serviceIP          string
+	serviceAnnotations map[string]string
 }
 
 // SparkIngress encapsulates information about the driver UI ingress.
@@ -169,6 +170,11 @@ func createSparkUIService(
 		},
 	}
 
+	serviceAnnotations := getServiceAnnotations(app)
+	if len(serviceAnnotations) != 0 {
+		service.ObjectMeta.Annotations = serviceAnnotations
+	}
+
 	glog.Infof("Creating a service %s for the Spark UI for application %s", service.Name, app.Name)
 	service, err = kubeClient.CoreV1().Services(app.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 	if err != nil {
@@ -176,12 +182,13 @@ func createSparkUIService(
 	}
 
 	return &SparkService{
-		serviceName:     service.Name,
-		serviceType:     service.Spec.Type,
-		servicePort:     service.Spec.Ports[0].Port,
-		servicePortName: service.Spec.Ports[0].Name,
-		targetPort:      service.Spec.Ports[0].TargetPort,
-		serviceIP:       service.Spec.ClusterIP,
+		serviceName:        service.Name,
+		serviceType:        service.Spec.Type,
+		servicePort:        service.Spec.Ports[0].Port,
+		servicePortName:    service.Spec.Ports[0].Name,
+		targetPort:         service.Spec.Ports[0].TargetPort,
+		serviceIP:          service.Spec.ClusterIP,
+		serviceAnnotations: serviceAnnotations,
 	}, nil
 }
 


### PR DESCRIPTION
Currently, there's no way to specify annotations on Spark UI services. One example of how this can be useful, is that we can add annotation on Spark UI services such that it can be ignored by Istio Pilot.