### PR TITLE
fix(connect): propagate executor memory setting to spark options

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -210,6 +210,12 @@ func executorConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 			fmt.Sprintf("%s=%d", common.SparkExecutorCores, *conn.Spec.Executor.Cores))
 	}
 
+	// Executor memory
+	if conn.Spec.Server.Memory != nil {
+		args = append(args, "--conf",
+			fmt.Sprintf("%s=%s", common.SparkExecutorMemory, *conn.Spec.Server.Memory))
+	}
+
 	// Use SparkConnect object name as executor pod name prefix.
 	args = append(args, "--conf", fmt.Sprintf("%s=%s", common.SparkKubernetesExecutorPodNamePrefix, conn.Name))
 


### PR DESCRIPTION
## Purpose of this PR

Previously, the `spec.executor.memory` value in `SparkConnect` was not passed to `--conf spark.executor.memory`. This caused executors to ignore the configured memory setting. The fix ensures that the memory value is correctly applied to the Spark configuration.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.