### PR TITLE
Modify istio enabled control flow in jobs to properly apply annotation when istio.enabled=false

### DIFF
--- a/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -13,6 +13,9 @@ spec:
       name: {{ include "spark-operator.fullname" . }}-webhook-cleanup
       {{- if .Values.istio.enabled }}
       annotations:
+        "sidecar.istio.io/inject": "true"
+      {{- else }}
+      annotations:
         "sidecar.istio.io/inject": "false"
       {{- end }}
     spec:

--- a/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -11,13 +11,8 @@ spec:
   template:
     metadata:
       name: {{ include "spark-operator.fullname" . }}-webhook-cleanup
-      {{- if .Values.istio.enabled }}
       annotations:
-        "sidecar.istio.io/inject": {{ .Values.istio.enabled | quote }}
-      {{- else }}
-      annotations:
-        "sidecar.istio.io/inject": "false"
-      {{- end }}
+        "sidecar.istio.io/inject": {{ .Values.istio.enabled | default false | quote }}
     spec:
       serviceAccountName: {{ include "spark-operator.serviceAccountName" . }}
       restartPolicy: OnFailure

--- a/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -13,7 +13,7 @@ spec:
       name: {{ include "spark-operator.fullname" . }}-webhook-cleanup
       {{- if .Values.istio.enabled }}
       annotations:
-        "sidecar.istio.io/inject": "true"
+        "sidecar.istio.io/inject": {{ .Values.istio.enabled | quote }}
       {{- else }}
       annotations:
         "sidecar.istio.io/inject": "false"

--- a/charts/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-init-job.yaml
@@ -13,6 +13,9 @@ spec:
       name: {{ include "spark-operator.fullname" . }}-webhook-init
       {{- if .Values.istio.enabled }}
       annotations:
+        "sidecar.istio.io/inject": "true"
+      {{- else }}
+      annotations:
         "sidecar.istio.io/inject": "false"
       {{- end }}
     spec:

--- a/charts/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-init-job.yaml
@@ -11,13 +11,8 @@ spec:
   template:
     metadata:
       name: {{ include "spark-operator.fullname" . }}-webhook-init
-      {{- if .Values.istio.enabled }}
       annotations:
-        "sidecar.istio.io/inject": {{ .Values.istio.enabled | quote }}
-      {{- else }}
-      annotations:
-        "sidecar.istio.io/inject": "false"
-      {{- end }}
+        "sidecar.istio.io/inject": {{ .Values.istio.enabled | default false | quote }}
     spec:
       serviceAccountName: {{ include "spark-operator.serviceAccountName" . }}
       restartPolicy: OnFailure

--- a/charts/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-init-job.yaml
@@ -13,7 +13,7 @@ spec:
       name: {{ include "spark-operator.fullname" . }}-webhook-init
       {{- if .Values.istio.enabled }}
       annotations:
-        "sidecar.istio.io/inject": "true"
+        "sidecar.istio.io/inject": {{ .Values.istio.enabled | quote }}
       {{- else }}
       annotations:
         "sidecar.istio.io/inject": "false"


### PR DESCRIPTION
Currently setting `istio.enabled = false` has no effect on the jobs.

If `istio.enabled` => set the annotation to be false.

The logic should be

if `istio.enabled` => set the annotation to be true.
else => set the annotation to be false.