### PR TITLE
Surface Spark Connect drvier container status

### DIFF
--- a/api/v1alpha1/sparkconnect_types.go
+++ b/api/v1alpha1/sparkconnect_types.go
@@ -182,4 +182,7 @@ type SparkConnectServerStatus struct {
 
 	// ServiceName is the name of the service that is exposing the Spark Connect server.
 	ServiceName string `json:"serviceName,omitempty"`
+
+	// DriverContainerStatus is the status of the Spark Connect Server driver container
+	DriverContainerStatus string `json:"driverContainerStatus,omitempty"`
 }

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkconnects.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkconnects.yaml
@@ -240,6 +240,10 @@ spec:
                 description: Server represents the current state of the SparkConnect
                   server.
                 properties:
+                  driverContainerStatus:
+                    description: DriverContainerStatus is the status of the Spark
+                      Connect Server driver container
+                    type: string
                   podIp:
                     description: PodIP is the IP address of the pod that is running
                       the Spark Connect server.

--- a/config/crd/bases/sparkoperator.k8s.io_sparkconnects.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkconnects.yaml
@@ -240,6 +240,10 @@ spec:
                 description: Server represents the current state of the SparkConnect
                   server.
                 properties:
+                  driverContainerStatus:
+                    description: DriverContainerStatus is the status of the Spark
+                      Connect Server driver container
+                    type: string
                   podIp:
                     description: PodIP is the IP address of the pod that is running
                       the Spark Connect server.

