### PR TITLE
Update pythonVersion to fix example

### DIFF
--- a/examples/spark-py-pi.yaml
+++ b/examples/spark-py-pi.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: default
 spec:
   type: Python
-  pythonVersion: "2"
+  pythonVersion: "3"
   mode: cluster
   image: "gcr.io/spark-operator/spark-py:v3.1.1"
   imagePullPolicy: Always


### PR DESCRIPTION
spark 3.1.1 (specified in image) doesn't work with Python 2. 
This change updates pythonVersion from 2 to 3.