### PR TITLE
Fix: use V1 api for CRDs for volcano integration

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.23
-appVersion: v1beta2-1.3.6-3.1.1
+version: 1.1.24
+appVersion: v1beta2-1.3.7-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -180,12 +180,19 @@ func New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {
 		return nil, fmt.Errorf("failed to initialize k8s extension client with error %v", err)
 	}
 
-	if _, err := extClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
+	if _, err := extClient.ApiextensionsV1().CustomResourceDefinitions().Get(
 		context.TODO(),
 		PodGroupName,
 		metav1.GetOptions{},
 	); err != nil {
-		return nil, fmt.Errorf("podGroup CRD is required to exists in current cluster error: %s", err)
+		//For backward compatibility check v1beta1 API version of CustomResourceDefinitions
+		if _, err := extClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
+			context.TODO(),
+			PodGroupName,
+			metav1.GetOptions{},
+		); err != nil {
+			return nil, fmt.Errorf("podGroup CRD is required to exists in current cluster error: %s", err)
+		}
 	}
 	return &VolcanoBatchScheduler{
 		extensionClient: extClient,


### PR DESCRIPTION
Volcano integration uses v1beta1 api version to check if podgroup CRD is present. However the apiextensions.k8s.io/v1beta1 API version for CRDs is no longer available in kubernetes 1.22+, apiextensions.k8s.io/v1 should be used instead. 