### PR TITLE
Implement --logs and --delete flags on 'sparkctl create' and a timeout on 'sparkctl log' to wait a pod startup

### DIFF
--- a/sparkctl/cmd/delete.go
+++ b/sparkctl/cmd/delete.go
@@ -51,12 +51,15 @@ var deleteCmd = &cobra.Command{
 }
 
 func doDelete(name string, crdClientset crdclientset.Interface) error {
-	err := crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
-	if err != nil {
+	if err := deleteSparkApplication(name, crdClientset); err != nil {
 		return err
 	}
 
 	fmt.Printf("SparkApplication \"%s\" deleted\n", name)
 
 	return nil
+}
+
+func deleteSparkApplication(name string, crdClientset crdclientset.Interface) error {
+	return crdClientset.SparkoperatorV1beta2().SparkApplications(Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
This PR added the following features:

- New flags on `sparkctl create`
  - `--logs`: watch SparkApplication logs until finished
  - `--delete`: delete the SparkApplication if already exists
- Timeout on `sparkctl log` to wait the pod startup and produce a log