### PR TITLE
Fix RBAC for leader election

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.26
+version: 1.1.27
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -13,14 +13,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - pods
+  verbs:
+  - "*"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
   verbs:
   - "*"
 - apiGroups:
   - ""
   resources:
   - services
-  - configmaps
   - secrets
   verbs:
   - create

--- a/manifest/spark-operator-install/spark-operator-rbac.yaml
+++ b/manifest/spark-operator-install/spark-operator-rbac.yaml
@@ -31,11 +31,11 @@ metadata:
   name: sparkoperator
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["configmaps", "pods"]
   verbs: ["*"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["*"]
+- apiGroups: [ "coordination.k8s.io" ]
+  resources: [ "leases" ]
+  verbs: [ "*" ]
 - apiGroups: [""]
   resources: ["services", "secrets"]
   verbs: ["create", "get", "delete"]


### PR DESCRIPTION
This PR fixes RBAC for leader election that is needed after upgrade of libraries from Go 1.15 to 1.19.
