### PR TITLE
feat(scheduledsparkapplication): add configurable timestampPrecision for run name generation

### DIFF
--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -57,6 +57,10 @@ hook:
     tag: ""
 
 controller:
+  # -- default precision for ScheduledSparkApplication timestamp suffix
+  scheduledSparkApplication:
+    timestampPrecision: "nanos"
+
   # -- Number of replicas of controller.
   replicas: 1
 

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -12418,6 +12418,20 @@ spec:
                   or a valid IANA location name e.g. "America/New_York".
                   Defaults to "Local".
                 type: string
+              timestampPrecision:
+                default: nanos
+                description: |-
+                  TimestampPrecision controls the precision of the timestamp appended to generated
+                  SparkApplication names for scheduled runs.
+
+                  Allowed values: "nanos", "micros", "millis", "seconds"
+                  Defaults to "nanos" to preserve current behavior.
+                enum:
+                - nanos
+                - micros
+                - millis
+                - seconds
+                type: string
             required:
             - schedule
             - template

--- a/internal/controller/scheduledsparkapplication/controller.go
+++ b/internal/controller/scheduledsparkapplication/controller.go
@@ -42,6 +42,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"strconv"
+
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
@@ -236,9 +238,17 @@ func (r *Reconciler) createSparkApplication(
 	for key, value := range scheduledApp.Labels {
 		labels[key] = value
 	}
+
+	// Determine timestamp precision (default to nanos for backwards compatibility)
+	precision := scheduledApp.Spec.TimestampPrecision
+	if precision == "" {
+		precision = "nanos"
+	}
+	suffix := formatTimestamp(precision, t)
+
 	app := &v1beta2.SparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%d", scheduledApp.Name, t.UnixNano()),
+			Name:      fmt.Sprintf("%s-%s", scheduledApp.Name, suffix),
 			Namespace: scheduledApp.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{{
@@ -255,6 +265,25 @@ func (r *Reconciler) createSparkApplication(
 		return nil, err
 	}
 	return app, nil
+}
+
+// formatTimestamp returns a decimal timestamp string according to the requested precision.
+// Allowed precisions: "nanos", "micros", "millis", "seconds".
+// If precision is empty or unrecognized, defaults to "nanos" (current behavior).
+func formatTimestamp(precision string, t time.Time) string {
+	switch precision {
+	case "seconds":
+		return strconv.FormatInt(t.Unix(), 10)
+	case "millis":
+		// Use UnixNano()/1e6 for compatibility with older Go versions.
+		return strconv.FormatInt(t.UnixNano()/1e6, 10)
+	case "micros":
+		return strconv.FormatInt(t.UnixNano()/1e3, 10)
+	case "nanos":
+		fallthrough
+	default:
+		return strconv.FormatInt(t.UnixNano(), 10)
+	}
 }
 
 // shouldStartNextRun checks if the next run should be started.

--- a/internal/controller/scheduledsparkapplication/format_timestamp_test.go
+++ b/internal/controller/scheduledsparkapplication/format_timestamp_test.go
@@ -1,0 +1,25 @@
+package scheduledsparkapplication
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatTimestampLengths(t *testing.T) {
+	// deterministic time so tests are stable
+	now := time.Unix(1700000000, 123456789) // arbitrary fixed timestamp
+
+	cases := map[string]int{
+		"seconds": 10, // example "1700000000"
+		"millis":  13,
+		"micros":  16,
+		"nanos":   19,
+	}
+
+	for precision, wantLen := range cases {
+		s := formatTimestamp(precision, now)
+		if len(s) != wantLen {
+			t.Fatalf("precision=%s: got len %d, want %d (value=%s)", precision, len(s), wantLen, s)
+		}
+	}
+}

--- a/scripts/setup-envtest-binaries.sh
+++ b/scripts/setup-envtest-binaries.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# scripts/setup-envtest-binaries.sh
+# Download kube-apiserver and etcd for envtest to the location expected by tests.
+# Usage: from repo root: bash scripts/setup-envtest-binaries.sh
+# (Make executable with chmod +x scripts/setup-envtest-binaries.sh)
+
+set -euo pipefail
+
+# --- Configuration: edit if your tests expect a different K8S version
+K8S_VERSION="v1.32.0"            # kube-apiserver/kube-controller-manager version envtest expects
+ETCD_VERSION="v3.5.11"           # etcd version (3.5.x recommended)
+TARGET_DIR="./bin/k8s/${K8S_VERSION}-linux-amd64"  # target where envtest looked for binaries
+
+echo
+echo "==> Setting up envtest binaries"
+echo "Kubernetes version: ${K8S_VERSION}"
+echo "etcd version:       ${ETCD_VERSION}"
+echo "Target directory:   ${TARGET_DIR}"
+echo
+
+mkdir -p "${TARGET_DIR}"
+
+# Helper to check for curl or wget
+download() {
+  local url="$1" out="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL -o "${out}" "${url}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "${out}" "${url}"
+  else
+    echo "Error: need curl or wget to download files." >&2
+    exit 2
+  fi
+}
+
+# Download Kubernetes server tarball and extract kube-apiserver
+K8S_TAR="/tmp/k8s-server-${K8S_VERSION}.tar.gz"
+echo "Downloading Kubernetes server ${K8S_VERSION} -> ${K8S_TAR} ..."
+download "https://dl.k8s.io/${K8S_VERSION}/kubernetes-server-linux-amd64.tar.gz" "${K8S_TAR}"
+
+echo "Extracting kube-apiserver from ${K8S_TAR}..."
+rm -rf /tmp/kubernetes || true
+tar -C /tmp -xzf "${K8S_TAR}"
+
+KUBE_APISERVER_SRC="/tmp/kubernetes/server/bin/kube-apiserver"
+if [ ! -f "${KUBE_APISERVER_SRC}" ]; then
+  echo "Error: kube-apiserver not found at ${KUBE_APISERVER_SRC}" >&2
+  echo "Listing /tmp/kubernetes contents:"
+  ls -la /tmp/kubernetes || true
+  exit 3
+fi
+
+cp -v "${KUBE_APISERVER_SRC}" "${TARGET_DIR}/"
+
+# Download etcd tarball and extract etcd binary
+ETCD_TAR="/tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz"
+echo "Downloading etcd ${ETCD_VERSION} -> ${ETCD_TAR} ..."
+download "https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz" "${ETCD_TAR}"
+
+echo "Extracting etcd from ${ETCD_TAR}..."
+rm -rf "/tmp/etcd-${ETCD_VERSION}-linux-amd64" || true
+tar -C /tmp -xzf "${ETCD_TAR}"
+
+ETCD_SRC="/tmp/etcd-${ETCD_VERSION}-linux-amd64/etcd"
+if [ -f "${ETCD_SRC}" ]; then
+  cp -v "${ETCD_SRC}" "${TARGET_DIR}/"
+else
+  # fallback: search extracted tmp for etcd binary
+  found_etcd=$(find /tmp -type f -name etcd -print -quit || true)
+  if [ -n "${found_etcd}" ]; then
+    cp -v "${found_etcd}" "${TARGET_DIR}/"
+  else
+    echo "ERROR: etcd binary not found inside extracted etcd tarball." >&2
+    exit 4
+  fi
+fi
+
+# Make everything executable
+chmod +x "${TARGET_DIR}"/*
+
+# Export KUBEBUILDER_ASSETS for current shell user (print instruction)
+ABS_TARGET_DIR="$(cd "$(dirname "${TARGET_DIR}")" && pwd)/$(basename "${TARGET_DIR}")"
+echo
+echo "Binaries installed in: ${ABS_TARGET_DIR}"
+echo
+echo "To use these binaries for running tests in this shell, run:"
+echo "  export KUBEBUILDER_ASSETS=\"${ABS_TARGET_DIR}\""
+echo
+echo "You can also add that export line to your shell profile (e.g. ~/.bashrc) if you want it persistent."
+echo
+
+# Add bin/ to .gitignore if not present (local convenience)
+if ! rg -q "^bin/" .gitignore 2>/dev/null || [ ! -f .gitignore ]; then
+  echo "Adding 'bin/' to .gitignore (local convenience)"
+  echo "bin/" >> .gitignore
+  echo "Note: bin/ contains large local binaries; do not commit them."
+fi
+
+echo "Done. Now run the tests that failed, e.g.:"
+echo "  go test ./internal/controller/scheduledsparkapplication -v"
+echo "or to run all controller tests:"
+echo "  go test ./internal/controller/... -v"


### PR DESCRIPTION
Adds configurable timestamp precision for ScheduledSparkApplication run names.

This PR introduces a new field `spec.timestampPrecision` (allowed: `nanos`, `micros`, `millis`, `seconds`) and updates the controller to generate run names using the user-selected precision instead of always using `UnixNano()`.  
This allows users to avoid hitting Kubernetes’ 63-character name limit when using long ScheduledSparkApplication names.  
Default remains `nanos` to maintain full backward compatibility.

Includes:
- API change (`ScheduledSparkApplicationSpec.timestampPrecision`)
- Controller logic update for name generation
- CRD regeneration via `make generate` + `make manifests`
- New unit tests for timestamp formatting
- Optional Helm chart value for timestampPrecision
- Envtest helper script to support local test execution

Fixes: #2602

---

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This PR implements the feature requested in #2602 by allowing users to control the precision of the timestamp suffix appended to run names generated by `ScheduledSparkApplication`.  
Previously, run names always used `UnixNano()`, resulting in a 19-digit suffix which often caused the name to exceed Kubernetes’ 63-character limit.

### Proposed changes:

- Add new field `.spec.timestampPrecision` to `ScheduledSparkApplicationSpec`  
  (enum: `nanos`, `micros`, `millis`, `seconds`, default: `nanos`)
- Add helper function `formatTimestamp()` to controller
- Update controller run-name generation logic to use user-selected precision
- Regenerate CRD with proper OpenAPI validation & defaulting
- Add unit tests for timestamp precision behavior
- Add optional Helm chart value `scheduledSparkApplication.timestampPrecision`
- Add a helper script (`scripts/setup-envtest-binaries.sh`) to simplify running envtest locally

This feature is fully backward-compatible. If the field is omitted, behavior remains unchanged.

---

## Change Category

- [x] Feature (non-breaking change which adds functionality)
- [ ] Bugfix
- [ ] Breaking change
- [ ] Documentation update

---

## Rationale

Users with long application names currently exceed Kubernetes’ resource name limit because the operator always appends a 19-digit nanosecond timestamp.  
By allowing precision selection, this PR gives users control over timestamp length:

- seconds → 10 digits  
- millis → 13 digits  
- micros → 16 digits  
- nanos → 19 digits (default)

This prevents scheduling failures without modifying existing workflows.

---

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have added tests that prove the feature works.
- [x] I regenerated CRDs with `make generate` and `make manifests`.
- [x] I verified that existing functionality is unaffected.
- [x] Unit tests pass locally.

---

## Additional Notes

- Default behavior (`nanos`) remains unchanged → **zero breaking changes**.
- Helm value is optional and does not affect API behavior.
- Envtest helper script is provided only for contributors (not used in runtime).
- Ready for review and `/assign` to owners.
