### PR TITLE
Fixes an error that was preventing the pods from being mutated

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -298,9 +298,12 @@ func (wh *WebHook) serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := admissionv1.AdmissionReview{}
+	response := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+		Response: reviewResponse,
+	}
+
 	if reviewResponse != nil {
-		response.Response = reviewResponse
 		if review.Request != nil {
 			response.Response.UID = review.Request.UID
 		}


### PR DESCRIPTION
When testing out the latest changes on k8s 1.22 I noticed that the pods were not getting mutated despite the webhook being invoked. 

When I checked the k8s logs I noticed an error message like the following

```
": expected webhook response of admission.k8s.io/v1, Kind=AdmissionReview, got /,
```

When I updated the operator to explicitly specify the Kind in TypeMeta the error went away and the modifications were applied to the pod.

