### PR TITLE
fix: Update Github workflow to publish Helm charts on chart changes, irrespective of image change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,10 @@ jobs:
   build-skip-check:
     runs-on: ubuntu-latest
     outputs:
-      skip: ${{ steps.skip-check.outputs.skip }}
-      version: ${{ steps.skip-check.outputs.VERSION_TAG }}
+      image_changed: ${{ steps.skip-check.outputs.image_changed }}
+      chart_changed: ${{ steps.skip-check.outputs.chart_changed }}
+      app_version_tag: ${{ steps.skip-check.outputs.app_version_tag }}
+      chart_version_tag: ${{ steps.skip-check.outputs.chart_version_tag }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -21,22 +23,36 @@ jobs:
       - name: Check if build should be skipped
         id: skip-check
         run: |
-          VERSION_TAG=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
-          if git rev-parse -q --verify "refs/tags/$VERSION_TAG"; then
-            echo "Spark-Operator Docker Image Tag $VERSION_TAG already exists!"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            git tag $VERSION_TAG
-            git push origin $VERSION_TAG
-            echo "Spark-Operator Docker Image new tag: $VERSION_TAG released"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+          app_version_tag=$(cat charts/spark-operator-chart/Chart.yaml | grep "appVersion: .*" | cut -c13-)
+          chart_version_tag=$(cat charts/spark-operator-chart/Chart.yaml | grep "version: .*" | cut -c10-)
+          
+          # Initialize flags 
+          image_changed=false
+          chart_changed=false
+          
+          if ! git rev-parse -q --verify "refs/tags/$app_version_tag"; then
+            image_changed=true
+            git tag $app_version_tag
+            git push origin $app_version_tag
+            echo "Spark-Operator Docker Image new tag: $app_version_tag released" 
           fi
-          echo "VERSION_TAG=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+
+          if ! git rev-parse -q --verify "refs/tags/$chart_version_tag"; then
+            chart_changed=true
+            git tag $chart_version_tag
+            git push origin $chart_version_tag
+            echo "Spark-Operator Helm Chart new tag: $chart_version_tag released" 
+          fi
+
+          echo "image_changed=${image_changed}" >> "$GITHUB_OUTPUT"
+          echo "chart_changed=${chart_changed}" >> "$GITHUB_OUTPUT"
+          echo "app_version_tag=${app_version_tag}" >> "$GITHUB_OUTPUT"
+          echo "chart_version_tag=${chart_version_tag}" >> "$GITHUB_OUTPUT"
   release:
     runs-on: ubuntu-latest
     needs:
       - build-skip-check
-    if: needs.build-skip-check.outputs.skip == 'false'
+    if: needs.build-skip-check.outputs.image_changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +113,7 @@ jobs:
     needs:
       - release
       - build-skip-check
-    if: needs.build-skip-check.outputs.skip == 'false'
+    if: needs.build-skip-check.outputs.image_changed == 'true'
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -112,7 +128,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: ${{ needs.build-skip-check.outputs.version }}
+          tags: ${{ needs.build-skip-check.outputs.app_version_tag }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -129,14 +145,19 @@ jobs:
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
   publish-chart:
     runs-on: ubuntu-latest
-    if: needs.publish-image.result == 'success' || needs.publish-image.result == 'skipped'
+    if: needs.build-skip-check.outputs.chart_changed == 'true'
     needs:
       - publish-image
+      - build-skip-check
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.3
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,11 +37,11 @@ jobs:
             echo "Spark-Operator Docker Image new tag: $app_version_tag released" 
           fi
 
-          if ! git rev-parse -q --verify "refs/tags/$chart_version_tag"; then
+          if ! git rev-parse -q --verify "refs/tags/spark-operator-chart-$chart_version_tag"; then
             chart_changed=true
-            git tag $chart_version_tag
-            git push origin $chart_version_tag
-            echo "Spark-Operator Helm Chart new tag: $chart_version_tag released" 
+            git tag spark-operator-chart-$chart_version_tag
+            git push origin spark-operator-chart-$chart_version_tag
+            echo "Spark-Operator Helm Chart new tag: spark-operator-chart-$chart_version_tag released" 
           fi
 
           echo "image_changed=${image_changed}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions.

_This pull request introduces modifications to the CI/CD process, ensuring the autonomous publication of Helm charts regardless of image update status. The motivation for these changes is to streamline the release process by allowing updates to Helm charts to be published even when no corresponding image changes have occurred._

**Proposed changes:**
_- Altered the GitHub Actions workflow to facilitate the independent release of Helm charts without the necessity of concurrent image update_

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

#1994 