### PR TITLE
[FIX] tolerations are not directly present in Driver(/Executor)Spec

### DIFF
--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -484,9 +484,9 @@ func addAffinity(pod *corev1.Pod, app *v1beta2.SparkApplication) *patchOperation
 func addTolerations(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation {
 	var tolerations []corev1.Toleration
 	if util.IsDriverPod(pod) {
-		tolerations = app.Spec.Driver.Tolerations
+		tolerations = app.Spec.Driver.SparkPodSpec.Tolerations
 	} else if util.IsExecutorPod(pod) {
-		tolerations = app.Spec.Executor.Tolerations
+		tolerations = app.Spec.Executor.SparkPodSpec.Tolerations
 	}
 
 	first := false


### PR DESCRIPTION
Tolerations are not part of DriverSpec or ExecutorSpec object. Instead they should be carried from SparkPodSpec field inside these objects.
Ref:
DriverSpec: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go#L535-L566
ExecutorSpec: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go#L569-L590
Master SHA: `b5b096471d1c08730ff6203bfb1869cd350f62ab`

Fixes #1366 