### PR TITLE
Fix : Propagate batch scheduler initialization errors to trigger retries

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -916,7 +916,10 @@ func (r *Reconciler) submitSparkApplication(ctx context.Context, app *v1beta2.Sp
 	}
 
 	// Use batch scheduler to perform scheduling task before submitting (before build command arguments).
-	if needScheduling, scheduler := r.shouldDoBatchScheduling(ctx, app); needScheduling {
+	if needScheduling, scheduler, err := r.shouldDoBatchScheduling(ctx, app); err != nil {
+		submitErr = fmt.Errorf("failed during batch scheduler setup or check: %v", err)
+		return
+	} else if needScheduling {
 		logger.Info("Do batch scheduling for SparkApplication")
 		if err := scheduler.Schedule(app); err != nil {
 			submitErr = fmt.Errorf("failed to process batch scheduler: %v", err)
@@ -1390,11 +1393,10 @@ func (r *Reconciler) resetSparkApplicationStatus(app *v1beta2.SparkApplication) 
 	}
 }
 
-func (r *Reconciler) shouldDoBatchScheduling(ctx context.Context, app *v1beta2.SparkApplication) (bool, scheduler.Interface) {
-	logger := log.FromContext(ctx)
+func (r *Reconciler) shouldDoBatchScheduling(ctx context.Context, app *v1beta2.SparkApplication) (bool, scheduler.Interface, error) {
 	// If batch scheduling isn't enabled
 	if r.registry == nil {
-		return false, nil
+		return false, nil, nil
 	}
 
 	schedulerName := r.options.DefaultBatchScheduler
@@ -1404,7 +1406,7 @@ func (r *Reconciler) shouldDoBatchScheduling(ctx context.Context, app *v1beta2.S
 
 	// If both the default and app batch scheduler are unspecified or empty
 	if schedulerName == "" {
-		return false, nil
+		return false, nil, nil
 	}
 
 	var err error
@@ -1431,15 +1433,14 @@ func (r *Reconciler) shouldDoBatchScheduling(ctx context.Context, app *v1beta2.S
 	}
 
 	if err != nil || scheduler == nil {
-		logger.Error(err, "Failed to get scheduler for SparkApplication", "scheduler", schedulerName)
-		return false, nil
+		return false, nil, fmt.Errorf("failed to get scheduler %s: %v", schedulerName, err)
 	}
-	return scheduler.ShouldSchedule(app), scheduler
+	return scheduler.ShouldSchedule(app), scheduler, nil
 }
 
 // Clean up when the spark application is terminated.
 func (r *Reconciler) cleanUpOnTermination(ctx context.Context, _, newApp *v1beta2.SparkApplication) error {
-	if needScheduling, scheduler := r.shouldDoBatchScheduling(ctx, newApp); needScheduling {
+	if needScheduling, scheduler, _ := r.shouldDoBatchScheduling(ctx, newApp); needScheduling {
 		if err := scheduler.Cleanup(newApp); err != nil {
 			return err
 		}


### PR DESCRIPTION
__Description:__
Fixes #2782 

Currently, the `SparkApplication` controller has an issue when handling errors that occur during the initialization or retrieval phase of a batch scheduler (e.g., Volcano) via the `shouldDoBatchScheduling` function. If the `r.registry.GetScheduler` call fails due to underlying Kubernetes API Server issues (e.g., transient errors like "CRD PodGroup does not exist" caused by a temporary `etcd` disconnection), the `shouldDoBatchScheduling` function logs the error but does not propagate it back to the `submitSparkApplication` caller.

This means that even if batch scheduler setup fails, the `submitErr` variable within `submitSparkApplication` remains `nil`. As a result, the `SparkApplication`'s status is not set to `ApplicationStateFailedSubmission`, preventing the built-in retry mechanism from being activated. The application might continue attempting submission with an improperly configured batch scheduler, or the error information might not be correctly reflected in the `SparkApplication`'s status.

__Changes Made:__

1. __Modified `Reconciler.shouldDoBatchScheduling` function signature:__

   - The function now returns an additional `error` type, i.e., `(bool, scheduler.Interface, error)`.
   - When `r.registry.GetScheduler` returns an error, `shouldDoBatchScheduling` will no longer just log the error but will also return it as part of its return values.
   - For robustness, if `GetScheduler` succeeds but returns a `nil` scheduler object, a corresponding error is also returned.

2. __Modified `Reconciler.submitSparkApplication` function:__

   - It now captures the error returned by `r.shouldDoBatchScheduling`.
   - If `shouldDoBatchScheduling` returns an error, `submitSparkApplication` will assign this error to `submitErr` and return early.
   - The logic in the `defer` statement will detect the presence of `submitErr`, correctly updating the `SparkApplication`'s status to `ApplicationStateFailedSubmission` and logging the appropriate failure message.

__Problem Solved:__

- __Error Propagation:__ Ensures that errors occurring during batch scheduler initialization or retrieval are correctly propagated upstream.
- __Retry Mechanism Activation:__ Enables submission failures caused by batch scheduler configuration or temporary API issues to trigger the `SparkApplication`'s built-in `FailedSubmission` retry strategy. This enhances resilience to transient errors.
- __Status Accuracy:__ Guarantees that the `SparkApplication`'s status accurately reflects the batch scheduler setup failure, providing clearer feedback to users.

__Testing Strategy:__

- Simulate transient Kubernetes API Server errors when handling CRD requests (e.g., during `GetScheduler` attempting to get the Volcano client, simulate a non-existent `PodGroup` CRD, or temporary `kube-apiserver` unavailability). Observe if the `SparkApplication` correctly enters the `FailedSubmission` state and retries.
- Confirm that the existing submission process remains unaffected when the batch scheduler initializes successfully.
