### PR TITLE
webhook timeout variable

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.10
+version: 1.1.11
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.11
+version: 1.1.12
 appVersion: v1beta2-1.2.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -130,6 +130,7 @@ All charts linted successfully
 | webhook.enable | bool | `false` | Enable webhook server |
 | webhook.namespaceSelector | string | `""` | The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2. Empty string (default) will operate on all namespaces |
 | webhook.port | int | `8080` | Webhook service port |
+| webhook.timeout | int | `30` | Webhook timeout in seconds |
 
 ## Maintainers
 

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -75,6 +75,7 @@ spec:
         - -enable-webhook=true
         - -webhook-svc-namespace={{ .Release.Namespace }}
         - -webhook-port={{ .Values.webhook.port }}
+        - -webhook-timeout={{ .Values.webhook.timeout }}
         - -webhook-svc-name={{ include "spark-operator.fullname" . }}-webhook
         - -webhook-config-name={{ include "spark-operator.fullname" . }}-webhook-config
         - -webhook-namespace-selector={{ .Values.webhook.namespaceSelector }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -90,6 +90,8 @@ webhook:
   cleanupAnnotations:
     "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
+    # -- Webhook Timeout in seconds
+  timeout: 30
 
 metrics:
   # -- Enable prometheus metric scraping

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ var (
 	namespace                      = flag.String("namespace", apiv1.NamespaceAll, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
 	labelSelectorFilter            = flag.String("label-selector-filter", "", "A comma-separated list of key=value, or key labels to filter resources during watch and list based on the specified labels.")
 	enableWebhook                  = flag.Bool("enable-webhook", false, "Whether to enable the mutating admission webhook for admitting and patching Spark pods.")
+	webhookTimeout                 = flag.Int("webhook-timeout", 30, "Webhook Timeout in seconds before the webhook returns a timeout")
 	enableResourceQuotaEnforcement = flag.Bool("enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
 	ingressURLFormat               = flag.String("ingress-url-format", "", "Ingress URL format.")
 	enableUIService                = flag.Bool("enable-ui-service", true, "Enable Spark service UI.")
@@ -195,7 +196,7 @@ func main() {
 		}
 		var err error
 		// Don't deregister webhook on exit if leader election enabled (i.e. multiple webhooks running)
-		hook, err = webhook.New(kubeClient, crInformerFactory, *namespace, !*enableLeaderElection, *enableResourceQuotaEnforcement, coreV1InformerFactory)
+		hook, err = webhook.New(kubeClient, crInformerFactory, *namespace, !*enableLeaderElection, *enableResourceQuotaEnforcement, coreV1InformerFactory, webhookTimeout)
 		if err != nil {
 			glog.Fatal(err)
 		}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -86,7 +86,7 @@ type WebHook struct {
 	enableResourceQuotaEnforcement bool
 	resourceQuotaEnforcer          resourceusage.ResourceQuotaEnforcer
 	coreV1InformerFactory          informers.SharedInformerFactory
-	TimeoutSeconds                 *int32
+	timeoutSeconds                 *int32
 }
 
 // Configuration parsed from command-line flags
@@ -155,7 +155,7 @@ func New(
 		failurePolicy:                  arv1beta1.Ignore,
 		coreV1InformerFactory:          coreV1InformerFactory,
 		enableResourceQuotaEnforcement: enableResourceQuotaEnforcement,
-		TimeoutSeconds:                 func(b int32) *int32 { return &b }(int32(*webhookTimeout)),
+		timeoutSeconds:                 func(b int32) *int32 { return &b }(int32(*webhookTimeout)),
 	}
 
 	if userConfig.webhookFailOnError {
@@ -390,7 +390,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 		},
 		FailurePolicy:     &wh.failurePolicy,
 		NamespaceSelector: wh.selector,
-		TimeoutSeconds:    wh.TimeoutSeconds,
+		TimeoutSeconds:    wh.timeoutSeconds,
 	}
 
 	validatingWebhook := v1beta1.ValidatingWebhook{
@@ -402,7 +402,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 		},
 		FailurePolicy:     &wh.failurePolicy,
 		NamespaceSelector: wh.selector,
-		TimeoutSeconds:    wh.TimeoutSeconds,
+		TimeoutSeconds:    wh.timeoutSeconds,
 	}
 
 	mutatingWebhooks := []v1beta1.MutatingWebhook{mutatingWebhook}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -86,6 +86,7 @@ type WebHook struct {
 	enableResourceQuotaEnforcement bool
 	resourceQuotaEnforcer          resourceusage.ResourceQuotaEnforcer
 	coreV1InformerFactory          informers.SharedInformerFactory
+	TimeoutSeconds                 *int32
 }
 
 // Configuration parsed from command-line flags
@@ -124,7 +125,8 @@ func New(
 	jobNamespace string,
 	deregisterOnExit bool,
 	enableResourceQuotaEnforcement bool,
-	coreV1InformerFactory informers.SharedInformerFactory) (*WebHook, error) {
+	coreV1InformerFactory informers.SharedInformerFactory,
+	webhookTimeout *int) (*WebHook, error) {
 
 	cert, err := NewCertProvider(
 		userConfig.serverCert,
@@ -153,6 +155,7 @@ func New(
 		failurePolicy:                  arv1beta1.Ignore,
 		coreV1InformerFactory:          coreV1InformerFactory,
 		enableResourceQuotaEnforcement: enableResourceQuotaEnforcement,
+		TimeoutSeconds:                 func(b int32) *int32 { return &b }(int32(*webhookTimeout)),
 	}
 
 	if userConfig.webhookFailOnError {
@@ -387,6 +390,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 		},
 		FailurePolicy:     &wh.failurePolicy,
 		NamespaceSelector: wh.selector,
+		TimeoutSeconds:    wh.TimeoutSeconds,
 	}
 
 	validatingWebhook := v1beta1.ValidatingWebhook{
@@ -398,6 +402,7 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 		},
 		FailurePolicy:     &wh.failurePolicy,
 		NamespaceSelector: wh.selector,
+		TimeoutSeconds:    wh.TimeoutSeconds,
 	}
 
 	mutatingWebhooks := []v1beta1.MutatingWebhook{mutatingWebhook}


### PR DESCRIPTION
Webhook timeout by default is set to 30s (as we use AdmissionregistrationV1beta1) and sometimes that causes the request to fail when the number of pods in the cluster is huge.  We fix the webhook error by recreating the webhook manually with a lower timeout value (This does get modified when the operator pod restarts). 

We found kubernetes/kubernetes#71508, which talks about how the default client timeout is 30s, so if the webhooks have a timeout equal or greater, the client can give up before the apiserver has, which means the failurePolicy: ignore has no effect. 

This PR provides a way to set a default value for webhook timeout which allow the users to configure the timeout time based on their usage.  