### PR TITLE
Re-enable e2e integration tests and fix small issue with deleting SparkApplication

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -178,9 +178,13 @@ jobs:
           docker build -t gcr.io/spark-operator/spark-operator:local .
           minikube image load gcr.io/spark-operator/spark-operator:local
 
-      # The integration tests are currently broken see: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1416
-      # - name: Run chart-testing (integration test)
-      #   run: make integation-test
+      - name: Apply CRDs
+        run: |
+          minikube kubectl apply -f manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+          minikube kubectl apply -f manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+
+      - name: Run chart-testing (integration test)
+        run: make integation-test
       
       - name: Setup tmate session
         if: failure()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -180,11 +180,11 @@ jobs:
 
       - name: Apply CRDs
         run: |
-          minikube kubectl apply -f manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
-          minikube kubectl apply -f manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+          minikube kubectl -- apply -f manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+          minikube kubectl -- apply -f manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
 
       - name: Run chart-testing (integration test)
-        run: make integation-test
+        run: make integration-test
       
       - name: Setup tmate session
         if: failure()

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following table lists the most recent few versions of the operator.
 | Operator Version | API Version | Kubernetes Version | Base Spark Version | Operator Image Tag |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | `latest` (master HEAD) | `v1beta2` | 1.13+ | `3.0.0` | `latest` |
+| `v1beta2-1.3.4-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.4-3.1.1` |
 | `v1beta2-1.3.3-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.3-3.1.1` |
 | `v1beta2-1.3.2-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.2-3.1.1` |
 | `v1beta2-1.3.0-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.0-3.1.1` |

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.17
-appVersion: v1beta2-1.3.3-3.1.1
+version: 1.1.19
+appVersion: v1beta2-1.3.4-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/manifest/spark-application-rbac/spark-application-rbac.yaml
+++ b/manifest/spark-application-rbac/spark-application-rbac.yaml
@@ -36,6 +36,9 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifest/test/spark-operator-with-webhook.yaml
+++ b/manifest/test/spark-operator-with-webhook.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sparkoperator
+  namespace: spark-operator
+  labels:
+    app.kubernetes.io/name: sparkoperator
+    app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sparkoperator
+      app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sparkoperator
+        app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+    spec:
+      serviceAccountName: sparkoperator
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: spark-webhook-certs
+      containers:
+      - name: sparkoperator
+        image: gcr.io/spark-operator/spark-operator:v1beta2-1.3.0-3.1.1
+        imagePullPolicy: Always
+        args:
+        - -logtostderr
+        - -enable-webhook=true
+        - -v=2
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /etc/webhook-certs