--- a/test/e2e/sparkconnect_test.go
+++ b/test/e2e/sparkconnect_test.go
@@ -2,8 +2,10 @@ package e2e_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,6 +20,90 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
+func loadSparkConnectFromFile(path string) *v1alpha1.SparkConnect {
+	file, err := os.Open(path)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(file).NotTo(BeNil())
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(file)
+
+	decoder := yaml.NewYAMLOrJSONDecoder(file, 100)
+	Expect(decoder).NotTo(BeNil())
+
+	conn := &v1alpha1.SparkConnect{}
+	Expect(decoder.Decode(conn)).NotTo(HaveOccurred())
+	return conn
+}
+
+func waitForServerPodReady(ctx context.Context, conn *v1alpha1.SparkConnect) {
+	Eventually(func() bool {
+		key := types.NamespacedName{
+			Namespace: conn.Namespace,
+			Name:      sparkconnect.GetServerPodName(conn),
+		}
+		server := &corev1.Pod{}
+		if err := k8sClient.Get(ctx, key, server); err != nil {
+			return false
+		}
+		return util.IsPodReady(server)
+	}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
+}
+
+func waitForServerServiceCreated(ctx context.Context, conn *v1alpha1.SparkConnect) {
+	Eventually(func() bool {
+		key := types.NamespacedName{
+			Namespace: conn.Namespace,
+			Name:      sparkconnect.GetServerServiceName(conn),
+		}
+		service := &corev1.Service{}
+		if err := k8sClient.Get(ctx, key, service); err != nil {
+			return false
+		}
+		return true
+	}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
+}
+
+func waitForExecutorPodsReady(ctx context.Context, conn *v1alpha1.SparkConnect, expectedCount int) {
+	Eventually(func() bool {
+		executors := &corev1.PodList{}
+		Expect(k8sClient.List(
+			ctx,
+			executors,
+			client.InNamespace(conn.Namespace),
+			client.MatchingLabels(sparkconnect.GetExecutorSelectorLabels(conn))),
+		).NotTo(HaveOccurred())
+
+		if len(executors.Items) != expectedCount {
+			return false
+		}
+
+		for _, executor := range executors.Items {
+			if !util.IsPodReady(&executor) {
+				return false
+			}
+		}
+		return true
+	}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
+}
+
+func getRunningExecutorCountFromStatus(ctx context.Context, conn *v1alpha1.SparkConnect) int {
+	key := types.NamespacedName{
+		Namespace: conn.Namespace,
+		Name:      conn.Name,
+	}
+	Expect(k8sClient.Get(ctx, key, conn)).To(Succeed())
+
+	runningCount := 0
+	if count, ok := conn.Status.Executors["running"]; ok {
+		runningCount = count
+	}
+	return runningCount
+}
+
 var _ = Describe("SparkConnect Controller", func() {
 	Context("Reconcile a new SparkConnect", func() {
 		ctx := context.Background()
@@ -27,15 +113,7 @@ var _ = Describe("SparkConnect Controller", func() {
 
 		BeforeEach(func() {
 			By("Parsing SparkConnect from file", func() {
-				file, err := os.Open(path)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(file).NotTo(BeNil())
-
-				decoder := yaml.NewYAMLOrJSONDecoder(file, 100)
-				Expect(decoder).NotTo(BeNil())
-
-				conn = &v1alpha1.SparkConnect{}
-				Expect(decoder.Decode(conn)).NotTo(HaveOccurred())
+				conn = loadSparkConnectFromFile(path)
 			})
 
 			By("Creating SparkConnect", func() {
@@ -52,6 +130,92 @@ var _ = Describe("SparkConnect Controller", func() {
 
 		It("Should reconcile SparkConnect correctly", func() {
 			By("Waiting for server pod to be ready", func() {
+				waitForServerPodReady(ctx, conn)
+			})
+
+			By("Waiting for executor pods to be ready", func() {
+				instances := int(ptr.Deref(conn.Spec.Executor.Instances, 0))
+				waitForExecutorPodsReady(ctx, conn, instances)
+			})
+
+			By("Waiting for server service to be created", func() {
+				waitForServerServiceCreated(ctx, conn)
+			})
+		})
+	})
+
+	Context("Test dynamic allocation of min executors", func() {
+		ctx := context.Background()
+		path := filepath.Join("..", "..", "examples", "sparkconnect", "spark-connect.yaml")
+
+		var conn *v1alpha1.SparkConnect
+
+		BeforeEach(func() {
+			By("Parsing SparkConnect from file", func() {
+				conn = loadSparkConnectFromFile(path)
+
+				conn.Spec.DynamicAllocation = &v1alpha1.DynamicAllocation{
+					Enabled:          true,
+					InitialExecutors: ptr.To(int32(1)),
+					MinExecutors:     ptr.To(int32(2)),
+				}
+			})
+
+			By("Creating SparkConnect with dynamic allocation", func() {
+				Expect(k8sClient.Create(ctx, conn)).To(Succeed())
+			})
+		})
+
+		AfterEach(func() {
+			By("Deleting SparkConnect", func() {
+				Expect(k8sClient.Delete(ctx, conn)).To(Succeed())
+				conn = nil
+			})
+		})
+
+		It("Should scale executors to 2", func() {
+			By("Waiting for initial executor pod to be ready", func() {
+				waitForExecutorPodsReady(ctx, conn, 2)
+			})
+
+			By("Verifying status reflects correct executor count", func() {
+				Eventually(func() int {
+					return getRunningExecutorCountFromStatus(ctx, conn)
+				}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(Equal(2))
+			})
+		})
+	})
+	Context("Test dynamic allocation with max executors limit", func() {
+		ctx := context.Background()
+		path := filepath.Join("..", "..", "examples", "sparkconnect", "spark-connect.yaml")
+
+		var conn *v1alpha1.SparkConnect
+
+		BeforeEach(func() {
+			By("Parsing SparkConnect from file", func() {
+				conn = loadSparkConnectFromFile(path)
+
+				// initial executors cannot exceed max executors
+				conn.Spec.DynamicAllocation = &v1alpha1.DynamicAllocation{
+					Enabled:          true,
+					InitialExecutors: ptr.To(int32(5)),
+					MaxExecutors:     ptr.To(int32(3)),
+				}
+			})
+
+			By("Creating SparkConnect with max executors limit", func() {
+				Expect(k8sClient.Create(ctx, conn)).To(Succeed())
+			})
+		})
+
+		AfterEach(func() {
+			By("Deleting SparkConnect", func() {
+				Expect(k8sClient.Delete(ctx, conn)).To(Succeed())
+				conn = nil
+			})
+		})
+		It("Should fail with containers in CrashLoopBackOff due to misconfigured max executors", func() {
+			By("Verifying server pod exists but containers are not ready", func() {
 				Eventually(func() bool {
 					key := types.NamespacedName{
 						Namespace: conn.Namespace,
@@ -61,45 +225,42 @@ var _ = Describe("SparkConnect Controller", func() {
 					if err := k8sClient.Get(ctx, key, server); err != nil {
 						return false
 					}
-					return util.IsPodReady(server)
+					return server != nil && !util.IsPodReady(server)
 				}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
 			})
-
-			By("Waiting for executor pods to be ready", func() {
-				Eventually(func() bool {
-					executors := &corev1.PodList{}
-					Expect(k8sClient.List(
-						ctx,
-						executors,
-						client.InNamespace(conn.Namespace),
-						client.MatchingLabels(sparkconnect.GetExecutorSelectorLabels(conn))),
-					).NotTo(HaveOccurred())
-
-					instances := int(ptr.Deref(conn.Spec.Executor.Instances, 0))
-					if len(executors.Items) != instances {
-						return false
-					}
-
-					for _, executor := range executors.Items {
-						if !util.IsPodReady(&executor) {
-							return false
-						}
-					}
-					return true
-				}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
-			})
-
-			By("Waiting for server service to be created", func() {
+			By("Verifying pod status shows container in crash loop", func() {
 				Eventually(func() bool {
 					key := types.NamespacedName{
 						Namespace: conn.Namespace,
-						Name:      sparkconnect.GetServerServiceName(conn),
+						Name:      sparkconnect.GetServerPodName(conn),
 					}
-					service := &corev1.Service{}
-					if err := k8sClient.Get(ctx, key, service); err != nil {
+					server := &corev1.Pod{}
+					if err := k8sClient.Get(ctx, key, server); err != nil {
 						return false
 					}
-					return true
+
+					for _, containerStatus := range server.Status.ContainerStatuses {
+						if containerStatus.State.Waiting != nil &&
+							containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
+							return true
+						}
+					}
+					return false
+				}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
+			})
+
+			By("Verifying driver container status in SparkConnect resource", func() {
+				Eventually(func() bool {
+					key := types.NamespacedName{
+						Namespace: conn.Namespace,
+						Name:      conn.Name,
+					}
+					updatedConn := &v1alpha1.SparkConnect{}
+					if err := k8sClient.Get(ctx, key, updatedConn); err != nil {
+						return false
+					}
+
+					return strings.Contains(updatedConn.Status.Server.DriverContainerStatus, "CrashLoopBackOff") || strings.Contains(updatedConn.Status.Server.DriverContainerStatus, "Terminated")
 				}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This surfaces Spark driver container status to SparkConnect CR. I think it's more user friendly to be able to see the status of the driver container just by looking at the CR's status field. 

Example outputs:

*No Error*

```yaml
status:
  server:
    driverContainerStatus: 'Running:  Driver container is running at 2025-07-10 23:53:08
      +0000 UTC'
    podName: spark-connect-server
    serviceName: spark-connect-server
```

**With Error***

```yaml
status:
  server:
    driverContainerStatus: 'Waiting: CrashLoopBackOff Driver container is waiting:
      back-off 1m20s restarting failed container=spark-kubernetes-driver pod=spark-connect-server_default(61a96816-3e03-49fa-9cf7-1aa734cb4076)'
    podName: spark-connect-server
    serviceName: spark-connect-server
```


**Proposed changes:**

- add `status.server.driverContainerStatus` field
- Add basic information about the driver container


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

I was playing with spark connect CR and it was a bit annoying to figure out what was happening to the driver container.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
