### PR TITLE
Resolves an error when deploying the webhook where the k8s api indica…

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -379,6 +379,8 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 		},
 	}
 
+	sideEffect := arv1.SideEffectClassNoneOnDryRun
+
 	mutatingWebhook := arv1.MutatingWebhook{
 		Name:  webhookName,
 		Rules: mutatingRules,
@@ -386,9 +388,11 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 			Service:  wh.serviceRef,
 			CABundle: caCert,
 		},
-		FailurePolicy:     &wh.failurePolicy,
-		NamespaceSelector: wh.selector,
-		TimeoutSeconds:    wh.timeoutSeconds,
+		FailurePolicy:           &wh.failurePolicy,
+		NamespaceSelector:       wh.selector,
+		TimeoutSeconds:          wh.timeoutSeconds,
+		SideEffects:             &sideEffect,
+		AdmissionReviewVersions: []string{"v1"},
 	}
 
 	validatingWebhook := arv1.ValidatingWebhook{
@@ -398,9 +402,11 @@ func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 			Service:  wh.serviceRef,
 			CABundle: caCert,
 		},
-		FailurePolicy:     &wh.failurePolicy,
-		NamespaceSelector: wh.selector,
-		TimeoutSeconds:    wh.timeoutSeconds,
+		FailurePolicy:           &wh.failurePolicy,
+		NamespaceSelector:       wh.selector,
+		TimeoutSeconds:          wh.timeoutSeconds,
+		SideEffects:             &sideEffect,
+		AdmissionReviewVersions: []string{"v1"},
 	}
 
 	mutatingWebhooks := []arv1.MutatingWebhook{mutatingWebhook}


### PR DESCRIPTION
When deploying the latest spark operator using the helm scripts configured with the tag `v1beta2-1.3.0-3.1.1`  on Kubernetes 1.22 the operator failed to deploy because the webhook was missing the settings SideEffects, and AdmissionReviewVersions.