### PR TITLE
Add unit test for sparkapplication_validator

### DIFF
--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+func TestSparkApplicationValidatorValidateCreate_NodeSelectorConflict(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	app := newSparkApplication()
+	app.Spec.NodeSelector = map[string]string{"role": "shared"}
+	app.Spec.Driver.NodeSelector = map[string]string{"role": "driver"}
+
+	if _, err := validator.ValidateCreate(context.Background(), app); err == nil || !strings.Contains(err.Error(), "node selector cannot be defined") {
+		t.Fatalf("expected node selector validation error, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_Success(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	if _, err := validator.ValidateCreate(context.Background(), newSparkApplication()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_DriverIngressDuplicatePort(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	app := newSparkApplication()
+	app.Spec.DriverIngressOptions = []v1beta2.DriverIngressConfiguration{
+		{
+			ServicePort:      ptr.To[int32](4040),
+			IngressURLFormat: "http://spark-a",
+		},
+		{
+			ServicePort:      ptr.To[int32](4040),
+			IngressURLFormat: "http://spark-b",
+		},
+	}
+
+	if _, err := validator.ValidateCreate(context.Background(), app); err == nil || !strings.Contains(err.Error(), "duplicate ServicePort") {
+		t.Fatalf("expected duplicate service port error, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_PodTemplateRequiresSpark3(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	app := newSparkApplication()
+	app.Spec.SparkVersion = "2.4.0"
+	app.Spec.Driver.Template = &corev1.PodTemplateSpec{}
+
+	if _, err := validator.ValidateCreate(context.Background(), app); err == nil || !strings.Contains(err.Error(), "requires Spark version 3.0.0 or higher") {
+		t.Fatalf("expected spark version validation error, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_ResourceQuotaSatisfied(t *testing.T) {
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ample",
+			Namespace: "default",
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceCPU:         resource.MustParse("20"),
+				corev1.ResourceRequestsCPU: resource.MustParse("20"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("20"),
+			},
+		},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{
+				corev1.ResourceCPU:         resource.MustParse("20"),
+				corev1.ResourceRequestsCPU: resource.MustParse("20"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("20"),
+			},
+			Used: corev1.ResourceList{
+				corev1.ResourceCPU:         resource.MustParse("0"),
+				corev1.ResourceRequestsCPU: resource.MustParse("0"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("0"),
+			},
+		},
+	}
+
+	validator := newTestValidator(t, true, quota)
+
+	if _, err := validator.ValidateCreate(context.Background(), newSparkApplication()); err != nil {
+		t.Fatalf("expected quota satisfied, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateUpdate_SameSpecSkipsValidation(t *testing.T) {
+	validator := newTestValidator(t, true)
+
+	base := newSparkApplication()
+	base.Spec.NodeSelector = map[string]string{"role": "shared"}
+	base.Spec.Driver.NodeSelector = map[string]string{"role": "driver"}
+
+	oldApp := base.DeepCopy()
+	newApp := base.DeepCopy()
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err != nil {
+		t.Fatalf("expected no error when spec unchanged, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateUpdate_SpecChangedTriggersValidation(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	oldApp := newSparkApplication()
+	newApp := oldApp.DeepCopy()
+	newApp.Spec.NodeSelector = map[string]string{"role": "shared"}
+	newApp.Spec.Driver.NodeSelector = map[string]string{"role": "driver"}
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err == nil || !strings.Contains(err.Error(), "node selector cannot be defined") {
+		t.Fatalf("expected node selector validation error, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateUpdate_SuccessWithSpecChange(t *testing.T) {
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ample",
+			Namespace: "default",
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceCPU:         resource.MustParse("20"),
+				corev1.ResourceRequestsCPU: resource.MustParse("20"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("20"),
+			},
+		},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{
+				corev1.ResourceCPU:         resource.MustParse("20"),
+				corev1.ResourceRequestsCPU: resource.MustParse("20"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("20"),
+			},
+			Used: corev1.ResourceList{
+				corev1.ResourceCPU:         resource.MustParse("1"),
+				corev1.ResourceRequestsCPU: resource.MustParse("1"),
+				corev1.ResourceLimitsCPU:   resource.MustParse("1"),
+			},
+		},
+	}
+
+	validator := newTestValidator(t, true, quota)
+
+	oldApp := newSparkApplication()
+	newApp := oldApp.DeepCopy()
+	newApp.Spec.Arguments = []string{"--foo"}
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err != nil {
+		t.Fatalf("expected successful update validation, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_ResourceQuotaExceeded(t *testing.T) {
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "strict",
+			Namespace: "default",
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceLimitsCPU: resource.MustParse("1"),
+			},
+		},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{
+				corev1.ResourceLimitsCPU: resource.MustParse("1"),
+			},
+			Used: corev1.ResourceList{
+				corev1.ResourceLimitsCPU: resource.MustParse("0"),
+			},
+		},
+	}
+
+	validator := newTestValidator(t, true, quota)
+
+	if _, err := validator.ValidateCreate(context.Background(), newSparkApplication()); err == nil || !strings.Contains(err.Error(), "failed to validate resource quota") {
+		t.Fatalf("expected resource quota validation error, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateDelete_Success(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	if _, err := validator.ValidateDelete(context.Background(), newSparkApplication()); err != nil {
+		t.Fatalf("expected successful delete validation, got %v", err)
+	}
+}
+
+func newTestValidator(t *testing.T, enforceQuota bool, objs ...client.Object) *SparkApplicationValidator {
+	t.Helper()
+
+	scheme := newTestScheme(t)
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objs) > 0 {
+		builder = builder.WithObjects(objs...)
+	}
+
+	return NewSparkApplicationValidator(builder.Build(), enforceQuota)
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := v1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add v1beta2 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func newSparkApplication() *v1beta2.SparkApplication {
+	mainFile := "local:///app.py"
+	return &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Type:                v1beta2.SparkApplicationTypeScala,
+			SparkVersion:        "3.5.0",
+			Mode:                v1beta2.DeployModeCluster,
+			MainApplicationFile: &mainFile,
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Cores:  ptr.To[int32](1),
+					Memory: ptr.To("1g"),
+				},
+			},
+			Executor: v1beta2.ExecutorSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Cores:  ptr.To[int32](1),
+					Memory: ptr.To("1g"),
+				},
+				Instances: ptr.To[int32](1),
+			},
+		},
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- This pull request adds a comprehensive set of unit tests for the `SparkApplicationValidator` in the `internal/webhook/sparkapplication_validator_test.go` file. These tests cover various validation scenarios for SparkApplication resource creation, update, and deletion, ensuring that the validator enforces rules around node selectors, driver ingress ports, Spark version compatibility, resource quotas, and spec changes.

- `internal/webhook/sparkapplication_validator.go` unit test coverage rate bump to 83.6% after this patch

### Unit test coverage for SparkApplication validation


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
