### PR TITLE
Spark memory unit needs to be converted to kubernetes resource util

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -168,6 +168,10 @@ const (
 	// SparkDynamicAllocationMaxExecutors is the Spark configuration key for specifying the
 	// upper bound of the number of executors to request if dynamic allocation is enabled.
 	SparkDynamicAllocationMaxExecutors = "spark.dynamicAllocation.maxExecutors"
+	// SparkDriverMemoryOverhead is the Spark configuration key for a string of memoryOverhead to pass to driver.
+	SparkDriverMemoryOverhead = "spark.driver.memoryOverhead"
+	// SparkExecutorMemoryOverhead is the Spark configuration key for a string of memoryOverhead to pass to executor.
+	SparkExecutorMemoryOverhead = "spark.executor.memoryOverhead"
 )
 
 const (

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -279,7 +279,7 @@ func addDriverConfOptions(app *v1beta2.SparkApplication, submissionID string) ([
 	}
 	if app.Spec.Driver.MemoryOverhead != nil {
 		driverConfOptions = append(driverConfOptions,
-			fmt.Sprintf("spark.driver.memoryOverhead=%s", *app.Spec.Driver.MemoryOverhead))
+			fmt.Sprintf("%s=%s", config.SparkDriverMemoryOverhead, *app.Spec.Driver.MemoryOverhead))
 	}
 
 	if app.Spec.Driver.ServiceAccount != nil {
@@ -371,7 +371,7 @@ func addExecutorConfOptions(app *v1beta2.SparkApplication, submissionID string) 
 	}
 	if app.Spec.Executor.MemoryOverhead != nil {
 		executorConfOptions = append(executorConfOptions,
-			fmt.Sprintf("spark.executor.memoryOverhead=%s", *app.Spec.Executor.MemoryOverhead))
+			fmt.Sprintf("%s=%s", config.SparkExecutorMemoryOverhead, *app.Spec.Executor.MemoryOverhead))
 	}
 
 	if app.Spec.Executor.ServiceAccount != nil {


### PR DESCRIPTION
### appearance
podgroup yaml
<img width="644" alt="image" src="https://user-images.githubusercontent.com/39509320/205048529-0beeeca5-71bd-4648-8d03-0152b0a5dfa5.png">

volcano proportion log
<img width="858" alt="image" src="https://user-images.githubusercontent.com/39509320/205048180-8a5fd855-cacd-4061-a37a-788bd4f9f79c.png">

Volcano memory is not limited, and it is treated as byte

### change
- Spark memory unit needs to be converted to kubernetes resource util (eg: m ->Mi)
- Volcano podgroup resource add SparkConf value， Driver include 'spark.driver.memoryOverhead' and  Executer include 'spark.executor.memoryOverhead'

