### PR TITLE
Fix driver host configuration to handle IPv6 addresses

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -170,9 +170,9 @@ func driverConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 	}
 
 	args = append(args, "--conf", "spark.driver.bindAddress=0.0.0.0")
-	
+
 	driverHost := "$(host=${POD_IP}; if [[ $host == *:* ]] && [[ $host != \\[* ]]; then echo \"[$host]\"; else echo \"$host\"; fi)"
-    args = append(args, "--conf", fmt.Sprintf("spark.driver.host=%s", driverHost))
+	args = append(args, "--conf", fmt.Sprintf("spark.driver.host=%s", driverHost))
 	args = append(args, "--conf", "spark.driver.port=7078")
 
 	// Driver pod name


### PR DESCRIPTION
When the driver pod IP is an IPv6 address, Spark expects the address to be enclosed in square brackets (e.g., `[2001:db8::1]`). The previous approach set `spark.driver.host` unconditionally via:

```go
args = append(args, "--conf", "spark.driver.host=${POD_IP}")
```

This fails Spark's strict hostname checks for IPv6 addresses.
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

Fix `spark.driver.host` to Enclose IPv6 Addresses in Brackets to Prevent AssertionError ([#2679](https://github.com/kubeflow/spark-operator/issues/2679))

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->


- Fixes the `AssertionError` on IPv6 clusters by ensuring Spark receives a valid host identifier.
- Compatible with both IPv4 and IPv6 environments.

<img width="969" height="166" alt="image" src="https://github.com/user-attachments/assets/e82558e2-3153-4a1c-b322-f6eef4d8960c" />
