### PR TITLE
Correct entrypoint.sh for Openshift

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ if ! getent passwd "$myuid" &> /dev/null; then
         NSS_WRAPPER_GROUP="$(mktemp)"
         export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
         mygid="$(id -g)"
-        printf 'spark:x:%s:%s:${SPARK_USER_NAME:-anonymous uid}:%s:/bin/false\n' "$myuid" "$mygid" "$SPARK_HOME" > "$NSS_WRAPPER_PASSWD"
+        printf 'spark:x:%s:%s:%s:%s:/bin/false\n' "$myuid" "$mygid" "${SPARK_USER_NAME:-anonymous uid}" "$SPARK_HOME" > "$NSS_WRAPPER_PASSWD"
         printf 'spark:x:%s:\n' "$mygid" > "$NSS_WRAPPER_GROUP"
         break
       fi


### PR DESCRIPTION
## Purpose of this PR
This change performs string interpolation during the creation of the temporary file, which is used on Openshift.
There is a parallel pull request that also corrects this behaviour in the official Spark images. https://github.com/apache/spark-docker/pull/90

**Proposed changes:**

- correct entrypoint.sh for Openshift

## Change Category

- [X] Bugfix (non-breaking change which fixes an issue)

### Rationale
See issue #2644

## Checklist

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes
