### PR TITLE
delete-service-accounts-and-roles-before-creation

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.12
+version: 1.1.13
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "spark-operator.fullname" . }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-failed
+    "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 rules:
@@ -113,7 +113,7 @@ metadata:
   name: {{ include "spark-operator.fullname" . }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-failed
+    "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 subjects:

--- a/charts/spark-operator-chart/templates/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "spark-operator.serviceAccountName" . }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-failed
+    "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
 {{- with .Values.serviceAccounts.sparkoperator.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Related with issue https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1359

The current version of helm chart does not handle hook tearing-down automatically. So after the uninstall, `spark-operator` will leave three artifacts `serviceAccount`, `ClusterRole` and `ClusterRoleBinding` inside the k8s config. Attempts to reinstall the same `spark-operator` will be blocked because `rbac.yaml` will try to install these as pre-install hook, despite the fact that they are already there.

Suggest to add the `before-hook-creation` inside `hook-delete-policy` as suggested by @swartz-k, to fix this issue.