### PR TITLE
Add hook deletion policy for spark-operator service account

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.5
+version: 1.1.6
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "spark-operator.serviceAccountName" . }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This PR relates to https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1155 that added pre-install hook for Argo CD. Mentioned PR fixed the issue with the webhooks, however service account is deleted and recreated by the Argo on every sync. This effectively deletes service account token used by spark-operator pod and results in loosing RBAC permissions for operated Spark pods. New annotation with helm hook deletion policy will ensure that service account is not recreated.