### PR TITLE
Add Rokt to who-is-using.md

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -43,3 +43,4 @@
 | [Molex](https://www.molex.com/) | @AshishPushpSingh | Evaluation/Production | Data Platform |
 | [Qualytics](https://www.qualytics.co/) | @josecsotomorales | Production | Data Quality Platform |
 | [Roblox](https://www.roblox.com/) | @matschaffer-roblox | Evaluation | Data Infrastructure |
+| [Rokt](https://www.rokt.com) | @jacobsalway | Production | Data Infrastructure |


### PR DESCRIPTION
Add Rokt to `who-is-using.md`. We're using the operator in production and are happy to see activity on the repo. We're likely to upstream some changes we've made internally