### PR TITLE
Fixes an issue with github action in job build-spark-operator

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,7 +89,7 @@ jobs:
             # If the resource is different
             if ! git diff  --quiet origin/master -- $resource; then
               ## And the appVersion hasn't been updated
-              if ! git diff --quiet charts/spark-operator-chart/Chart.yaml | grep +appVersion; then
+              if ! git diff origin/master -- charts/spark-operator-chart/Chart.yaml | grep +appVersion; then
                 echo "resource used in gcr.io/spark-operator/spark-operator has changed in $resource, need to update the appVersion in charts/spark-operator-chart/Chart.yaml"
                 git diff origin/master -- $resource;
                 echo "failing the build... " && false


### PR DESCRIPTION
It seems that https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1418/files introduces a bug in the workflow, at step `Check changes in resources used in docker file` in job `build-spark-operator`:
```
      - name: Check changes in resources used in docker file
        run: |
          DOCKERFILE_RESOURCES=$(cat Dockerfile | grep -P -o "COPY [a-zA-Z0-9].*? " | cut -c6-)
          for resource in $DOCKERFILE_RESOURCES; do
            # If the resource is different
            if ! git diff  --quiet origin/master -- $resource; then
              ## And the appVersion hasn't been updated
              if ! git diff --quiet charts/spark-operator-chart/Chart.yaml | grep +appVersion; then
                echo "resource used in gcr.io/spark-operator/spark-operator has changed in $resource, need to update the appVersion in charts/spark-operator-chart/Chart.yaml"
                git diff origin/master -- $resource;
                echo "failing the build... " && false
              fi
            fi
          done
```
Basically, `git diff --quiet charts/spark-operator-chart/Chart.yaml | grep +appVersion` would always fail since `--quiet` removes all output and can't be used together with `grep`. As a consequence, the required changes to `Chart.yaml` are never detected and builds would fail. 