### PR TITLE
Add automountServiceAccountToken: true

### DIFF
--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "spark-operator.serviceAccountName" . }}
+      automountServiceAccountToken: true
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Need support for   automountServiceAccountToken: true by default to access the kube APIs.
Fixes #1189