### PR TITLE
fix NPE introduce on #1280

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -376,7 +376,13 @@ func (c *Controller) getAndUpdateExecutorState(app *v1beta2.SparkApplication) er
 			if !exists || newState != oldState {
 				if newState == v1beta2.ExecutorFailedState {
 					execContainerState := getExecutorContainerTerminatedState(pod.Status)
-					c.recordExecutorEvent(app, newState, pod.Name, execContainerState.ExitCode, execContainerState.Reason)
+					if execContainerState != nil {
+						c.recordExecutorEvent(app, newState, pod.Name, execContainerState.ExitCode, execContainerState.Reason)
+					} else {
+						// If we can't find the container state,
+						// we need to set the exitCode and the Reason to unambiguous values.
+						c.recordExecutorEvent(app, newState, pod.Name, -1, "Unknown (Container not Found)")
+					}
 				} else {
 					c.recordExecutorEvent(app, newState, pod.Name)
 				}

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -138,7 +138,11 @@ func getDriverContainerTerminatedState(podStatus apiv1.PodStatus) *apiv1.Contain
 }
 
 func getExecutorContainerTerminatedState(podStatus apiv1.PodStatus) *apiv1.ContainerStateTerminated {
-	return getContainerTerminatedState(config.SparkExecutorContainerName, podStatus)
+	state := getContainerTerminatedState(config.Spark3DefaultExecutorContainerName, podStatus)
+	if state == nil {
+		state = getContainerTerminatedState(config.SparkExecutorContainerName, podStatus)
+	}
+	return state
 }
 
 func getContainerTerminatedState(name string, podStatus apiv1.PodStatus) *apiv1.ContainerStateTerminated {


### PR DESCRIPTION
Hi,

Following testing on our side,
We've detected that the change I introduced on #1280 introduced NPE on executor failure on Spark3

This PR fix the executor on Spark3 and avoid NPE if we can't find the executor container
In case of NPE we show `Executor {{exec-name}} failed with ExitCode: -1, Reason: Unknown (Container not Found)`