### PR TITLE
Logging info when resources associated with SparkApplication still exist

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -498,6 +498,8 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 				r.recordSparkApplicationEvent(app)
 				r.resetSparkApplicationStatus(app)
 				r.submitSparkApplication(ctx, app)
+			} else {
+				logger.Info("Resources associated with SparkApplication still exist")
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
 				return err
@@ -789,9 +791,7 @@ func (r *Reconciler) reconcileSuspendedSparkApplication(ctx context.Context, req
 					}
 				}
 			} else {
-				err := fmt.Errorf("resources associated with SparkApplication still exist")
-				logger.Error(err, "Failed to confirm being deleted resources associated with SparkApplication", "state", app.Status.AppState.State)
-				return err
+				logger.Info("Resources associated with SparkApplication still exist")
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

Close #2724.

**Proposed changes:**

- Remove unnecessary error logging for suspended SparkApplication reconciliation.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

- When the app is in `SUSPENDING` state, the controller sends requests to API server to delete resources like driver pod, server and ingress, then change the state to `SUSPENDED` state.
- But the driver pod can still exists when reconciling a `SUSPENDED` app, thus the erros will show up in controller logs.
- When the driver pod is actually deleted, the `SUSPENDED` app will be reconciled again. So it is fine to remove the error logging statements to suprress the errors.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
