### PR TITLE
Updated default registry to ghcr.io

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -148,8 +148,8 @@ jobs:
 
       - name: Run chart-testing (install)
         run: |
-          docker build -t gcr.io/spark-operator/spark-operator:local .
-          minikube image load gcr.io/spark-operator/spark-operator:local
+          docker build -t ghcr.io/googlecloudplatform/spark-operator:local .
+          minikube image load ghcr.io/googlecloudplatform/spark-operator:local
           ct install
 
   integration-test:

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.17
+version: 1.1.18
 appVersion: v1beta2-1.3.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   # -- Image repository
-  repository: gcr.io/spark-operator/spark-operator
+  repository: ghcr.io/googlecloudplatform/spark-operator
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- if set, override the image tag whose default is the chart appVersion.

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -3120,8 +3120,8 @@ map[string]string
 <td>
 <code>ingressTLS</code><br/>
 <em>
-<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ingresstls-v1beta1-extensions">
-[]Kubernetes extensions/v1beta1.IngressTLS
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ingresstls-v1-networking">
+[]Kubernetes networking/v1.IngressTLS
 </a>
 </em>
 </td>


### PR DESCRIPTION
As the automated build system now pushes images to GitHub container registry, it makes sense to adjust the helm chart to use that as default instead of the old one. 