### PR TITLE
Add user defined pod labels

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.4
+version: 1.1.5
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -102,6 +102,7 @@ All charts linted successfully
 | nameOverride | string | `""` | String to partially override `spark-operator.fullname` template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Additional annotations to add to the pod |
+| podLabels | object | `{}` | Additional labels to add to the pod |
 | podMonitor | object | `{"enable":false,"jobLabel":"spark-operator-podmonitor","labels":{},"podMetricsEndpoint":{"interval":"5s","scheme":"http"}}` | Prometheus pod monitor for operator's pod. |
 | podMonitor.enable | bool | `false` | If enabled, a pod monitor for operator's pod will be submitted. Note that prometheus metrics should be enabled as well. |
 | podMonitor.jobLabel | string | `"spark-operator-podmonitor"` | The label to use to retrieve the job name from |

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
     {{- end }}
       labels:
         {{- include "spark-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "spark-operator.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -120,6 +120,9 @@ affinity: {}
 # podAnnotations -- Additional annotations to add to the pod
 podAnnotations: {}
 
+# podLabels -- Additional labels to add to the pod
+podLabels: {}
+
 # resources -- Pod resource requests and limits
 # Note, that each job submission will spawn a JVM within the Spark Operator Pod using "/usr/local/openjdk-11/bin/java -Xmx128m".
 # Kubernetes may kill these Java processes at will to enforce resource limits. When that happens, you will see the following error:


### PR DESCRIPTION
This adds the ability to define user labels on Spark operator pod. Main use case is integration with external logging solution. Please let me know if I should bump chart version in the PR or if you manage release cycle for the chart. Thanks