### PR TITLE
[WIP] Add a hook to dowload the external jar if it is specified

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,8 +50,8 @@ jobs:
       - name: Build Spark-Operator Docker Image
         run: |
           tag=$(git describe --tags --dirty)_v3.1.1
-          docker build -t gcr.io/spark-operator/spark-operator:${tag} .
-          docker build -t gcr.io/spark-operator/spark-operator:local .
+          docker build -t quay.io/crawl_soever/spark-operator:${tag} .
+          docker build -t quay.io/crawl_soever/spark-operator:local .
 
       - name: Install Helm
         uses: azure/setup-helm@v1
@@ -85,7 +85,7 @@ jobs:
       - name: Run chart-testing (install)
         run: |
           tag=$(git describe --tags --dirty)_v3.1.1
-          minikube image load gcr.io/spark-operator/spark-operator:local
+          minikube image load quay.io/crawl_soever/spark-operator:local
           ct install
 
       # The integration tests are currently broken see: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1416

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,11 +3,11 @@ name: Pre-commit checks
 on:
   pull_request:
     branches:
-      - master
+      - bagnaram/remote-spark-jar
 
   push:
     branches:
-      - master
+      - bagnaram/remote-spark-jar
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,12 +47,28 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: log in to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build Spark-Operator Docker Image
         run: |
           #tag=$(git describe --tags --dirty)_v3.1.1
           tag=`git rev-parse HEAD`
           docker build -t quay.io/crawl_soever/spark-operator:${tag} .
           docker build -t quay.io/crawl_soever/spark-operator:local .
+          echo "Ideally, we'd release the docker container at this point, but the maintainer of this repo needs to approve..."
+          echo "docker push quay.io/crawl_soever/spark-operator:${tag}"
+
+#      - name: Build Spark-Operator Docker Image
+#        run: |
+#          #tag=$(git describe --tags --dirty)_v3.1.1
+#          tag=`git rev-parse HEAD`
+#          docker build -t quay.io/crawl_soever/spark-operator:${tag} .
+#          docker build -t quay.io/crawl_soever/spark-operator:local .
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Build Spark-Operator Docker Image
         run: |
-          tag=$(git describe --tags --dirty)_v3.1.1
+          #tag=$(git describe --tags --dirty)_v3.1.1
+          tag=`git rev-parse HEAD`
           docker build -t quay.io/crawl_soever/spark-operator:${tag} .
           docker build -t quay.io/crawl_soever/spark-operator:local .
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: log in to container registry
         uses: docker/login-action@v1
         with:
-          registry: gcr.io
+          registry: quay.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -60,8 +60,7 @@ jobs:
           tag=`git rev-parse HEAD`
           docker build -t quay.io/crawl_soever/spark-operator:${tag} .
           docker build -t quay.io/crawl_soever/spark-operator:local .
-          echo "Ideally, we'd release the docker container at this point, but the maintainer of this repo needs to approve..."
-          echo "docker push quay.io/crawl_soever/spark-operator:${tag}"
+          docker push quay.io/crawl_soever/spark-operator:${tag}
 
 #      - name: Build Spark-Operator Docker Image
 #        run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - master
+      - bagnaram/remote-spark-jar
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,20 +31,20 @@ jobs:
       # TODO: Maintainer of repository to follow:
       # https://github.com/docker/login-action#google-container-registry-gcr to add credentials so
       # we can push from github actions
-      # - name: log in to container registry
-      #   uses: docker/login-action@v1
-      #   with:
-      #     registry: gcr.io
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: log in to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Spark-Operator Docker Image
         run: |
           tag=$(git describe --tags --dirty)_v3.1.1
-          docker build -t gcr.io/spark-operator/spark-operator:${tag} .
-          docker build -t gcr.io/spark-operator/spark-operator:local .
+          docker build -t quay.io/crawl_soever/spark-operator:${tag} .
+          docker build -t quay.io/crawl_soever/spark-operator:local .
           echo "Ideally, we'd release the docker container at this point, but the maintainer of this repo needs to approve..."
-          echo "docker push gcr.io/spark-operator/spark-operator:${tag}"
+          echo "docker push quay.io/crawl_soever/spark-operator:${tag}"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 .PHONY: clean-sparkctl
 
 SPARK_OPERATOR_GOPATH=/go/src/github.com/bagnaram/spark-on-k8s-operator
-DEP_VERSION:=`grep DEP_VERSION= Dockerfile | awk -F\" '{print $$2}'`
-BUILDER=`grep "FROM golang:" Dockerfile | awk '{print $$2}'`
+DEP_VERSION:=`awk -F\" '/DEP_VERSION=/{print $$2}' Dockerfile`
+BUILDER=`awk '/^FROM golang:/{print $$2}' Dockerfile`
 UNAME:=`uname | tr '[:upper:]' '[:lower:]'`
 REPO=github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .SILENT:
 .PHONY: clean-sparkctl
 
-SPARK_OPERATOR_GOPATH=/go/src/github.com/GoogleCloudPlatform/spark-on-k8s-operator
+SPARK_OPERATOR_GOPATH=/go/src/github.com/bagnaram/spark-on-k8s-operator
 DEP_VERSION:=`grep DEP_VERSION= Dockerfile | awk -F\" '{print $$2}'`
 BUILDER=`grep "FROM golang:" Dockerfile | awk '{print $$2}'`
 UNAME:=`uname | tr '[:upper:]' '[:lower:]'`

--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -19,6 +19,7 @@
 | Riskified | @henbh | Evaluation | Analytics Data Platform |
 | CloudZone | @iftachsc | Evaluation | Big Data Analytics Consultancy |
 | Cyren | @avnerl | Evaluation | Data pipelines |
+| [Procore](https://www.procore.com/) | @bagnaram | Evaluation | Data Platform / Data Infrastructure |
 | Shell (Agile Hub) | @TomLous | Production | Data pipelines |
 | Nielsen Identity Engine | @roitvt | Evaluation | Data pipelines |
 | [Data Mechanics](https://www.datamechanics.co)  | @jrj-d | Production | Managed Spark Platform |

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -214,9 +214,6 @@ func buildSubmissionCommandArgs(app *v1beta2.SparkApplication, driverPodName str
 			if err != nil {
 				return nil, err
 			}
-
-			//set the application to point to local
-			*app.Spec.MainApplicationFile = "local:///tmp/application.jar"
 		}
 
 		// Add the main application file if it is present.


### PR DESCRIPTION
🚧 
I will squash and revert the CI changes when ready to merge. 

This introduces logic to the spark-submit to fetch external JAR files to local. This is useful to download jobs from an artifact repository without rebuilding container images for each job.
