### PR TITLE
Add Operator volumes and volumeMounts in chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Release Spark-Operator Docker Image to github container registry
+      - name: Build and Push Spark-Operator Docker Image to github container registry
         run: |
           DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
           docker build -t gcr.io/spark-operator/spark-operator:${DOCKER_TAG} .
@@ -49,15 +49,26 @@ jobs:
           docker tag gcr.io/spark-operator/spark-operator:${DOCKER_TAG} ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}
           if ! docker pull ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}; then
             docker push ghcr.io/googlecloudplatform/spark-operator:${DOCKER_TAG}
-            git tag $DOCKER_TAG
-            git push origin $DOCKER_TAG
+          else
+            echo "Spark-Operator Docker Image alredy exists"
           fi
 
-      - name: Run chart-releaser
+      - name: Release Spark-Operator Helm Chart
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "spark-operator-chart-{{ .Version }}"
+
+      - name: Release Spark-Operator Docker Image
+        run: |
+          DOCKER_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
+          if git rev-parse -q --verify "refs/tags/$DOCKER_TAG"; then
+            echo "Spark-Operator Docker Image Tag $DOCKER_TAG already exists!"
+          else
+            git tag $DOCKER_TAG
+            git push origin $DOCKER_TAG
+            echo "Spark-Operator Docker Image new tag: $DOCKER_TAG released"
+          fi
 
       - name: Setup tmate session
         if: failure()

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.17
+version: 1.1.18
 appVersion: v1beta2-1.3.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.18
+version: 1.1.19
 appVersion: v1beta2-1.3.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -88,15 +88,27 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-      {{- if .Values.webhook.enable }}
+        {{- if or .Values.webhook.enable (ne (len .Values.volumeMounts) 0 ) }}
         volumeMounts:
+        {{- end }}
+          {{- if .Values.webhook.enable }}
           - name: webhook-certs
             mountPath: /etc/webhook-certs
+          {{- end }}
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- if or .Values.webhook.enable (ne (len .Values.volumes) 0 ) }}
       volumes:
+      {{- end }}
+        {{- if .Values.webhook.enable }}
         - name: webhook-certs
           secret:
             secretName: {{ include "spark-operator.fullname" . }}-webhook-certs
-      {{- end }}
+        {{- end }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -74,6 +74,12 @@ podSecurityContext: {}
 # securityContext -- Operator container security context
 securityContext: {}
 
+# volumes - Operator volumes
+volumes: {}
+
+# volumeMounts - Operator volumeMounts
+volumeMounts: {}
+  
 webhook:
   # -- Enable webhook server
   enable: false

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -79,7 +79,7 @@ volumes: []
 
 # volumeMounts - Operator volumeMounts
 volumeMounts: []
-  
+
 webhook:
   # -- Enable webhook server
   enable: false


### PR DESCRIPTION
It is needed to mount one or more volumes into spark operator pod  because of various reasons such as external ivy cache.

In this pr, it is supported to operator pod's volumes and volumeMounts in chart.