--- a/manifest/test/spark-operator-with-webhook.yaml
+++ b/manifest/test/spark-operator-with-webhook.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: sparkoperator
         image: gcr.io/spark-operator/spark-operator:v1beta2-1.3.0-3.1.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
         - -logtostderr
         - -enable-webhook=true

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -442,7 +442,9 @@ func (c *Controller) getAndUpdateAppState(app *v1beta2.SparkApplication) error {
 }
 
 func (c *Controller) handleSparkApplicationDeletion(app *v1beta2.SparkApplication) {
-	c.metrics.exportMetricsOnDelete(app)
+  if c.metrics != nil {
+    c.metrics.exportMetricsOnDelete(app)
+  }
 	// SparkApplication deletion requested, lets delete driver pod.
 	if err := c.deleteSparkResources(app); err != nil {
 		glog.Errorf("failed to delete resources associated with deleted SparkApplication %s/%s: %v", app.Namespace, app.Name, err)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -39,11 +39,12 @@ type Framework struct {
 	SparkApplicationClient crdclientset.Interface
 	MasterHost             string
 	Namespace              *v1.Namespace
+	TestNamespace          *v1.Namespace
 	OperatorPod            *v1.Pod
 	DefaultTimeout         time.Duration
 }
 
-var SparkTestNamespace = ""
+var SparkTestNamespace = "spark"
 var SparkTestServiceAccount = ""
 var SparkTestImage = ""
 
@@ -64,6 +65,11 @@ func New(ns, sparkNs, kubeconfig, opImage string, opImagePullPolicy string) (*Fr
 		fmt.Println(nil, err, namespace)
 	}
 
+	testnamespace, err := CreateNamespace(cli, sparkNs)
+	if err != nil {
+		fmt.Println(nil, err, testnamespace)
+	}
+
 	saClient, err := crdclientset.NewForConfig(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create SparkApplication client")
@@ -74,6 +80,7 @@ func New(ns, sparkNs, kubeconfig, opImage string, opImagePullPolicy string) (*Fr
 		KubeClient:             cli,
 		SparkApplicationClient: saClient,
 		Namespace:              namespace,
+		TestNamespace:          testnamespace,
 		DefaultTimeout:         time.Minute,
 	}
 
@@ -94,31 +101,31 @@ func (f *Framework) Setup(sparkNs, opImage string, opImagePullPolicy string) err
 }
 
 func (f *Framework) setupOperator(sparkNs, opImage string, opImagePullPolicy string) error {
-	if _, err := CreateServiceAccount(f.KubeClient, f.Namespace.Name, "../../manifest/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if _, err := CreateServiceAccount(f.KubeClient, f.Namespace.Name, "../../manifest/spark-operator-install/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create operator service account")
 	}
 
-	if err := CreateClusterRole(f.KubeClient, "../../manifest/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := CreateClusterRole(f.KubeClient, "../../manifest/spark-operator-install/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create cluster role")
 	}
 
-	if _, err := CreateClusterRoleBinding(f.KubeClient, "../../manifest/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if _, err := CreateClusterRoleBinding(f.KubeClient, "../../manifest/spark-operator-install/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create cluster role binding")
 	}
 
-	if _, err := CreateServiceAccount(f.KubeClient, sparkNs, "../../manifest/spark-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if _, err := CreateServiceAccount(f.KubeClient, f.TestNamespace.Name, "../../manifest/spark-application-rbac/spark-application-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create Spark service account")
 	}
 
-	if err := CreateRole(f.KubeClient, sparkNs, "../../manifest/spark-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := CreateRole(f.KubeClient, sparkNs, "../../manifest/spark-application-rbac/spark-application-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create role")
 	}
 
-	if _, err := CreateRoleBinding(f.KubeClient, sparkNs, "../../manifest/spark-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if _, err := CreateRoleBinding(f.KubeClient, sparkNs, "../../manifest/spark-application-rbac/spark-application-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create role binding")
 	}
 
-	job, err := MakeJob("../../manifest/spark-operator-with-webhook.yaml")
+	job, err := MakeJob("../../manifest/spark-operator-with-webhook-install/spark-operator-webhook.yaml")
 	if err != nil {
 		return err
 	}
@@ -146,11 +153,11 @@ func (f *Framework) setupOperator(sparkNs, opImage string, opImagePullPolicy str
 		return errors.Wrap(err, "failed to delete the init job")
 	}
 
-	if _, err := CreateService(f.KubeClient, f.Namespace.Name, "../../manifest/spark-operator-with-webhook.yaml"); err != nil {
+	if _, err := CreateService(f.KubeClient, f.Namespace.Name, "../../manifest/spark-operator-with-webhook-install/spark-operator-webhook.yaml"); err != nil {
 		return errors.Wrap(err, "failed to create webhook service")
 	}
 
-	deploy, err := MakeDeployment("../../manifest/spark-operator-with-webhook.yaml")
+	deploy, err := MakeDeployment("../../manifest/test/spark-operator-with-webhook.yaml")
 	if err != nil {
 		return err
 	}
@@ -185,11 +192,11 @@ func (f *Framework) setupOperator(sparkNs, opImage string, opImagePullPolicy str
 
 // Teardown tears down a previously initialized test environment.
 func (f *Framework) Teardown() error {
-	if err := DeleteClusterRole(f.KubeClient, "../../manifest/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := DeleteClusterRole(f.KubeClient, "../../manifest/spark-operator-install/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to delete operator cluster role")
 	}
 
-	if err := DeleteClusterRoleBinding(f.KubeClient, "../../manifest/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := DeleteClusterRoleBinding(f.KubeClient, "../../manifest/spark-operator-install/spark-operator-rbac.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to delete operator cluster role binding")
 	}
 
@@ -198,6 +205,10 @@ func (f *Framework) Teardown() error {
 	}
 
 	if err := DeleteNamespace(f.KubeClient, f.Namespace.Name); err != nil {
+		return err
+	}
+
+	if err := DeleteNamespace(f.KubeClient, f.TestNamespace.Name); err != nil {
 		return err
 	}
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -34,12 +34,11 @@ var framework *operatorFramework.Framework
 var TIMEOUT = 240 * time.Second
 var INTERVAL = 1 * time.Second
 
-var STATES = [9]string{
+var STATES = [8]string{
 	"",
 	"SUBMITTED",
 	"RUNNING",
 	"COMPLETED",
-	"INVALIDATING",
 	"PENDING_RERUN",
 	"SUBMITTED",
 	"RUNNING",
@@ -57,7 +56,7 @@ func TestMain(m *testing.M) {
 	opImage := flag.String("operator-image", "", "operator image, e.g. image:tag")
 	opImagePullPolicy := flag.String("operator-image-pullPolicy", "IfNotPresent", "pull policy, e.g. Always")
 	ns := flag.String("namespace", "spark-operator", "e2e test namespace")
-	sparkTestNamespace := flag.String("spark-test-namespace", "default", "e2e test spark-test-namespace")
+	sparkTestNamespace := flag.String("spark-test-namespace", "spark", "e2e test spark-test-namespace")
 	sparkTestImage := flag.String("spark-test-image", "", "spark test image, e.g. image:tag")
 	sparkTestServiceAccount := flag.String("spark-test-service-account", "spark", "e2e test spark test service account")
 	flag.Parse()


### PR DESCRIPTION
This PR fixes the following issues:
* https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1416
* https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1467

It also bumps the chart version and spark-operator version. 

The e2e integration tests have been broken for a while now. This change only fixes the issues and re-enables them; however nothing is changed about the tests themselves. I've noticed that upon many runs there are some occasional failures, perhaps due to some race-conditions:
```
| cleaning up caches and output
| running unit tests
| === RUN   TestSubmitSparkPiYaml
| === PAUSE TestSubmitSparkPiYaml
| === RUN   TestSubmitSparkPiCustomResourceYaml
| === PAUSE TestSubmitSparkPiCustomResourceYaml
| === RUN   TestLifeCycleManagement
| --- PASS: TestLifeCycleManagement (73.16s)
| === RUN   TestMountConfigMap
| --- PASS: TestMountConfigMap (7.09s)
| === CONT  TestSubmitSparkPiYaml
| === CONT  TestSubmitSparkPiCustomResourceYaml
| --- PASS: TestSubmitSparkPiCustomResourceYaml (38.10s)
| === CONT  TestSubmitSparkPiYaml
|     basic_test.go:63:
|         	Error Trace:	basic_test.go:63
|         	Error:      	Not equal:
|         	            	expected: <nil>(<nil>)
|         	            	actual  : *errors.errorString(&errors.errorString{s:"timed out waiting for the condition"})
|         	Test:       	TestSubmitSparkPiYaml
|     basic_test.go:68:
|         	Error Trace:	basic_test.go:68
|         	Error:      	Not equal:
|         	            	expected: <nil>(<nil>)
|         	            	actual  : *errors.errorString(&errors.errorString{s:"resource name may not be empty"})
|         	Test:       	TestSubmitSparkPiYaml
|     basic_test.go:69:
|         	Error Trace:	basic_test.go:69
|         	Error:      	Should not be: -1
|         	Test:       	TestSubmitSparkPiYaml
| --- FAIL: TestSubmitSparkPiYaml (240.09s)
| FAIL
| FAIL	github.com/GoogleCloudPlatform/spark-on-k8s-operator/test/e2e	325.659s
| FAIL
| make: *** [Makefile:74: integration-test] Error 1
```

@TomHellier a review of the changes around e2e tests would be greatly appreciated. All my local tests were done against minikube with either [act](https://github.com/nektos/act) or just manual run (`make integration-test`). 