### PR TITLE
Fix #1581

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -339,6 +339,7 @@ const (
 	PendingRerunState     ApplicationStateType = "PENDING_RERUN"
 	InvalidatingState     ApplicationStateType = "INVALIDATING"
 	SucceedingState       ApplicationStateType = "SUCCEEDING"
+	SuspendedState        ApplicationStateType = "SUSPENDED"
 	FailingState          ApplicationStateType = "FAILING"
 	UnknownState          ApplicationStateType = "UNKNOWN"
 )


### PR DESCRIPTION
suspend a running spark streaming application

We add a new State: suspended.

to switch to suspended state we only need to annotate SparkApplication object with a specific annotation.
to resume the job, we need to delete the annotation

we can switch to suspended from all non-final states