### PR TITLE
Add unit test for scheduledsparkapplication_validator

### DIFF
--- a/internal/webhook/scheduledsparkapplication_validator_test.go
+++ b/internal/webhook/scheduledsparkapplication_validator_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+func TestScheduledSparkApplicationValidatorValidateCreate(t *testing.T) {
+	validator := NewScheduledSparkApplicationValidator()
+
+	t.Run("returns nil for unrelated object types", func(t *testing.T) {
+		warnings, err := validator.ValidateCreate(context.Background(), &v1beta2.SparkApplication{})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("accepts ScheduledSparkApplication instances", func(t *testing.T) {
+		app := &v1beta2.ScheduledSparkApplication{}
+		warnings, err := validator.ValidateCreate(context.Background(), app)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+}
+
+func TestScheduledSparkApplicationValidatorValidateUpdate(t *testing.T) {
+	validator := NewScheduledSparkApplicationValidator()
+
+	t.Run("returns nil for unrelated object types", func(t *testing.T) {
+		warnings, err := validator.ValidateUpdate(
+			context.Background(),
+			&v1beta2.ScheduledSparkApplication{},
+			&v1beta2.SparkApplication{},
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("accepts ScheduledSparkApplication instances", func(t *testing.T) {
+		oldApp := &v1beta2.ScheduledSparkApplication{}
+		newApp := &v1beta2.ScheduledSparkApplication{}
+		warnings, err := validator.ValidateUpdate(context.Background(), oldApp, newApp)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+}
+
+func TestScheduledSparkApplicationValidatorValidateDelete(t *testing.T) {
+	validator := NewScheduledSparkApplicationValidator()
+
+	t.Run("returns nil for unrelated object types", func(t *testing.T) {
+		warnings, err := validator.ValidateDelete(context.Background(), &v1beta2.SparkApplication{})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("accepts ScheduledSparkApplication instances", func(t *testing.T) {
+		warnings, err := validator.ValidateDelete(context.Background(), &v1beta2.ScheduledSparkApplication{})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

bump test coverage of `scheduledsparkapplication_validator` to 90.5%

**Proposed changes:**

* Added `TestScheduledSparkApplicationValidatorValidateCreate` to check that the validator returns no errors or warnings for both unrelated object types and valid `ScheduledSparkApplication` instances.
* Added `TestScheduledSparkApplicationValidatorValidateUpdate` to confirm correct behavior when updating between unrelated types and between `ScheduledSparkApplication` instances.
* Added `TestScheduledSparkApplicationValidatorValidateDelete` to validate that deletion of unrelated types and `ScheduledSparkApplication` instances is handled without errors or warnings.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
<img width="2410" height="94" alt="image" src="https://github.com/user-attachments/assets/4f124ef4-0a00-4177-b6f4-c86f7855a5fb" />

