### PR TITLE
fix: fix issue #1723 about spark-operator not working with volcano on OCP

### DIFF
--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -82,8 +82,10 @@ rules:
   resources:
   - sparkapplications
   - sparkapplications/status
+  - sparkapplications/finalizers
   - scheduledsparkapplications
   - scheduledsparkapplications/status
+  - scheduledsparkapplications/finalizers
   verbs:
   - "*"
   {{- if .Values.batchScheduler.enable }}

--- a/manifest/spark-operator-install/spark-operator-rbac.yaml
+++ b/manifest/spark-operator-install/spark-operator-rbac.yaml
@@ -58,7 +58,7 @@ rules:
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
   verbs: ["create", "get", "update", "delete"]
 - apiGroups: ["sparkoperator.k8s.io"]
-  resources: ["sparkapplications", "scheduledsparkapplications", "sparkapplications/status", "scheduledsparkapplications/status"]
+  resources: ["sparkapplications", "scheduledsparkapplications", "sparkapplications/status", "scheduledsparkapplications/status", "sparkapplications/finalizers", "scheduledsparkapplications/finalizers"]
   verbs: ["*"]
 - apiGroups: ["scheduling.volcano.sh"]
   resources: ["podgroups", "queues", "queues/status"]

--- a/pkg/batchscheduler/volcano/volcano_scheduler.go
+++ b/pkg/batchscheduler/volcano/volcano_scheduler.go
@@ -115,9 +115,12 @@ func (v *VolcanoBatchScheduler) getAppPodGroupName(app *v1beta2.SparkApplication
 }
 
 func (v *VolcanoBatchScheduler) syncPodGroup(app *v1beta2.SparkApplication, size int32, minResource corev1.ResourceList) error {
-	var err error
+	var (
+		err error
+		pg  *v1beta1.PodGroup
+	)
 	podGroupName := v.getAppPodGroupName(app)
-	if pg, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(context.TODO(), podGroupName, metav1.GetOptions{}); err != nil {
+	if pg, err = v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(context.TODO(), podGroupName, metav1.GetOptions{}); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
Fix issue #1723 

We fix some parts of code:
- pkg/batchscheduler/volcano/volcano_scheduler.go: to return error when appear on podGroup create.
- pkg/batchscheduler/volcano/volcano_scheduler.go and manifest/spark-operator-install/spark-operator-rbac.yaml to fix right on OCP.

It fix error on OCP
```
podgroups.scheduling.volcano.sh "spark-spark-test-pg" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```