### PR TITLE
Add kube-scheduler podgroup unit tests

### DIFF
--- a/internal/scheduler/kubescheduler/scheduler.go
+++ b/internal/scheduler/kubescheduler/scheduler.go
@@ -139,7 +139,8 @@ func (s *Scheduler) syncPodGroup(podGroup *schedulingv1alpha1.PodGroup) error {
 		Name:      podGroup.Name,
 	}
 
-	if err := s.client.Get(context.TODO(), key, &schedulingv1alpha1.PodGroup{}); err != nil {
+	existing := &schedulingv1alpha1.PodGroup{}
+	if err := s.client.Get(context.TODO(), key, existing); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
@@ -150,6 +151,8 @@ func (s *Scheduler) syncPodGroup(podGroup *schedulingv1alpha1.PodGroup) error {
 		logger.Info("Created PodGroup", "Name", podGroup.Name, "Namespace", podGroup.Namespace)
 		return nil
 	}
+
+	podGroup.SetResourceVersion(existing.GetResourceVersion())
 
 	if err := s.client.Update(context.TODO(), podGroup); err != nil {
 		return err

--- a/internal/scheduler/kubescheduler/scheduler_test.go
+++ b/internal/scheduler/kubescheduler/scheduler_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubescheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+	schedulingv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
+)
+
+func TestFactoryWithValidConfig(t *testing.T) {
+	scheme := newTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cfg := &Config{SchedulerName: Name, Client: fakeClient}
+	sch, err := Factory(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, Name, sch.Name())
+}
+
+func TestFactoryWithInvalidConfig(t *testing.T) {
+	_, err := Factory(struct{}{})
+	require.Error(t, err)
+}
+
+func TestSchedulerName(t *testing.T) {
+	sch, _ := newTestScheduler(t)
+	assert.Equal(t, Name, sch.Name())
+}
+
+func TestShouldScheduleAlwaysTrue(t *testing.T) {
+	sch, _ := newTestScheduler(t)
+	app := newTestSparkApplication()
+
+	assert.True(t, sch.ShouldSchedule(app))
+}
+
+func TestScheduleCreatesPodGroupAndLabelsApp(t *testing.T) {
+	sch, cl := newTestScheduler(t)
+	app := newTestSparkApplication()
+
+	err := sch.Schedule(app)
+	require.NoError(t, err)
+
+	assert.Equal(t, getPodGroupName(app), app.Labels[schedulingv1alpha1.PodGroupLabel])
+
+	created := &schedulingv1alpha1.PodGroup{}
+	err = cl.Get(context.Background(), types.NamespacedName{Namespace: app.Namespace, Name: getPodGroupName(app)}, created)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), created.Spec.MinMember)
+	assertResourceListEqual(t, created.Spec.MinResources, expectedMinResources(app))
+	require.Len(t, created.OwnerReferences, 1)
+	assert.Equal(t, app.Name, created.OwnerReferences[0].Name)
+	assert.NotNil(t, created.OwnerReferences[0].Controller)
+	assert.True(t, *created.OwnerReferences[0].Controller)
+}
+
+func TestScheduleUpdatesExistingPodGroup(t *testing.T) {
+	app := newTestSparkApplication()
+	existing := &schedulingv1alpha1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            getPodGroupName(app),
+			Namespace:       app.Namespace,
+			ResourceVersion: "1",
+			Labels:          map[string]string{"existing": "label"},
+		},
+		Spec: schedulingv1alpha1.PodGroupSpec{
+			MinMember: 5,
+			MinResources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+	}
+
+	sch, cl := newTestScheduler(t, existing)
+	app.Labels = map[string]string{"preserve": "me"}
+
+	err := sch.Schedule(app)
+	require.NoError(t, err)
+
+	updated := &schedulingv1alpha1.PodGroup{}
+	err = cl.Get(context.Background(), types.NamespacedName{Namespace: app.Namespace, Name: getPodGroupName(app)}, updated)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), updated.Spec.MinMember)
+	assertResourceListEqual(t, updated.Spec.MinResources, expectedMinResources(app))
+	require.Len(t, updated.OwnerReferences, 1)
+	assert.Equal(t, app.Name, updated.OwnerReferences[0].Name)
+	assert.Equal(t, "me", app.Labels["preserve"])
+	assert.Equal(t, getPodGroupName(app), app.Labels[schedulingv1alpha1.PodGroupLabel])
+}
+
+func TestCleanupDeletesPodGroup(t *testing.T) {
+	app := newTestSparkApplication()
+	existing := &schedulingv1alpha1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPodGroupName(app),
+			Namespace: app.Namespace,
+		},
+	}
+
+	sch, cl := newTestScheduler(t, existing)
+
+	err := sch.Cleanup(app)
+	require.NoError(t, err)
+
+	err = cl.Get(context.Background(), types.NamespacedName{Namespace: app.Namespace, Name: getPodGroupName(app)}, &schedulingv1alpha1.PodGroup{})
+	require.Error(t, err)
+	assert.True(t, client.IgnoreNotFound(err) == nil)
+}
+
+func TestCleanupIgnoresNotFound(t *testing.T) {
+	sch, _ := newTestScheduler(t)
+	err := sch.Cleanup(newTestSparkApplication())
+	assert.NoError(t, err)
+}
+
+func newTestScheduler(t *testing.T, objs ...client.Object) (*Scheduler, client.Client) {
+	t.Helper()
+
+	scheme := newTestScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &Scheduler{name: Name, client: cl}, cl
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta2.AddToScheme(scheme))
+	require.NoError(t, schedulingv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func newTestSparkApplication() *v1beta2.SparkApplication {
+	return &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "test-ns",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Type:         v1beta2.SparkApplicationTypeScala,
+			SparkVersion: "3.5.0",
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Cores:          util.Int32Ptr(1),
+					Memory:         util.StringPtr("1Gi"),
+					MemoryOverhead: util.StringPtr("256Mi"),
+				},
+			},
+			Executor: v1beta2.ExecutorSpec{
+				Instances: util.Int32Ptr(2),
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Cores:          util.Int32Ptr(1),
+					Memory:         util.StringPtr("2Gi"),
+					MemoryOverhead: util.StringPtr("512Mi"),
+				},
+			},
+		},
+	}
+}
+
+func expectedMinResources(app *v1beta2.SparkApplication) corev1.ResourceList {
+	return util.SumResourceList([]corev1.ResourceList{util.GetDriverRequestResource(app), util.GetExecutorRequestResource(app)})
+}
+
+func assertResourceListEqual(t *testing.T, actual, expected corev1.ResourceList) {
+	t.Helper()
+
+	assert.Equal(t, len(expected), len(actual))
+	for name, exp := range expected {
+		got, ok := actual[name]
+		if assert.Truef(t, ok, "missing resource %s", name) {
+			assert.Zerof(t, exp.Cmp(got), "resource %s mismatch: want %s, got %s", name, exp.String(), got.String())
+		}
+	}
+}


### PR DESCRIPTION

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

Add kube-scheduler podgroup unit tests to enhanced unit test. Details:

- cover scheduler factory, scheduling, and cleanup code paths with the fake client
- ensure PodGroup sync reuses the existing resourceVersion before issuing Update

After patch:
```
ok      github.com/kubeflow/spark-operator/v2/internal/scheduler/kubescheduler  3.039s  coverage: 86.5% of statements
```

> I'd like to gradually contribute code to the current open-source project to improve test coverage, so that it can meet our internal usage standards

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
