### PR TITLE
feat(chart): add deploymentAnnotations option

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -115,6 +115,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.rbac.annotations | object | `{}` | Extra annotations for the controller RBAC resources. |
 | controller.labels | object | `{}` | Extra labels for controller pods. |
 | controller.annotations | object | `{}` | Extra annotations for controller pods. |
+| controller.deploymentAnnotations | object | `{}` | Extra annotations for controller deployment. |
 | controller.volumes | list | `[{"emptyDir":{"sizeLimit":"1Gi"},"name":"tmp"}]` | Volumes for controller pods. |
 | controller.nodeSelector | object | `{}` | Node selector for controller pods. |
 | controller.affinity | object | `{}` | Affinity for controller pods. |
@@ -156,6 +157,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.rbac.annotations | object | `{}` | Extra annotations for the webhook RBAC resources. |
 | webhook.labels | object | `{}` | Extra labels for webhook pods. |
 | webhook.annotations | object | `{}` | Extra annotations for webhook pods. |
+| webhook.deploymentAnnotations | object | `{}` | Extra annotations for webhook deployment. |
 | webhook.sidecars | list | `[]` | Sidecar containers for webhook pods. |
 | webhook.volumes | list | `[{"emptyDir":{"sizeLimit":"500Mi"},"name":"serving-certs"}]` | Volumes for webhook pods. |
 | webhook.nodeSelector | object | `{}` | Node selector for webhook pods. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -17,6 +17,10 @@ limitations under the License.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with .Values.controller.deploymentAnnotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   name: {{ include "spark-operator.controller.deploymentName" . }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -18,6 +18,10 @@ limitations under the License.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with .Values.webhook.deploymentAnnotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   name: {{ include "spark-operator.webhook.deploymentName" . }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -62,6 +62,25 @@ tests:
           path: spec.replicas
           value: 0
 
+  - it: Should not contain deployment annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: Should set annotations if `controller.deploymentAnnotations` is set
+    set:
+      controller:
+        deploymentAnnotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: metadata.annotations["key1"]
+          value: value1
+      - equal:
+          path: metadata.annotations["key2"]
+          value: value2
+
   - it: Should set revisionHistoryLimit to the default value
     asserts:
       - equal:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -57,6 +57,21 @@ tests:
           path: spec.replicas
           value: 0
 
+  - it: Should not contain deployment annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: Should set annotations if `webhook.deploymentAnnotations` is set
+    set:
+      webhook:
+        deploymentAnnotations:
+          secret.reloader.stakater.com/reload: "{{ include \"spark-operator.webhook.secretName\" . }}"
+    asserts:
+      - equal:
+          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+          value: spark-operator-webhook-certs
+
   - it: Should set revisionHistoryLimit to the default value
     asserts:
       - equal:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -149,6 +149,11 @@ controller:
     # key1: value1
     # key2: value2
 
+  # -- Extra annotations for controller deployment.
+  deploymentAnnotations: {}
+    # key1: value1
+    # key2: value2
+
   # -- Volumes for controller pods.
   volumes:
   # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
@@ -315,6 +320,10 @@ webhook:
   annotations: {}
     # key1: value1
     # key2: value2
+
+  # -- Extra annotations for webhook deployment.
+  deploymentAnnotations: {}
+    # secret.reloader.stakater.com/reload: "{{ include \"spark-operator.webhook.secretName\" . }}"
 
   # -- Sidecar containers for webhook pods.
   sidecars: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

The PR adds configuration option for setting annotations on the deployment objects - useful when integrating with other operators, like Reloader, to automatically rotate webhook deployment on secret change.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
