### PR TITLE
Added permissions for leader election #1635

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.26
+version: 1.1.27
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -105,7 +105,25 @@ rules:
   verbs:
   - delete
   {{- end }}
-
+  {{- if gt (int .Values.replicaCount) 1 }}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - {{ .Values.leaderElection.lockName }}
+  verbs:
+  - get
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  {{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Added new RBAC permissions needed by default for leader election for the coordination/v1 API. 
Required after upgrade to golang:1.19.2.
In k8s.io/client-go@v0.25.3/tools/leaderelection/resourcelock/interface.go:166 `configMapsResourceLock` was removed and should be replaced by `ConfigMapsLeasesResourceLock`.

https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1635