### PR TITLE
Kubernetes v1.22 extensions/v1beta1 API removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The following table lists the most recent few versions of the operator.
 | Operator Version | API Version | Kubernetes Version | Base Spark Version | Operator Image Tag |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | `latest` (master HEAD) | `v1beta2` | 1.13+ | `3.0.0` | `latest` |
+| `v1beta2-1.3.3-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.3-3.1.1` |
+| `v1beta2-1.3.2-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.2-3.1.1` |
 | `v1beta2-1.3.0-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.0-3.1.1` |
 | `v1beta2-1.2.3-3.1.1` | `v1beta2` | 1.13+ | `3.1.1` | `v1beta2-1.2.3-3.1.1` |
 | `v1beta2-1.2.0-3.0.0` | `v1beta2` | 1.13+ | `3.0.0` | `v1beta2-1.2.0-3.0.0` |

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.1.16
-appVersion: v1beta2-1.3.2-3.1.1
+appVersion: v1beta2-1.3.3-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.16
+version: 1.1.17
 appVersion: v1beta2-1.3.3-3.1.1
 keywords:
   - spark

--- a/main.go
+++ b/main.go
@@ -153,6 +153,10 @@ func main() {
 		glog.Fatal(err)
 	}
 
+	if err = util.InitializeIngressCapabilities(kubeClient); err != nil {
+		glog.Fatalf("Error retrieving Kubernetes cluster capabilities: %s", err.Error())
+	}
+
 	var batchSchedulerMgr *batchscheduler.SchedulerManager
 	if *enableBatchScheduler {
 		if !*enableWebhook {

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -18,7 +18,7 @@ package v1beta2
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -322,7 +322,7 @@ type SparkUIConfiguration struct {
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 	// TlsHosts is useful If we need to declare SSL certificates to the ingress object
 	// +optional
-	IngressTLS []extensions.IngressTLS `json:"ingressTLS,omitempty"`
+	IngressTLS []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
 }
 
 // ApplicationStateType represents the type of the current state of an application.

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -24,7 +24,7 @@ package v1beta2
 
 import (
 	v1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -1009,6 +1009,13 @@ func (in *SparkUIConfiguration) DeepCopyInto(out *SparkUIConfiguration) {
 		*out = new(v1.ServiceType)
 		**out = **in
 	}
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.IngressAnnotations != nil {
 		in, out := &in.IngressAnnotations, &out.IngressAnnotations
 		*out = make(map[string]string, len(*in))
@@ -1018,7 +1025,7 @@ func (in *SparkUIConfiguration) DeepCopyInto(out *SparkUIConfiguration) {
 	}
 	if in.IngressTLS != nil {
 		in, out := &in.IngressTLS, &out.IngressTLS
-		*out = make([]v1beta1.IngressTLS, len(*in))
+		*out = make([]networkingv1.IngressTLS, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -873,7 +873,7 @@ func (c *Controller) deleteSparkResources(app *v1beta2.SparkApplication) error {
 	sparkUIIngressName := app.Status.DriverInfo.WebUIIngressName
 	if sparkUIIngressName != "" {
 		glog.V(2).Infof("Deleting Spark UI Ingress %s in namespace %s", sparkUIIngressName, app.Namespace)
-		err := c.kubeClient.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(context.TODO(), sparkUIIngressName, metav1.DeleteOptions{GracePeriodSeconds: int64ptr(0)})
+		err := c.kubeClient.NetworkingV1().Ingresses(app.Namespace).Delete(context.TODO(), sparkUIIngressName, metav1.DeleteOptions{GracePeriodSeconds: int64ptr(0)})
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -916,7 +916,7 @@ func (c *Controller) validateSparkResourceDeletion(app *v1beta2.SparkApplication
 
 	sparkUIIngressName := app.Status.DriverInfo.WebUIIngressName
 	if sparkUIIngressName != "" {
-		_, err := c.kubeClient.ExtensionsV1beta1().Ingresses(app.Namespace).Get(context.TODO(), sparkUIIngressName, metav1.GetOptions{})
+		_, err := c.kubeClient.NetworkingV1().Ingresses(app.Namespace).Get(context.TODO(), sparkUIIngressName, metav1.GetOptions{})
 		if err == nil || !errors.IsNotFound(err) {
 			return false
 		}

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -872,10 +872,19 @@ func (c *Controller) deleteSparkResources(app *v1beta2.SparkApplication) error {
 
 	sparkUIIngressName := app.Status.DriverInfo.WebUIIngressName
 	if sparkUIIngressName != "" {
-		glog.V(2).Infof("Deleting Spark UI Ingress %s in namespace %s", sparkUIIngressName, app.Namespace)
-		err := c.kubeClient.NetworkingV1().Ingresses(app.Namespace).Delete(context.TODO(), sparkUIIngressName, metav1.DeleteOptions{GracePeriodSeconds: int64ptr(0)})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
+		if util.IngressCapabilities.Has("networking.k8s.io/v1") {
+			glog.V(2).Infof("Deleting Spark UI Ingress %s in namespace %s", sparkUIIngressName, app.Namespace)
+			err := c.kubeClient.NetworkingV1().Ingresses(app.Namespace).Delete(context.TODO(), sparkUIIngressName, metav1.DeleteOptions{GracePeriodSeconds: int64ptr(0)})
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+		}
+		if util.IngressCapabilities.Has("extensions/v1beta1") {
+			glog.V(2).Infof("Deleting extensions/v1beta1 Spark UI Ingress %s in namespace %s", sparkUIIngressName, app.Namespace)
+			err := c.kubeClient.ExtensionsV1beta1().Ingresses(app.Namespace).Delete(context.TODO(), sparkUIIngressName, metav1.DeleteOptions{GracePeriodSeconds: int64ptr(0)})
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
 		}
 	}
 

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -1599,7 +1599,7 @@ func TestIngressWithSubpathAffectsSparkConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ingresses, err := ctrl.kubeClient.ExtensionsV1beta1().Ingresses(app.Namespace).List(context.TODO(), metav1.ListOptions{})
+	ingresses, err := ctrl.kubeClient.NetworkingV1().Ingresses(app.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -48,6 +48,7 @@ func newFakeController(app *v1beta2.SparkApplication, pods ...*apiv1.Pod) (*Cont
 	crdclientfake.AddToScheme(scheme.Scheme)
 	crdClient := crdclientfake.NewSimpleClientset()
 	kubeClient := kubeclientfake.NewSimpleClientset()
+	util.IngressCapabilities = map[string]bool{"networking.k8s.io/v1": true}
 	informerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0*time.Second)
 	recorder := record.NewFakeRecorder(3)
 
@@ -1602,6 +1603,9 @@ func TestIngressWithSubpathAffectsSparkConfiguration(t *testing.T) {
 	ingresses, err := ctrl.kubeClient.NetworkingV1().Ingresses(app.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if ingresses == nil || ingresses.Items == nil || len(ingresses.Items) != 1 {
+		t.Fatal("The ingress does not exist, has no items, or wrong amount of items")
 	}
 	if ingresses.Items[0].Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Path != "/"+app.Namespace+"/"+app.Name+"(/|$)(.*)" {
 		t.Fatal("The ingress subpath was not created successfully.")

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 // Helper method to create a key with namespace and appName
@@ -100,8 +100,8 @@ func getIngressResourceAnnotations(app *v1beta2.SparkApplication) map[string]str
 	return ingressAnnotations
 }
 
-func getIngressTlsHosts(app *v1beta2.SparkApplication) []v1beta1.IngressTLS {
-	var ingressTls []v1beta1.IngressTLS
+func getIngressTlsHosts(app *v1beta2.SparkApplication) []networkingv1.IngressTLS {
+	var ingressTls []networkingv1.IngressTLS
 	if app.Spec.SparkUIOptions != nil && app.Spec.SparkUIOptions.IngressTLS != nil {
 		for _, ingTls := range app.Spec.SparkUIOptions.IngressTLS {
 			ingressTls = append(ingressTls, ingTls)

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 
 	apiv1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -33,6 +34,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
 )
 
 const (
@@ -80,6 +82,14 @@ type SparkIngress struct {
 }
 
 func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, kubeClient clientset.Interface) (*SparkIngress, error) {
+	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
+		return createSparkUIIngress_v1(app, service, ingressURL, kubeClient)
+	} else {
+		return createSparkUIIngress_legacy(app, service, ingressURL, kubeClient)
+	}
+}
+
+func createSparkUIIngress_v1(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, kubeClient clientset.Interface) (*SparkIngress, error) {
 	ingressResourceAnnotations := getIngressResourceAnnotations(app)
 	ingressTlsHosts := getIngressTlsHosts(app)
 
@@ -89,7 +99,7 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 		ingressURLPath = ingressURLPath + "(/|$)(.*)"
 	}
 
-  implementationSpecific := networkingv1.PathTypeImplementationSpecific
+	implementationSpecific := networkingv1.PathTypeImplementationSpecific
 
 	ingress := networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -105,15 +115,15 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{
 							Backend: networkingv1.IngressBackend{
-                Service: &networkingv1.IngressServiceBackend{
-                    Name: service.serviceName,
-                    Port: networkingv1.ServiceBackendPort{
-                      Number: service.servicePort,
-                    },
+								Service: &networkingv1.IngressServiceBackend{
+									Name: service.serviceName,
+									Port: networkingv1.ServiceBackendPort{
+										Number: service.servicePort,
+									},
 								},
 							},
-							Path: ingressURLPath,
-              PathType: &implementationSpecific,
+							Path:     ingressURLPath,
+							PathType: &implementationSpecific,
 						}},
 					},
 				},
@@ -137,7 +147,6 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 	}
 	glog.Infof("Creating an Ingress %s for the Spark UI for application %s", ingress.Name, app.Name)
 	_, err := kubeClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.TODO(), &ingress, metav1.CreateOptions{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -145,8 +154,86 @@ func createSparkUIIngress(app *v1beta2.SparkApplication, service SparkService, i
 		ingressName: ingress.Name,
 		ingressURL:  ingressURL,
 		annotations: ingress.Annotations,
-		ingressTLS:  ingress.Spec.TLS,
+		ingressTLS:  ingressTlsHosts,
 	}, nil
+}
+
+func createSparkUIIngress_legacy(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, kubeClient clientset.Interface) (*SparkIngress, error) {
+	ingressResourceAnnotations := getIngressResourceAnnotations(app)
+	// var ingressTlsHosts networkingv1.IngressTLS[]
+	// That we convert later for extensionsv1beta1, but return as is in SparkIngress
+	ingressTlsHosts := getIngressTlsHosts(app)
+
+	ingressURLPath := ingressURL.Path
+	// If we're serving on a subpath, we need to ensure we create capture groups
+	if ingressURLPath != "" && ingressURLPath != "/" {
+		ingressURLPath = ingressURLPath + "(/|$)(.*)"
+	}
+
+	ingress := extensions.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            getDefaultUIIngressName(app),
+			Namespace:       app.Namespace,
+			Labels:          getResourceLabels(app),
+			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(app)},
+		},
+		Spec: extensions.IngressSpec{
+			Rules: []extensions.IngressRule{{
+				Host: ingressURL.Host,
+				IngressRuleValue: extensions.IngressRuleValue{
+					HTTP: &extensions.HTTPIngressRuleValue{
+						Paths: []extensions.HTTPIngressPath{{
+							Backend: extensions.IngressBackend{
+								ServiceName: service.serviceName,
+								ServicePort: intstr.IntOrString{
+									Type:   intstr.Int,
+									IntVal: service.servicePort,
+								},
+							},
+							Path: ingressURLPath,
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	if len(ingressResourceAnnotations) != 0 {
+		ingress.ObjectMeta.Annotations = ingressResourceAnnotations
+	}
+
+	// If we're serving on a subpath, we need to ensure we use the capture groups
+	if ingressURL.Path != "" && ingressURL.Path != "/" {
+		if ingress.ObjectMeta.Annotations == nil {
+			ingress.ObjectMeta.Annotations = make(map[string]string)
+		}
+		ingress.ObjectMeta.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$2"
+	}
+	if len(ingressTlsHosts) != 0 {
+		ingress.Spec.TLS = convertIngressTlsHostsToLegacy(ingressTlsHosts)
+	}
+	glog.Infof("Creating an extensions/v1beta1 Ingress %s for the Spark UI for application %s", ingress.Name, app.Name)
+	_, err := kubeClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(context.TODO(), &ingress, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &SparkIngress{
+		ingressName: ingress.Name,
+		ingressURL:  ingressURL,
+		annotations: ingress.Annotations,
+		ingressTLS:  ingressTlsHosts,
+	}, nil
+}
+
+func convertIngressTlsHostsToLegacy(ingressTlsHosts []networkingv1.IngressTLS) []extensions.IngressTLS {
+	var ingressTlsHosts_legacy []extensions.IngressTLS
+	for _, ingressTlsHost := range ingressTlsHosts {
+		ingressTlsHosts_legacy = append(ingressTlsHosts_legacy, extensions.IngressTLS{
+			Hosts:      ingressTlsHost.Hosts,
+			SecretName: ingressTlsHost.SecretName,
+		})
+	}
+	return ingressTlsHosts_legacy
 }
 
 func createSparkUIService(

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
 )
 
 func TestCreateSparkUIService(t *testing.T) {
@@ -43,6 +44,7 @@ func TestCreateSparkUIService(t *testing.T) {
 	}
 	testFn := func(test testcase, t *testing.T) {
 		fakeClient := fake.NewSimpleClientset()
+		util.IngressCapabilities = map[string]bool{"networking.k8s.io/v1": true}
 		sparkService, err := createSparkUIService(test.app, fakeClient)
 		if err != nil {
 			if test.expectError {

--- a/pkg/util/capabilities.go
+++ b/pkg/util/capabilities.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+type Capabilities map[string]bool
+
+func (c Capabilities) Has(wanted string) bool {
+	return c[wanted]
+}
+
+func (c Capabilities) String() string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
+}
+
+// getPreferredAvailableAPIs queries the cluster for the preferred resources information and returns a Capabilities
+// instance containing those api groups that support the specified kind.
+//
+// kind should be the title case singular name of the kind. For example, "Ingress" is the kind for a resource "ingress".
+func getPreferredAvailableAPIs(client kubernetes.Interface, kind string) (Capabilities, error) {
+	discoveryclient := client.Discovery()
+	lists, err := discoveryclient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+
+	caps := Capabilities{}
+	for _, list := range lists {
+		if len(list.APIResources) == 0 {
+			continue
+		}
+		for _, resource := range list.APIResources {
+			if len(resource.Verbs) == 0 {
+				continue
+			}
+			if resource.Kind == kind {
+				caps[list.GroupVersion] = true
+			}
+		}
+	}
+
+	return caps, nil
+}
+
+var (
+	IngressCapabilities Capabilities
+)
+
+func InitializeIngressCapabilities(client kubernetes.Interface) (err error) {
+	if IngressCapabilities != nil {
+		return
+	}
+	IngressCapabilities, err = getPreferredAvailableAPIs(client, "Ingress")
+	return
+}


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1426.
This is a breaking change, meaning that on kubernetes versions older than 1.19 Ingress objects would fail to be created (everything else should still work as expected). It also defines the `pathType` statically as "ImplementationSpecific". 