### PR TITLE
Ensure that driver is deleted prior to sparkapplication resubmission

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.20
+version: 1.1.21
 appVersion: v1beta2-1.3.5-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.1.20
-appVersion: v1beta2-1.3.4-3.1.1
+appVersion: v1beta2-1.3.5-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator


### PR DESCRIPTION
Under rare circumstances, a Spark driver pod could have been created despite the fact that spark submission attempt failed. The driver pod might not necessarily be running, it could be stuck in Pending state due to failure of creating the associated configmap, for example. In such situation, the current Spark operator would not attempt to resubmit the job, nor would the submission count attempt increase. As a result, the sparkapplication will be stuck in the submission failure state indefinitely.

This MR deletes the associated spark resource in case such situation arise, which will allow the spark operator to resubmit the job again.

