### PR TITLE
Handle invalid API resources in discovery

### DIFF
--- a/pkg/util/capabilities.go
+++ b/pkg/util/capabilities.go
@@ -19,6 +19,8 @@ package util
 import (
 	"strings"
 
+	"github.com/golang/glog"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -44,7 +46,11 @@ func getPreferredAvailableAPIs(client kubernetes.Interface, kind string) (Capabi
 	discoveryclient := client.Discovery()
 	lists, err := discoveryclient.ServerPreferredResources()
 	if err != nil {
-		return nil, err
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			glog.Infof("There is an orphaned API service. Server reports: %s", err)
+		} else {
+			return nil, err
+		}
 	}
 
 	caps := Capabilities{}


### PR DESCRIPTION
Solution based in a similar issue fixed in helm: [helm/helm#6361](https://github.com/helm/helm/issues/6361)

To reproduce the problem, just deploy an `apiservice`

```bash
$ oc apply -f https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/artifacts/example/apiservice.yaml
```

This gonna create an error in your cluster

```
$ oc api-resources > /dev/null
error: unable to retrieve the complete list of server APIs: wardle.example.com/v1alpha1: the server is currently unable to handle the request
```

After this, the Spark Operator `pod` will stop with the same error above.

This PR prevents this using the [IsGroupDiscoveryFailedError](https://pkg.go.dev/k8s.io/client-go@v1.5.2/1.5/discovery#IsGroupDiscoveryFailedError) method.