### PR TITLE
Support `seccompProfile` in Spark application CRD and fix pre-commit jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -98,7 +98,7 @@ jobs:
           done
 
   build-helm-chart:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -153,7 +153,7 @@ jobs:
           ct install
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.27
+version: 1.1.28
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -919,6 +919,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -1272,6 +1277,11 @@ spec:
                           type: array
                         securityContext:
                           properties:
+                            seccompProfile:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
                             allowPrivilegeEscalation:
                               type: boolean
                             capabilities:
@@ -1704,6 +1714,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -2731,6 +2746,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -2980,6 +3000,11 @@ spec:
                           type: array
                         securityContext:
                           properties:
+                            seccompProfile:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
                             allowPrivilegeEscalation:
                               type: boolean
                             capabilities:
@@ -3408,6 +3433,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -905,6 +905,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -1258,6 +1263,11 @@ spec:
                       type: array
                     securityContext:
                       properties:
+                        seccompProfile:
+                          type: object
+                          properties:
+                            type:
+                              type: string
                         allowPrivilegeEscalation:
                           type: boolean
                         capabilities:
@@ -1690,6 +1700,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -2717,6 +2732,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -2966,6 +2986,11 @@ spec:
                       type: array
                     securityContext:
                       properties:
+                        seccompProfile:
+                          type: object
+                          properties:
+                            type:
+                              type: string
                         allowPrivilegeEscalation:
                           type: boolean
                         capabilities:
@@ -3394,6 +3419,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1293,6 +1293,20 @@ GC settings or other logging.</p>
 </tr>
 <tr>
 <td>
+<code>lifecycle</code><br/>
+<em>
+<a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lifecycle-v1-core">
+Kubernetes core/v1.Lifecycle
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Lifecycle for running preStop or postStart commands</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>deleteOnTermination</code><br/>
 <em>
 bool

--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -919,6 +919,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -1272,6 +1277,11 @@ spec:
                           type: array
                         securityContext:
                           properties:
+                            seccompProfile:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
                             allowPrivilegeEscalation:
                               type: boolean
                             capabilities:
@@ -1704,6 +1714,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -2731,6 +2746,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -2980,6 +3000,11 @@ spec:
                           type: array
                         securityContext:
                           properties:
+                            seccompProfile:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
                             allowPrivilegeEscalation:
                               type: boolean
                             capabilities:
@@ -3408,6 +3433,11 @@ spec:
                                 type: object
                               securityContext:
                                 properties:
+                                  seccompProfile:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
                                   allowPrivilegeEscalation:
                                     type: boolean
                                   capabilities:
@@ -3935,6 +3965,29 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            properties:
+                              volumeClaimTemplate:
+                                properties:
+                                  spec:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      resources:
+                                        properties:
+                                          requests:
+                                            properties:
+                                              storage:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        type: string
+                                    type: object
+                                type: object
                             type: object
                           fc:
                             properties:

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -905,6 +905,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -1258,6 +1263,11 @@ spec:
                       type: array
                     securityContext:
                       properties:
+                        seccompProfile:
+                          type: object
+                          properties:
+                            type:
+                              type: string
                         allowPrivilegeEscalation:
                           type: boolean
                         capabilities:
@@ -1690,6 +1700,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -2717,6 +2732,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -2966,6 +2986,11 @@ spec:
                       type: array
                     securityContext:
                       properties:
+                        seccompProfile:
+                          type: object
+                          properties:
+                            type:
+                              type: string
                         allowPrivilegeEscalation:
                           type: boolean
                         capabilities:
@@ -3394,6 +3419,11 @@ spec:
                             type: object
                           securityContext:
                             properties:
+                              seccompProfile:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
                               allowPrivilegeEscalation:
                                 type: boolean
                               capabilities:
@@ -3923,6 +3953,29 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          volumeClaimTemplate:
+                            properties:
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    properties:
+                                      requests:
+                                        properties:
+                                          storage:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                type: object
+                            type: object
                         type: object
                       fc:
                         properties:


### PR DESCRIPTION
* Added support for `seccompProfile` in Spark application CRD. It is necessary for Kubernetes Pod Security Standards Restricted profile.
https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
* Aligned _manifest/crds_ with _charts/spark-operator-chart/crds_
* Fixed pre-commit jobs.
  `build-helm-chart` and `integration-test` were failing with:
  `Run manusa/actions-setup-minikube@v2.4.2
   Error: Unsupported OS, action only works in Ubuntu 18 or 20`