### PR TITLE
use github container registry instead of gcr.io for releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,8 +80,7 @@ jobs:
 
       - name: Build Spark-Operator Docker Image
         run: |
-          DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
-          docker build -t gcr.io/spark-operator/spark-operator:${DOCKER_TAG} .
+          docker build -t gcr.io/spark-operator/spark-operator:latest .
 
       - name: Check changes in resources used in docker file
         run: |
@@ -97,7 +96,7 @@ jobs:
               fi
             fi
           done
-          
+
   build-helm-chart:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,10 +33,13 @@ jobs:
       #     registry: gcr.io
       #     username: ${{ secrets.DOCKER_USERNAME }}
       #     password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: log in to github container registry
-        run: |
-          docker login ghcr.io -u token --password-stdin <<< ${{ github.token }}
+      
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Spark-Operator Docker Image to github container registry
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,27 +24,28 @@ jobs:
         with:
           version: v3.7.1
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.10
-
       # TODO: Maintainer of repository to follow:
       # https://github.com/docker/login-action#google-container-registry-gcr to add credentials so
       # we can push from github actions
-      # - name: log in to container registry
+      # - name: log in to google container registry
       #   uses: docker/login-action@v1
       #   with:
       #     registry: gcr.io
       #     username: ${{ secrets.DOCKER_USERNAME }}
       #     password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Release Spark-Operator Docker Image
+      - name: log in to github container registry
+        run: |
+          docker login ghcr.io -u token --password-stdin <<< ${{ github.token }}
+
+      - name: Release Spark-Operator Docker Image to github container registry
         run: |
           DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
           docker build -t gcr.io/spark-operator/spark-operator:${DOCKER_TAG} .
           echo "Ideally, we'd release the docker container at this point, but the maintainer of this repo needs to approve..."
-          if ! docker pull docker pull gcr.io/spark-operator/spark-operator:${DOCKER_TAG}; then
-            echo "docker push gcr.io/spark-operator/spark-operator:${DOCKER_TAG}"
+          docker tag gcr.io/spark-operator/spark-operator:${DOCKER_TAG} ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}
+          if ! docker pull ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}; then
+            docker push ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}
             git tag $DOCKER_TAG
             git push origin $DOCKER_TAG
           fi


### PR DESCRIPTION
I don't think any CI tool currently deploys the spark-operator to gcr.io, I think @liyinan926  has possibly been doing it manually.

This change moves to using the github container registry because the repository should be able to authenticate with github easier than requiring an administrator of this repository to do some manual steps.

it appears possible looking at this repository

https://github.com/GoogleCloudPlatform/gke-autoneg-controller/blame/master/.github/workflows/go.yml