### PR TITLE
Add Roblox to who-is

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -41,3 +41,4 @@
 | [C2FO](https://www.c2fo.com/) | @vanhoale | Production | Data Platform / Data Infrastructure |
 | [Kognita](https://kognita.com.br/) | @andreclaudino | Production | MLOps, Data Platform / Data Infrastructure, ML/AI |
 | [Molex](https://www.molex.com/) | @AshishPushpSingh | Evaluation/Production | Data Platform |
+| [Roblox](https://www.roblox.com/) | @matschaffer-roblox | Evaluation | Data Infrastructure |


### PR DESCRIPTION
Partly just to test the CLA check for my account, but also nice to be able to share or usage status.