### PR TITLE
No propagate Kueue labels to driver and executor pods

### DIFF
--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -390,6 +390,13 @@ func driverConfOption(app *v1beta2.SparkApplication) ([]string, error) {
 
 	// Populate SparkApplication labels to driver pod
 	for key, value := range app.Labels {
+		// Don't propagate Kueue labels to driver pod.
+		// This is a quick workaround to avoid issues in Kueue integration.
+		// Community may consider a better label propagation control mechanisms in the future.
+		// ref: https://github.com/kubeflow/spark-operator/issues/2669#issuecomment-3500165528
+		if strings.HasPrefix(key, common.KueueLabelPrefix) {
+			continue
+		}
 		property = fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, key)
 		args = append(args, "--conf", fmt.Sprintf("%s=%s", property, value))
 	}
@@ -735,6 +742,13 @@ func executorConfOption(app *v1beta2.SparkApplication) ([]string, error) {
 
 	// Populate SparkApplication labels to executor pod
 	for key, value := range app.Labels {
+		// Don't propagate Kueue labels to driver pod.
+		// This is a quick workaround to avoid issues in Kueue integration.
+		// Community may consider a better label propagation control mechanisms in the future.
+		// ref: https://github.com/kubeflow/spark-operator/issues/2669#issuecomment-3500165528
+		if strings.HasPrefix(key, common.KueueLabelPrefix) {
+			continue
+		}
 		property := fmt.Sprintf(common.SparkKubernetesExecutorLabelTemplate, key)
 		args = append(args, "--conf", fmt.Sprintf("%s=%s", property, value))
 	}

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -102,6 +102,31 @@ func TestExecutorConfOption(t *testing.T) {
 				"--conf", fmt.Sprintf("%s=%t", common.SparkKubernetesExecutorDeleteOnTermination, true),
 			},
 		},
+		{
+			name: "kueue labels on SparkApplication should not be propagated to executor conf",
+			app: &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spark-kueue",
+					Labels: map[string]string{
+						"environment":               "production",
+						"kueue.x-k8s.io/queue-name": "high-priority",
+					},
+				},
+				Status: v1beta2.SparkApplicationStatus{
+					SubmissionID: "minimal-123",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Executor: v1beta2.ExecutorSpec{},
+				},
+			},
+			expected: []string{
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesExecutorLabelTemplate, "environment"), "production"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesExecutorLabelTemplate, common.LabelSparkAppName), "spark-kueue"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesExecutorLabelTemplate, common.LabelLaunchedBySparkOperator), "true"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesExecutorLabelTemplate, common.LabelMutatedBySparkOperator), "true"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesExecutorLabelTemplate, common.LabelSubmissionID), "minimal-123"),
+			},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -281,6 +306,31 @@ func TestDriverConfOption(t *testing.T) {
 				},
 			},
 			expected: []string{
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelSparkAppName), "spark-minimal"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelLaunchedBySparkOperator), "true"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelMutatedBySparkOperator), "true"),
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelSubmissionID), "minimal-123"),
+			},
+		},
+		{
+			name: "kueue labels on SparkApplication should not be propagated to driver conf",
+			app: &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spark-minimal",
+					Labels: map[string]string{
+						"environment":               "production",
+						"kueue.x-k8s.io/queue-name": "high-priority",
+					},
+				},
+				Status: v1beta2.SparkApplicationStatus{
+					SubmissionID: "minimal-123",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Driver: v1beta2.DriverSpec{},
+				},
+			},
+			expected: []string{
+				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, "environment"), "production"),
 				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelSparkAppName), "spark-minimal"),
 				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelLaunchedBySparkOperator), "true"),
 				"--conf", fmt.Sprintf("%s=%s", fmt.Sprintf(common.SparkKubernetesDriverLabelTemplate, common.LabelMutatedBySparkOperator), "true"),

--- a/pkg/common/kueue.go
+++ b/pkg/common/kueue.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const (
+	KueueLabelPrefix = "kueue.x-k8s.io/"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- This PR updates labels propagation behavior for labels on `SparkApplication` CR down to Driver/Executor pods so that Kueue-related labels `kueue.x-k8s.io/*` won't be propagated

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

This is a quick workaround for Kueue integration(github.com/kubernetes-sigs/kueue/pull/7268) as proposed in https://github.com/kubeflow/spark-operator/issues/2669#issuecomment-3500171804. Community would explore more sophisticated way to control labels propagation mechanism if more use-cases/demand arised.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
