### PR TITLE
Explain "signal: kill" errors during submission

### DIFF
--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -121,6 +121,9 @@ affinity: {}
 podAnnotations: {}
 
 # resources -- Pod resource requests and limits
+# Note, that each job submission will spawn a JVM within the Spark Operator Pod using "/usr/local/openjdk-11/bin/java -Xmx128m".
+# Kubernetes may kill these Java processes at will to enforce resource limits. When that happens, you will see the following error:
+# 'failed to run spark-submit for SparkApplication [...]: signal: killed' - when this happens, you may want to increase memory limits.
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
Added comment that better describes the issue as in:
failed to run spark-submit for SparkApplication namespace/job-timestamp: signal: killed #1287