### PR TITLE
Generate HTML coverage report after running unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 bin/
 codecov.yaml
 cover.out
+cover.html
 .DS_Store
 *.iml

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,9 @@ unit-test: envtest ## Run unit tests.
 	@echo "Running unit tests..."
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"
 	go test $(shell go list ./... | grep -v /e2e) -coverprofile cover.out
+	@echo "Generating HTML coverage report..."
+	go tool cover -html=cover.out -o cover.html
+	@echo "Coverage report available at cover.html"
 
 .PHONY: e2e-test
 e2e-test: envtest ## Run the e2e tests against a Kind k8s instance that is spun up.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This pull request adds a new Makefile target to make it easier to generate and view test coverage reports after running unit tests.

Testing and coverage improvements:

* Added a `.PHONY` target named `coverage` to the `Makefile`, which generates an HTML coverage report (`cover.html`) from the output of unit tests, making it easier to visualize code coverage.

```
make help

Usage:
  make <target>

General
  help                            Display this help.
  version                         Print version information.

Development
  manifests                       Generate CustomResourceDefinition, RBAC and WebhookConfiguration manifests.
  generate                        Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
  update-crd                      Update CRD files in the Helm chart.
  verify-codegen                  Install code-generator commands and verify changes
  go-clean                        Clean up caches and output.
  go-fmt                          Run go fmt against code.
  go-vet                          Run go vet against code.
  go-lint                         Run golangci-lint linter.
  go-lint-fix                     Run golangci-lint linter and perform fixes.
  unit-test                       Run unit tests.
  coverage                        Generate HTML coverage report in cover.html.
  e2e-test                        Run the e2e tests against a Kind k8s instance that is spun up.
  ```

HTML Results as
<img width="2358" height="1894" alt="image" src="https://github.com/user-attachments/assets/c99e9a0d-d5b2-48c3-9108-ae027d79e7d1" />


<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
