### PR TITLE
added SparkApp name validator to accept valid DNS-1035 format

### DIFF
--- a/internal/webhook/scheduledsparkapplication_validator.go
+++ b/internal/webhook/scheduledsparkapplication_validator.go
@@ -19,9 +19,10 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
@@ -93,12 +94,8 @@ func (v *ScheduledSparkApplicationValidator) validate(_ *v1beta2.ScheduledSparkA
 // results in a valid DNS-1035 label for Kubernetes Service names. This prevents failures later
 // when creating SparkApplication resources that require DNS-1035 compliant names.
 func (v *ScheduledSparkApplicationValidator) validateName(name string) error {
-	// DNS-1035: must start with letter, contain only lowercase letters, numbers, and hyphens
-	// must not have consecutive hyphens, and must end with letter or number
-	// Max length is 63 characters
-	namePattern := regexp.MustCompile(`^[a-z]([a-z0-9]|-[a-z0-9]){0,61}[a-z0-9]?$`)
-	if !namePattern.MatchString(name) {
-		return fmt.Errorf("invalid ScheduledSparkApplication name %q: name must contain only lowercase letters, numbers, and hyphens, and end with a letter or number", name)
+	if errs := validation.IsDNS1035Label(name); len(errs) > 0 {
+		return fmt.Errorf("invalid ScheduledSparkApplication name %q: %s", name, strings.Join(errs, ", "))
 	}
 	return nil
 }

--- a/internal/webhook/scheduledsparkapplication_validator_test.go
+++ b/internal/webhook/scheduledsparkapplication_validator_test.go
@@ -144,7 +144,7 @@ func TestScheduledSparkApplicationValidatorValidateName(t *testing.T) {
 		{"name with uppercase in middle", "test-App", true},
 		{"name starting with hyphen", "-test-app", true},
 		{"name ending with hyphen", "test-app-", true},
-		{"name with consecutive hyphens", "test--app", true},
+		{"name with consecutive hyphens", "test--app", false}, // Kubernetes validation allows consecutive hyphens
 		{"empty name", "", true},
 		{"name too long", strings.Repeat("a", 64), true},
 		{"name with special characters", "test@app", true},
@@ -168,8 +168,8 @@ func TestScheduledSparkApplicationValidatorValidateName(t *testing.T) {
 				t.Errorf("validateName(%q) = error %v, wantError %v, got error: %v", tt.appName, hasError, tt.wantError, err)
 			}
 
-			if hasError && !strings.Contains(err.Error(), "name must contain only lowercase letters") {
-				t.Errorf("validateName(%q) error message should mention validation requirements, got: %v", tt.appName, err)
+			if hasError && err.Error() == "" {
+				t.Errorf("validateName(%q) should return a non-empty error message, got: %v", tt.appName, err)
 			}
 		})
 	}

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -270,7 +270,7 @@ func TestSparkApplicationValidatorValidateName(t *testing.T) {
 		{"name with uppercase in middle", "test-App", true},
 		{"name starting with hyphen", "-test-app", true},
 		{"name ending with hyphen", "test-app-", true},
-		{"name with consecutive hyphens", "test--app", true},
+		{"name with consecutive hyphens", "test--app", false}, // Kubernetes validation allows consecutive hyphens
 		{"empty name", "", true},
 		{"name too long", strings.Repeat("a", 64), true},
 		{"name with special characters", "test@app", true},
@@ -290,8 +290,8 @@ func TestSparkApplicationValidatorValidateName(t *testing.T) {
 				t.Errorf("validateName(%q) = error %v, wantError %v, got error: %v", tt.appName, hasError, tt.wantError, err)
 			}
 
-			if hasError && !strings.Contains(err.Error(), "name must contain only lowercase letters") {
-				t.Errorf("validateName(%q) error message should mention validation requirements, got: %v", tt.appName, err)
+			if hasError && err.Error() == "" {
+				t.Errorf("validateName(%q) should return a non-empty error message, got: %v", tt.appName, err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This PR adds early validation of SparkApplication metadata.name to ensure it conforms to DNS-1035 label requirements (same as Kubernetes Service names). This prevents applications with invalid names from being accepted and failing later when the controller attempts to create the web UI Service. Even though the jobs are succeeded/failed it SparkApp is stuck in submitted state; that leads to stale resources in k8s cluster.

**Problem:**
Currently, SparkApplications with invalid names (e.g., starting with numbers like `123-test-4zynu1`) are accepted by the API server but fail during reconciliation with errors like:
```
Failed to reconcile SparkApplication: failed to create web UI service: Service "..." is invalid: 
metadata.name: Invalid value: "...": a DNS-1035 label must consist of lower case alphanumeric 
characters or '-', start with an alphabetic character, and end with an alphanumeric character
```

**Solution:**
Add webhook validation using Kubernetes' built-in `validation.IsDNS1035Label()` function to reject invalid names at admission time with clear, actionable error messages.
```
Failed to submit job: admission webhook "validate-sparkoperator-k8s-io-v1beta2-sparkapplication.sparkoperator.k8s.io" 
denied the request:invalid SparkApplication name "123-test-4zynu1": a DNS-1035 label must consist of lower case 
alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-
name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```
**Proposed changes:**

- Added `validateName()` function using Kubernetes' built-in `validation.IsDNS1035Label()` for DNS-1035 label compliance
- Integrated name validation into `ValidateCreate()` and `ValidateUpdate()` webhook handlers for both `SparkApplication` and `ScheduledSparkApplication`
- Uses standard Kubernetes validation function which provides clear, actionable error messages

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

**Why this change is needed:**
1. **Early Failure Detection**: Currently, invalid names are only detected when the controller tries to create Services, resulting in confusing errors long after submission.
2. **Better User Experience**: Users get immediate, clear feedback about naming requirements instead of delayed reconciliation errors.
3. **Consistency**: Ensures SparkApplication names follow Kubernetes naming conventions from the start, preventing downstream resource creation failures.
4. **Standard Validation**: Uses Kubernetes' built-in `validation.IsDNS1035Label()` function, ensuring consistency with Kubernetes standards and reducing maintenance burden.

**Impact:**
- ✅ **Non-breaking**: Only rejects names that would have failed anyway during reconciliation
- ✅ **Backward Compatible**: Does not affect existing valid SparkApplications
- ✅ **Clear Errors**: Provides actionable error messages for common naming mistakes

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

**Error Message Examples:**
Error messages are provided by Kubernetes' `validation.IsDNS1035Label()` function, which returns clear validation errors. Example:
- Invalid name starting with number: `"invalid SparkApplication name \"28478459-kafka-to-gcs-streaming-6j783x\": [validation error from Kubernetes]"`
- Invalid name too long: `"invalid SparkApplication name \"...\": [validation error from Kubernetes]"`

**Valid Name Requirements (DNS-1035):**
- Must start with a lowercase letter [a-z]
- Can contain lowercase letters, numbers [0-9], and hyphens [-]
- Must end with a letter or number (not a hyphen)
- Maximum 63 characters
- Examples: `my-job`, `job1`, `data-pipeline-01`, `a1`
- Note: Consecutive hyphens are allowed (as per Kubernetes validation)

**Testing:**
- Comprehensive test coverage for both `SparkApplication` and `ScheduledSparkApplication` validators
- Tested with names starting with numbers (should be rejected)
- Tested with valid names (should be accepted)
- Tested with names containing uppercase letters (should be rejected)
- Tested with names starting/ending with hyphens (should be rejected)
- Verified error messages from Kubernetes validation are clear and actionable

**Related:**
This validation prevents the same issue that would occur when creating the web UI Service during reconciliation, but catches it earlier with better error messages.
