### PR TITLE
Fix docs for Volcano integration

### DIFF
--- a/docs/volcano-integration.md
+++ b/docs/volcano-integration.md
@@ -16,7 +16,7 @@ same environment, please refer [Quick Start Guide](https://github.com/volcano-sh
 Within the help of Helm chart, Kubernetes Operator for Apache Spark with Volcano can be easily installed with the command below:
 ```bash
 $ helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
-$ helm install my-release spark-operator/spark-operator --namespace spark-operator --set enableBatchScheduler=true --set enableWebhook=true
+$ helm install my-release spark-operator/spark-operator --namespace spark-operator --set batchScheduler.enable=true --set webhook.enable=true
 ```
 
 # Run Spark Application with Volcano scheduler


### PR DESCRIPTION
Docs had old chart flags for enabling batch scheduler/webhook, so it was not working.

@liyinan926 can you help merge this?