### PR TITLE
Set ControllerReference on driver pod and non-Controller OwnerReference on executor pod at submission time

### DIFF
--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -19,6 +19,8 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -180,7 +182,11 @@ func addOwnerReference(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
 		return nil
 	}
 	ownerReference := util.GetOwnerReference(app)
-	pod.OwnerReferences = append(pod.OwnerReferences, ownerReference)
+	if !slices.ContainsFunc(pod.OwnerReferences, func(r metav1.OwnerReference) bool {
+		return reflect.DeepEqual(r, ownerReference)
+	}) {
+		pod.OwnerReferences = append(pod.OwnerReferences, ownerReference)
+	}
 	return nil
 }
 

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -73,6 +73,15 @@ func TestPatchSparkPod_OwnerReference(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Len(t, modifiedPod.OwnerReferences, 2)
+
+	// Test patching OwnerReference be idempotent.
+	oldOwnerReferences := modifiedPod.DeepCopy().OwnerReferences
+	pod.OwnerReferences = modifiedPod.DeepCopy().OwnerReferences
+	modifiedPod, err = getModifiedPod(pod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, modifiedPod.OwnerReferences, oldOwnerReferences)
 }
 
 func TestPatchSparkPod_Local_Volumes(t *testing.T) {


### PR DESCRIPTION
This feature is required in https://github.com/kubernetes-sigs/kueue/pull/7268 

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- This PR puts an owner reference at submission time instead of webhook
  - `OwnerReference(controller=true)` on driver pod
  - `OwnerReference(controller=false)` on executor pod
    - because it already has the controller reference to the driver pod.
    - a non-controller owner reference just makes other controllers find the executor pod is managed(but not contrlled) by `SparkApplication` easily
- for backward compatibility, I made a mutation webhook idempotent on `OwnerReference` (i.e. just skip if it already has it)

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Typical kubernetes controllers expect `OwnerReference` is set on resources when the webhook is called. Thus, if multiple webhooks are deployed, there could be a race on them. Particularly, this can be a problem in Kueue integration(_also described in https://github.com/kubeflow/spark-operator/issues/2669_).

- Kueue basically activates integration in the mutating webhook:
  - If `Pod` has no owner reference and `queue-name` label, then activate `Pod` integration
  - If `Pod` has `SparkApplication` owner reference and `queue-name` label, then activate `SparkApplication` integration
- But, spark-operator also puts `OwnerReference` on the Spark driver pod in the [mutating webhook](https://github.com/kubeflow/spark-operator/blob/v2.3.0/internal/webhook/sparkpod_defaulter.go#L178-L185).
- Thus, the `OwnerReference` race happens because Kubernetes does not have an explicit spec on the order of the webhook called. 
- Consequently, Kueue's webhook might see a spark driver pod without an owner reference. This could activate plain pod integration mistakenly. 


Moreover, executor pods do not have `OwnerReference` to `SparkApplication` but just have it to their driver pod. This makes other controllers difficult to find that the executor pods are managed under `SparkApplicaton`. This PR also addresses this case by setting `OwnerReference(controller=false)` at submission time.

_It can be a part of https://github.com/kubeflow/spark-operator/issues/2502_



## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
