### PR TITLE
add crds drift check between chart/ and manifest/

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,11 @@ jobs:
   it:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,17 +29,9 @@ jobs:
       - name: unit tests
         run: make test
 
-      - name: integration tests
-        run: make test
-
   it:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -67,6 +59,9 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint
+
+      - name: Detect CRDs drift between chart and manifest
+        run: make detect-crds-drift
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ fmt-check: clean
 	@echo "running fmt check"
 	./.travis.gofmt.sh
 
+detect-crds-drift:
+	diff -q charts/spark-operator-chart/crds manifest/crds
+
 clean:
 	@echo "cleaning up caches and output"
 	go clean -cache -testcache -r -x ./... 2>&1 >/dev/null


### PR DESCRIPTION
Hello,

This PR address the issue of crds drift between chart/ and manifest/ encountered in #1262 
I've also delete redundant element in `.github/workflows/main.yaml`

This PR comes with an open question: 
Should we keep Travis-ci, since everything that it does is also check by GitHub workflow ?