### PR TITLE
Fix signal handling for non-leader processes

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,7 +219,11 @@ func main() {
 
 	if *enableLeaderElection {
 		glog.Info("Waiting to be elected leader before starting application controller goroutines")
-		<-startCh
+		select {
+		case <-signalCh:
+			os.Exit(0)
+		case <-startCh:
+		}
 	}
 
 	glog.Info("Starting application controller goroutines")


### PR DESCRIPTION
# Description
This PR fixes a small issue: when Leader Election is enabled, all non-leader processes are waiting on:
https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/c261df66a00635509f7d8cb2a7fba4c602c9228e/main.go#L222

However, this means that they are never getting to this signal-handling logic below:
https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/c261df66a00635509f7d8cb2a7fba4c602c9228e/main.go#L234-L238

This results in non-leader processes not responding to `SIGTERM` or `SIGINT`, those signals are simply ignored. The only way to terminate those processes is a `SIGKILL`. 

This PR makes sure that non-leader processes can be terminated with `SIGTERM` or `SIGINT`, just like the leader process.

# Testing
Verified this behaviour in our Kubernetes environment:
- Before the PR, `kill <PID>` was ignored for non-leader processes but worked for the leader process
- After the PR, `kill <PID>` successfully terminates both leader and non-leader processes