### PR TITLE
Github actions workflow fix for Helm chart deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Release Spark-Operator Docker Image
         run: |
           DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
-          if git rev-parse -q --verify "refs/tags/$DOCKER_TAG" >/dev/null; then
+          if git rev-parse -q --verify "refs/tags/$DOCKER_TAG"; then
             echo "Spark-Operator Docker Image Tag $DOCKER_TAG already exists!"
           else
             git tag $DOCKER_TAG

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Release Spark-Operator Docker Image to github container registry
+      - name: Build and Push Spark-Operator Docker Image to github container registry
         run: |
           DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
           docker build -t gcr.io/spark-operator/spark-operator:${DOCKER_TAG} .
@@ -49,15 +49,26 @@ jobs:
           docker tag gcr.io/spark-operator/spark-operator:${DOCKER_TAG} ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}
           if ! docker pull ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}; then
             docker push ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}
-            git tag $DOCKER_TAG
-            git push origin $DOCKER_TAG
+          else
+            echo "Spark-Operator Docker Image alredy exists"
           fi
 
-      - name: Run chart-releaser
+      - name: Release Spark-Operator Helm Chart
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "spark-operator-chart-{{ .Version }}"
+
+      - name: Release Spark-Operator Docker Image
+        run: |
+          DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
+          if git rev-parse -q --verify "refs/tags/$DOCKER_TAG" >/dev/null; then
+            echo "Spark-Operator Docker Image Tag $DOCKER_TAG already exists!"
+          else
+            git tag $DOCKER_TAG
+            git push origin $DOCKER_TAG
+            echo "Spark-Operator Docker Image new tag: $DOCKER_TAG released"
+          fi
 
       - name: Setup tmate session
         if: failure()


### PR DESCRIPTION
## What does this PR do?
### Problem: 
Helm Chart release deployment workflow is broken since `spark-operator-chart-1.1.15` due to an issue within the release workflow. Release workflow `name: Release Spark-Operator Docker Image to github container registry` step is building the Docker image and pushing the image to Github container registry. This step also creates a git `tag` and pushes the tag to this repo. The subsequent git action step `name: Run chart-releaser` is pulling the latest tag from the repo to identify the changes in the chart folder. This Helm chart step could never find the changes in the repo due to tag commit from the previous step.

### Solution: 
This PR moved `git tag` and `git push` tags to  a new github action step `name: Release Spark-Operator Docker Image` at end of the workflow. This ensures Docker image is published and the Helm Chart is published before pushing the TAG to the repo.

