### PR TITLE
feat(chart): add hostUsers (user namespace) option

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -122,6 +122,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.priorityClassName | string | `""` | Priority class for controller pods. |
 | controller.podSecurityContext | object | `{"fsGroup":185}` | Security context for controller pods. |
 | controller.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. Ref: [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The labelSelector field in topology spread constraint will be set to the selector labels for controller pods if not specified. |
+| controller.hostUsers | string | `nil` | Whether to use user namespace or not Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | controller.env | list | `[]` | Environment variables for controller containers. |
 | controller.envFrom | list | `[]` | Environment variable sources for controller containers. |
 | controller.volumeMounts | list | `[{"mountPath":"/tmp","name":"tmp","readOnly":false}]` | Volume mounts for controller containers. |
@@ -164,6 +165,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.priorityClassName | string | `""` | Priority class for webhook pods. |
 | webhook.podSecurityContext | object | `{"fsGroup":185}` | Security context for webhook pods. |
 | webhook.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. Ref: [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The labelSelector field in topology spread constraint will be set to the selector labels for webhook pods if not specified. |
+| webhook.hostUsers | string | `nil` | Whether to use user namespace or not Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | webhook.env | list | `[]` | Environment variables for webhook containers. |
 | webhook.envFrom | list | `[]` | Environment variable sources for webhook containers. |
 | webhook.volumeMounts | list | `[{"mountPath":"/etc/k8s-webhook-server/serving-certs","name":"serving-certs","readOnly":false,"subPath":"serving-certs"}]` | Volume mounts for webhook containers. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -184,6 +184,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.controller.hostUsers) }}
+      hostUsers: {{ .Values.controller.hostUsers }}
+      {{- end }}
       {{- with .Values.controller.tolerations }}
       tolerations:
       {{- toYaml . | nindent 6 }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -144,6 +144,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.webhook.hostUsers) }}
+      hostUsers: {{ .Values.webhook.hostUsers }}
+      {{- end }}
       {{- with .Values.webhook.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -668,6 +668,71 @@ tests:
       - failedTemplate:
           errorMessage: "controller.replicas must be greater than 1 to enable topology spread constraints for controller pods"
 
+  - it: Should include hostUsers when kubernetes version >= 1.30 and hostUsers is true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      controller:
+        hostUsers: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+
+  - it: Should include hostUsers when kubernetes version >= 1.30 and hostUsers is false
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    set:
+      controller:
+        hostUsers: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: false
+
+  - it: Should not contain hostUsers when kubernetes version < 1.29 and hostUsers is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    set:
+      controller:
+        hostUsers: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should not include hostUsers when kubernetes version >= 1.30 but value not set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should should NOT include hostUsers when kubernetes version >= 1.30 but value is string
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    set:
+      controller:
+        hostUsers: "true"
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should not include hostUsers when kubernetes version >= 1.30 but value is null
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    set:
+      controller:
+        hostUsers: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
   - it: Should contain `--pprof-bind-address` arg if `controller.pprof.enable` is set to `true`
     set:
       controller:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -579,3 +579,68 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "webhook.replicas must be greater than 1 to enable topology spread constraints for webhook pods"
+
+  - it: Should include hostUsers when kubernetes version >= 1.30 and hostUsers is true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 30
+    set:
+      webhook:
+        hostUsers: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+
+  - it: Should include hostUsers when kubernetes version >= 1.30 and hostUsers is false
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    set:
+      webhook:
+        hostUsers: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: false
+
+  - it: Should not contain hostUsers when kubernetes version < 1.29 and hostUsers is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 29
+    set:
+      webhook:
+        hostUsers: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should not include hostUsers when kubernetes version >= 1.30 but value not set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should should NOT include hostUsers when kubernetes version >= 1.30 but value is string
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    set:
+      webhook:
+        hostUsers: "true"
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should not include hostUsers when kubernetes version >= 1.30 but value is null
+    capabilities:
+      majorVersion: 1
+      minorVersion: 34
+    set:
+      webhook:
+        hostUsers: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -183,6 +183,11 @@ controller:
   #   topologyKey: kubernetes.io/hostname
   #   whenUnsatisfiable: DoNotSchedule
 
+  # -- Whether to use user namespace or not
+  # Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  hostUsers: null
+
   # -- Environment variables for controller containers.
   env: []
 
@@ -352,6 +357,11 @@ webhook:
   # - maxSkew: 1
   #   topologyKey: kubernetes.io/hostname
   #   whenUnsatisfiable: DoNotSchedule
+
+  # -- Whether to use user namespace or not
+  # Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  hostUsers: null
 
   # -- Environment variables for webhook containers.
   env: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

With Kubernetes 1.33, [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) are supported to enhance pod security by isolating pod processes in a separate user namespace, reducing the risk of privilege escalation. This PR adds an opt-in configuration to enable user namespaces for controller/webhook pods.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
