### PR TITLE
[fix] trigger reconcile if driver pod Waiting

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -1487,10 +1487,10 @@ func (r *Reconciler) cleanUpPodTemplateFiles(ctx context.Context, app *v1beta2.S
 func isDriverStuckInPending(ctx context.Context, pod *corev1.Pod) (bool, string, string) {
 	logger := log.FromContext(ctx)
 	logger.Info("Checking driver pod for failure reasons", "pod", pod.Name)
-	reason := util.GetPodFailureReason(pod)
+	reason, msg := util.GetPodFailureReason(pod)
 	unschedulable := util.IsPodUnschedulable(pod)
 	if reason != "" && !unschedulable {
-		return true, reason, pod.Status.Message
+		return true, reason, msg
 	}
 	return false, "", ""
 }

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -327,8 +327,10 @@ func (r *Reconciler) reconcileSubmittedSparkApplication(ctx context.Context, req
 			app := old.DeepCopy()
 
 			pod, err := r.getDriverPod(ctx, app)
-
-			if pod != nil || err != nil {
+			if err != nil {
+				return err
+			}
+			if pod != nil {
 				failed, reason, message := isDriverStuckInPending(ctx, pod)
 
 				if failed && app.Status.AppState.State != v1beta2.ApplicationStateFailed {
@@ -1487,7 +1489,7 @@ func isDriverStuckInPending(ctx context.Context, pod *corev1.Pod) (bool, string,
 	logger.Info("Checking driver pod for failure reasons", "pod", pod.Name)
 	reason := util.GetPodFailureReason(pod)
 	unschedulable := util.IsPodUnschedulable(pod)
-	if reason != "" || unschedulable {
+	if reason != "" && !unschedulable {
 		return true, reason, pod.Status.Message
 	}
 	return false, "", ""

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -79,7 +79,7 @@ func (f *sparkPodEventFilter) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	if newPod.Status.Phase == oldPod.Status.Phase {
+	if !util.ShouldProcessPodUpdate(oldPod, newPod) {
 		return false
 	}
 

--- a/internal/controller/sparkapplication/event_handler.go
+++ b/internal/controller/sparkapplication/event_handler.go
@@ -87,7 +87,8 @@ func (h *SparkPodEventHandler) Update(ctx context.Context, event event.UpdateEve
 	if newPod.Status.Phase != oldPod.Status.Phase {
 		logger.Info("Spark pod updated", "name", newPod.Name, "namespace", newPod.Namespace, "oldPhase", oldPod.Status.Phase, "newPhase", newPod.Status.Phase)
 	} else if util.DriverFailureReasonChanged(oldPod, newPod) {
-		logger.Info("Spark driver pod waiting reason updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase, "reason", util.GetPodFailureReason(newPod))
+		rsn, _ := util.GetPodFailureReason(newPod)
+		logger.Info("Spark driver pod waiting reason updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase, "reason", rsn)
 	} else {
 		logger.Info("Spark driver pod scheduling condition updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase)
 	}

--- a/internal/controller/sparkapplication/event_handler.go
+++ b/internal/controller/sparkapplication/event_handler.go
@@ -84,13 +84,26 @@ func (h *SparkPodEventHandler) Update(ctx context.Context, event event.UpdateEve
 	}
 
 	logger := log.FromContext(ctx)
-	if newPod.Status.Phase != oldPod.Status.Phase {
-		logger.Info("Spark pod updated", "name", newPod.Name, "namespace", newPod.Namespace, "oldPhase", oldPod.Status.Phase, "newPhase", newPod.Status.Phase)
-	} else if util.DriverFailureReasonChanged(oldPod, newPod) {
-		rsn, _ := util.GetPodFailureReason(newPod)
-		logger.Info("Spark driver pod waiting reason updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase, "reason", rsn)
-	} else {
-		logger.Info("Spark driver pod scheduling condition updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase)
+	if newPod.Status.Phase == oldPod.Status.Phase {
+		if !util.ShouldProcessPodUpdate(oldPod, newPod) {
+			return
+		}
+
+		if util.DriverFailureReasonChanged(oldPod, newPod) {
+			rsn, _ := util.GetPodFailureReason(newPod)
+			logger.Info("Spark driver pod waiting reason updated",
+				"name", newPod.Name,
+				"namespace", newPod.Namespace,
+				"phase", newPod.Status.Phase,
+				"reason", rsn,
+			)
+		} else {
+			logger.Info("Spark driver pod scheduling condition updated",
+				"name", newPod.Name,
+				"namespace", newPod.Namespace,
+				"phase", newPod.Status.Phase,
+			)
+		}
 	}
 	h.enqueueSparkAppForUpdate(ctx, newPod, queue)
 

--- a/internal/controller/sparkapplication/event_handler.go
+++ b/internal/controller/sparkapplication/event_handler.go
@@ -79,12 +79,18 @@ func (h *SparkPodEventHandler) Update(ctx context.Context, event event.UpdateEve
 		return
 	}
 
-	if newPod.Status.Phase == oldPod.Status.Phase {
+	if !util.ShouldProcessPodUpdate(oldPod, newPod) {
 		return
 	}
 
 	logger := log.FromContext(ctx)
-	logger.Info("Spark pod updated", "name", newPod.Name, "namespace", newPod.Namespace, "oldPhase", oldPod.Status.Phase, "newPhase", newPod.Status.Phase)
+	if newPod.Status.Phase != oldPod.Status.Phase {
+		logger.Info("Spark pod updated", "name", newPod.Name, "namespace", newPod.Namespace, "oldPhase", oldPod.Status.Phase, "newPhase", newPod.Status.Phase)
+	} else if util.DriverFailureReasonChanged(oldPod, newPod) {
+		logger.Info("Spark driver pod waiting reason updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase, "reason", util.GetPodFailureReason(newPod))
+	} else {
+		logger.Info("Spark driver pod scheduling condition updated", "name", newPod.Name, "namespace", newPod.Namespace, "phase", newPod.Status.Phase)
+	}
 	h.enqueueSparkAppForUpdate(ctx, newPod, queue)
 
 	if h.metrics != nil && util.IsExecutorPod(oldPod) && util.IsExecutorPod(newPod) {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -54,3 +54,8 @@ const (
 	// Epsilon is a small number used to compare 64 bit floating point numbers.
 	Epsilon = 1e-9
 )
+
+const (
+	ReasonErrImagePull     = "ErrImagePull"
+	ReasonImagePullBackOff = "ImagePullBackOff"
+)

--- a/pkg/util/sparkpod.go
+++ b/pkg/util/sparkpod.go
@@ -84,13 +84,13 @@ func ShouldProcessPodUpdate(oldPod, newPod *corev1.Pod) bool {
 }
 
 func DriverFailureReasonChanged(oldPod, newPod *corev1.Pod) bool {
-	oldReason := GetPodFailureReason(oldPod)
-	newReason := GetPodFailureReason(newPod)
+	oldReason, _ := GetPodFailureReason(oldPod)
+	newReason, _ := GetPodFailureReason(newPod)
 
 	return newReason != "" && newReason != oldReason
 }
 
-func GetPodFailureReason(pod *corev1.Pod) string {
+func GetPodFailureReason(pod *corev1.Pod) (string, string) {
 	for _, status := range pod.Status.ContainerStatuses {
 		if status.State.Waiting == nil {
 			continue
@@ -98,11 +98,11 @@ func GetPodFailureReason(pod *corev1.Pod) string {
 
 		switch status.State.Waiting.Reason {
 		case common.ReasonImagePullBackOff, common.ReasonErrImagePull:
-			return status.State.Waiting.Reason
+			return status.State.Waiting.Reason, status.State.Waiting.Message
 		}
 	}
 
-	return ""
+	return "", ""
 }
 
 func BecameUnschedulable(oldPod, newPod *corev1.Pod) bool {

--- a/pkg/util/sparkpod.go
+++ b/pkg/util/sparkpod.go
@@ -65,3 +65,58 @@ func IsPodReady(pod *corev1.Pod) bool {
 	}
 	return false
 }
+
+func ShouldProcessPodUpdate(oldPod, newPod *corev1.Pod) bool {
+	if newPod.Status.Phase != oldPod.Status.Phase {
+		return true
+	}
+
+	// Only driver pod transitions can unblock the application status while the phase is pending.
+	if !IsDriverPod(newPod) {
+		return false
+	}
+
+	if DriverFailureReasonChanged(oldPod, newPod) {
+		return true
+	}
+
+	return BecameUnschedulable(oldPod, newPod)
+}
+
+func DriverFailureReasonChanged(oldPod, newPod *corev1.Pod) bool {
+	oldReason := GetPodFailureReason(oldPod)
+	newReason := GetPodFailureReason(newPod)
+
+	return newReason != "" && newReason != oldReason
+}
+
+func GetPodFailureReason(pod *corev1.Pod) string {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Waiting == nil {
+			continue
+		}
+
+		switch status.State.Waiting.Reason {
+		case common.ReasonImagePullBackOff, common.ReasonErrImagePull:
+			return status.State.Waiting.Reason
+		}
+	}
+
+	return ""
+}
+
+func BecameUnschedulable(oldPod, newPod *corev1.Pod) bool {
+	return !IsPodUnschedulable(oldPod) && IsPodUnschedulable(newPod)
+}
+
+func IsPodUnschedulable(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == corev1.PodReasonUnschedulable {
+			return true
+		}
+	}
+
+	return false
+}

--- a/test/e2e/bad_examples/image-pull-failure.yaml
+++ b/test/e2e/bad_examples/image-pull-failure.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright 2025 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: SparkApplication
+metadata:
+  name: image-pull-failure
+  namespace: default
+spec:
+  type: Scala
+  mode: cluster
+  # Intentionally invalid image to trigger ErrImagePull/ImagePullBackOff
+  image: invalid.registry.local/spark:nonexistent
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples.jar
+  sparkVersion: 4.0.0
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    memory: 512m
+    serviceAccount: spark-operator-spark
+  executor:
+    instances: 1
+    cores: 1
+    memory: 512m

--- a/test/e2e/image_pull_e2e_test.go
+++ b/test/e2e/image_pull_e2e_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+// This E2E test verifies that a SparkApplication transitions out of Submitted and into
+// Failing/Failed when the driver image cannot be pulled (ErrImagePull/ImagePullBackOff).
+var _ = Describe("image-pull failure", func() {
+	ctx := context.Background()
+	path := filepath.Join("bad_examples", "image-pull-failure.yaml")
+	app := &v1beta2.SparkApplication{}
+
+	BeforeEach(func() {
+		By("Parsing SparkApplication from file")
+		file, err := os.Open(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file).NotTo(BeNil())
+
+		decoder := yaml.NewYAMLOrJSONDecoder(file, 100)
+		Expect(decoder).NotTo(BeNil())
+		Expect(decoder.Decode(app)).NotTo(HaveOccurred())
+
+		app.Spec.RestartPolicy.Type = v1beta2.RestartPolicyNever
+
+		By("Creating SparkApplication")
+		Expect(k8sClient.Create(ctx, app)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+		Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+		By("Deleting SparkApplication")
+		Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+	})
+
+	It("should move to Failing then Failed with an image pull error message", func() {
+		key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+
+		By("Waiting for application to enter Failing due to image pull error")
+		cancelCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		sawFailing := false
+		err := wait.PollUntilContextCancel(cancelCtx, PollInterval, true, func(ctx context.Context) (bool, error) {
+			got := &v1beta2.SparkApplication{}
+			if e := k8sClient.Get(ctx, key, got); e != nil {
+				return false, e
+			}
+			if got.Status.AppState.State == v1beta2.ApplicationStateFailed {
+				sawFailing = true
+				msg := got.Status.AppState.ErrorMessage
+				Expect(msg).NotTo(BeEmpty())
+				Expect(strings.Contains(msg, common.ReasonErrImagePull) || strings.Contains(msg, common.ReasonImagePullBackOff)).To(BeTrue())
+				Expect(got.Status.TerminationTime.Time.IsZero()).To(BeFalse())
+				return true, nil
+			}
+			return false, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sawFailing).To(BeTrue())
+
+		By("Waiting for application to reach Failed")
+		Expect(waitForSparkAppFailed(ctx, key)).NotTo(HaveOccurred())
+	})
+})
+
+func waitForSparkAppFailed(ctx context.Context, key types.NamespacedName) error {
+	cancelCtx, cancel := context.WithTimeout(ctx, WaitTimeout)
+	defer cancel()
+
+	app := &v1beta2.SparkApplication{}
+	return wait.PollUntilContextCancel(cancelCtx, PollInterval, true, func(ctx context.Context) (bool, error) {
+		if err := k8sClient.Get(ctx, key, app); err != nil {
+			return false, err
+		}
+		switch app.Status.AppState.State {
+		case v1beta2.ApplicationStateFailed:
+			return true, nil
+		case v1beta2.ApplicationStateCompleted, v1beta2.ApplicationStateFailedSubmission:
+			return false, &unexpectedTerminalState{state: string(app.Status.AppState.State), message: app.Status.AppState.ErrorMessage}
+		}
+		return false, nil
+	})
+}
+
+type unexpectedTerminalState struct {
+	state   string
+	message string
+}
+
+func (e *unexpectedTerminalState) Error() string {
+	return "unexpected terminal state: " + e.state + ": " + e.message
+}


### PR DESCRIPTION
## Purpose of this PR

Fixing a bug where the SparkApplication did not transition to Failed when the driver pod, while in pending status, received an ErrImagePull.

**Proposed changes:**
- Extend pkg/util/sparkpod_test.go
- Exercise controller-specific logic such as ShouldProcessPodUpdate, driver failure reason detection, and unschedulable transitions.
- Add reusable pod/status builders to keep complex test scenarios concise.


## Change Category

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

These helpers are central to the controller’s reconciliation flow. Covering them with table-top tests protects against regressions when adjusting pod labels, conditions, or driver-specific status handling.


## Checklist

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

I’m not sure the solution is correct, but the bug is fixed.
