### PR TITLE
Optional sidecars for operator pod

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.27
+version: 1.1.28
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
         {{- with .Values.volumeMounts }}
         {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with .Values.sidecars }}
+      sidecars:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.webhook.enable (ne (len .Values.volumes) 0 ) }}
       volumes:
       {{- end }}

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -99,8 +99,7 @@ spec:
         {{- toYaml . | nindent 10 }}
         {{- end }}
       {{- with .Values.sidecars }}
-      sidecars:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- if or .Values.webhook.enable (ne (len .Values.volumes) 0 ) }}
       volumes:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -77,6 +77,9 @@ podSecurityContext: {}
 # securityContext -- Operator container security context
 securityContext: {}
 
+# sidecars -- Sidecar containers
+sidecars: []
+
 # volumes - Operator volumes
 volumes: []
 


### PR DESCRIPTION
Adding a sidecar to collect logs is a quite common requirement in a production environment.