### PR TITLE
fix: add pre-upgrade hook to rbac resources

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.22
+version: 1.1.23
 appVersion: v1beta2-1.3.6-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -4,8 +4,9 @@ kind: ClusterRole
 metadata:
   name: {{ include "spark-operator.fullname" . }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    "helm.sh/hook-weight": "-10"
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 rules:
@@ -112,8 +113,9 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "spark-operator.fullname" . }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    "helm.sh/hook-weight": "-10"
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 subjects:

--- a/charts/spark-operator-chart/templates/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/serviceaccount.yaml
@@ -4,8 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "spark-operator.serviceAccountName" . }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    "helm.sh/hook-weight": "-10"
 {{- with .Values.serviceAccounts.sparkoperator.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1379#issuecomment-966284850, a breaking change was introduced. 

The result is that when I did a helm upgrade from 1.1.6 chart to a 1.1.10+ chart, the spark-operator ClusterRole and ClusterRoleBinding resources are deleted. also see: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1407

In this PR, I added pre-upgrade value to all 3 resources. Although it won't create the RBAC resources upon the 1st `helm upgrade` from the old chart(I think this is helm behavior), a second `helm upgrade` will apply the previously non-hook RBAC resources.