### PR TITLE
`Role` and `RoleBinding` not installed for `webhook-init` in Helm `pre-hook`

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.8
+version: 1.1.9
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-operator.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 rules:
@@ -108,6 +111,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "spark-operator.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 subjects:


### PR DESCRIPTION
This causes the issue: https://github.com/fluxcd/flux2/issues/2030

Tested with the following chart:

```
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: spark-operator-development
  namespace: development
spec:
  chart:
    spec:
      chart: spark-operator
      sourceRef:
        kind: HelmRepository
        name: enliven-systems
        namespace: kube-system
      version: 1.1.9
  interval: 30m0s
  install:
    crds: CreateReplace
    replace: true
    remediation:
      retries: -1
    disableWaitForJobs: true
    disableWait: true
    timeout: "2m"
  upgrade:
    crds: CreateReplace
    remediation:
      retries: -1
    disableWaitForJobs: true
  uninstall:
    timeout: "1m"
  values:
    image:
      tag: v1beta2-1.2.3-3.1.1
      pullPolicy: Always
    webhook:
      enable: true
      namespaceSelector: "name=development"
    sparkJobNamespace: development
    resyncInterval: 10
    metrics:
      enable: false
    controllerThreads: 1
    batchScheduler:
      enable: true
    resourceQuotaEnforcement:
      enable: true
    rbac:
      createClusterRole: true
      createRole: true
    resources:
      requests:
        memory: 250Mi
        cpu: 100m
      limits:
        memory: 250Mi
        cpu: 500m
```

Also, with Flux 2 the chart seems to stay on state "Release reconciliation succeeded".