### PR TITLE
fix running metrics for application deletion

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -442,6 +442,7 @@ func (c *Controller) getAndUpdateAppState(app *v1beta2.SparkApplication) error {
 }
 
 func (c *Controller) handleSparkApplicationDeletion(app *v1beta2.SparkApplication) {
+	c.metrics.exportMetricsOnDelete(app)
 	// SparkApplication deletion requested, lets delete driver pod.
 	if err := c.deleteSparkResources(app); err != nil {
 		glog.Errorf("failed to delete resources associated with deleted SparkApplication %s/%s: %v", app.Namespace, app.Name, err)


### PR DESCRIPTION
Decrease `running` metrics for the case of application deletion.

closes #1354