### PR TITLE
Remove redundant name and namespace context in logs

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -742,7 +742,7 @@ func (r *Reconciler) reconcileSuspendingSparkApplication(ctx context.Context, re
 			r.recordSparkApplicationEvent(app)
 
 			if err := r.deleteSparkResources(ctx, app); err != nil {
-				logger.Error(err, "failed to delete spark resources", "name", app.Name, "namespace", app.Namespace)
+				logger.Error(err, "failed to delete spark resources")
 				return err
 			}
 
@@ -758,7 +758,7 @@ func (r *Reconciler) reconcileSuspendingSparkApplication(ctx context.Context, re
 		},
 	)
 	if retryErr != nil {
-		logger.Error(retryErr, "Failed to reconcile SparkApplication", "name", key.Name, "namespace", key.Namespace)
+		logger.Error(retryErr, "Failed to reconcile SparkApplication")
 		return ctrl.Result{}, retryErr
 	}
 	return ctrl.Result{}, nil
@@ -780,7 +780,7 @@ func (r *Reconciler) reconcileSuspendedSparkApplication(ctx context.Context, req
 			app := old.DeepCopy()
 
 			if r.validateSparkResourceDeletion(ctx, app) {
-				logger.Info("Successfully deleted resources associated with SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
+				logger.Info("Successfully deleted resources associated with SparkApplication", "state", app.Status.AppState.State)
 				r.resetSparkApplicationStatus(app)
 				r.recordSparkApplicationEvent(app)
 				if !ptr.Deref(app.Spec.Suspend, false) {
@@ -789,8 +789,8 @@ func (r *Reconciler) reconcileSuspendedSparkApplication(ctx context.Context, req
 					}
 				}
 			} else {
-				err := fmt.Errorf("resources associated with SparkApplication still exist: %s/%s", app.Namespace, app.Name)
-				logger.Error(err, "Failed to confirm being deleted resources associated with SparkApplication", "name", app.Name, "namespace", app.Namespace, "state", app.Status.AppState.State)
+				err := fmt.Errorf("resources associated with SparkApplication still exist")
+				logger.Error(err, "Failed to confirm being deleted resources associated with SparkApplication", "state", app.Status.AppState.State)
 				return err
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
@@ -800,7 +800,7 @@ func (r *Reconciler) reconcileSuspendedSparkApplication(ctx context.Context, req
 		},
 	)
 	if retryErr != nil {
-		logger.Error(retryErr, "Failed to reconcile SparkApplication", "name", key.Name, "namespace", key.Namespace)
+		logger.Error(retryErr, "Failed to reconcile SparkApplication")
 		return ctrl.Result{}, retryErr
 	}
 	return ctrl.Result{}, nil
@@ -831,7 +831,7 @@ func (r *Reconciler) reconcileResumingSparkApplication(ctx context.Context, req 
 		},
 	)
 	if retryErr != nil {
-		logger.Error(retryErr, "Failed to reconcile SparkApplication", "name", key.Name, "namespace", key.Namespace)
+		logger.Error(retryErr, "Failed to reconcile SparkApplication")
 		return ctrl.Result{Requeue: true}, retryErr
 	}
 	return ctrl.Result{}, nil
@@ -858,7 +858,7 @@ func (r *Reconciler) transitionToSuspending(ctx context.Context, req ctrl.Reques
 		},
 	)
 	if retryErr != nil {
-		logger.Error(retryErr, "Failed to reconcile SparkApplication", "name", key.Name, "namespace", key.Namespace)
+		logger.Error(retryErr, "Failed to reconcile SparkApplication")
 		return ctrl.Result{Requeue: true}, retryErr
 	}
 	return ctrl.Result{}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Remove redundant name and namespace context in logs.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

Otherwise, there will be duplicated `name` and `namespace` contexts in logs, for example:

```txt
2025-11-12T02:20:40.457Z    INFO    sparkapplication/controller.go:783    Successfully deleted resources associated with SparkApplication    {"controller": "spark-applicat
ion-controller", "namespace": "spark", "name": "spark-pi-suspend", "reconcileID": "be1c129d-21e6-4683-bc2e-83249b22d85d", "name": "spark-pi-suspend", "namespace": "spark",
 "state": "SUSPENDED"}
```

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
