### PR TITLE
feat: skip reconcile for webhook-patched executor fields

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -91,6 +91,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | hook.affinity | object | `{}` | Affinity for the Helm hook Job. |
 | hook.tolerations | list | `[]` | List of node taints to tolerate for the Helm hook Job. |
 | controller.replicas | int | `1` | Number of replicas of controller. |
+| controller.featureGates | list | `[]` | Feature gates to enable or disable specific features. Example: featureGates: - name: PartialRestart   enabled: true |
 | controller.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | controller.leaderElection.enable | bool | `true` | Specifies whether to enable leader election for controller. |
 | controller.leaderElection.leaseDuration | string | `"15s"` | Leader election lease duration. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -124,6 +124,9 @@ spec:
         {{- if .Values.controller.maxTrackedExecutorPerApp }}
         - --max-tracked-executor-per-app={{ .Values.controller.maxTrackedExecutorPerApp }}
         {{- end }}
+        {{- if .Values.controller.featureGates }}
+        - --feature-gates={{ range $index, $gate := .Values.controller.featureGates }}{{ if $index }},{{ end }}{{ $gate.name }}={{ $gate.enabled }}{{ end }}
+        {{- end }}
         {{- if or .Values.prometheus.metrics.enable .Values.controller.pprof.enable }}
         ports:
         {{- if .Values.controller.pprof.enable }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -828,3 +828,33 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --leader-election-retry-period=15s
 
+  - it: Should not contain `--feature-gates` arg if `controller.featureGates` is not set
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          pattern: --feature-gates=.*
+
+  - it: Should contain `--feature-gates` arg with single feature gate if `controller.featureGates` is set
+    set:
+      controller:
+        featureGates:
+          - name: PartialRestart
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --feature-gates=PartialRestart=true
+
+  - it: Should contain `--feature-gates` arg with multiple feature gates if `controller.featureGates` is set
+    set:
+      controller:
+        featureGates:
+          - name: PartialRestart
+            enabled: true
+          - name: AnotherFeature
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --feature-gates=PartialRestart=true,AnotherFeature=false
+

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -68,6 +68,13 @@ controller:
   # -- Number of replicas of controller.
   replicas: 1
 
+  # -- Feature gates to enable or disable specific features.
+  # Example:
+  # featureGates:
+  # - name: PartialRestart
+  #   enabled: true
+  featureGates: []
+
   # -- The number of old history to retain to allow rollback.
   revisionHistoryLimit: 10
 

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -31,6 +31,7 @@ import (
 
 	// Import features package to register feature gates.
 	_ "github.com/kubeflow/spark-operator/v2/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 
 	"github.com/spf13/cobra"
@@ -199,6 +200,8 @@ func NewStartCommand() *cobra.Command {
 	ctrl.RegisterFlags(flagSet)
 	zapOptions.BindFlags(flagSet)
 	command.Flags().AddGoFlagSet(flagSet)
+
+	utilfeature.DefaultMutableFeatureGate.AddFlag(command.Flags())
 
 	return command
 }

--- a/internal/controller/sparkapplication/event_filter_test.go
+++ b/internal/controller/sparkapplication/event_filter_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sparkapplication
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+func TestIsWebhookPatchedFieldsOnlyChange(t *testing.T) {
+	logger := log.Log.WithName("test")
+	filter := &EventFilter{
+		logger: logger,
+	}
+
+	baseApp := func() *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "default",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				Type:         v1beta2.SparkApplicationTypeScala,
+				SparkVersion: "3.5.0",
+				Driver: v1beta2.DriverSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(1); return &v }(),
+					},
+				},
+				Executor: v1beta2.ExecutorSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(2); return &v }(),
+					},
+					Instances: func() *int32 { v := int32(2); return &v }(),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		oldApp   *v1beta2.SparkApplication
+		newApp   *v1beta2.SparkApplication
+		expected bool
+	}{
+		{
+			name:     "no changes",
+			oldApp:   baseApp(),
+			newApp:   baseApp(),
+			expected: false, // No changes at all, so not "only webhook fields changed"
+		},
+		{
+			name:   "only executor priorityClassName changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.PriorityClassName = func() *string { v := "high-priority"; return &v }()
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only executor nodeSelector changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.NodeSelector = map[string]string{"node-type": "spark"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only executor tolerations changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Tolerations = []corev1.Toleration{
+					{Key: "spark", Operator: corev1.TolerationOpExists},
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only executor affinity changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Affinity = &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{Key: "type", Operator: corev1.NodeSelectorOpIn, Values: []string{"spark"}},
+									},
+								},
+							},
+						},
+					},
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only executor schedulerName changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.SchedulerName = func() *string { v := "volcano"; return &v }()
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "multiple executor webhook fields changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.PriorityClassName = func() *string { v := "high-priority"; return &v }()
+				app.Spec.Executor.NodeSelector = map[string]string{"node-type": "spark"}
+				app.Spec.Executor.Tolerations = []corev1.Toleration{
+					{Key: "spark", Operator: corev1.TolerationOpExists},
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "driver cores changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.Cores = func() *int32 { v := int32(2); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "executor instances changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Instances = func() *int32 { v := int32(4); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "sparkVersion changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.SparkVersion = "3.5.1"
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "executor webhook field and non-webhook field both changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.PriorityClassName = func() *string { v := "high-priority"; return &v }()
+				app.Spec.Executor.Instances = func() *int32 { v := int32(4); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "driver priorityClassName changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.PriorityClassName = func() *string { v := "high-priority"; return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filter.isWebhookPatchedFieldsOnlyChange(tt.oldApp, tt.newApp)
+			if result != tt.expected {
+				t.Errorf("isWebhookPatchedFieldsOnlyChange() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasExecutorWebhookFieldChanges(t *testing.T) {
+	baseApp := func() *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "default",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				Type:         v1beta2.SparkApplicationTypeScala,
+				SparkVersion: "3.5.0",
+				Executor: v1beta2.ExecutorSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(2); return &v }(),
+					},
+					Instances: func() *int32 { v := int32(2); return &v }(),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		oldApp   *v1beta2.SparkApplication
+		newApp   *v1beta2.SparkApplication
+		expected bool
+	}{
+		{
+			name:     "no changes",
+			oldApp:   baseApp(),
+			newApp:   baseApp(),
+			expected: false,
+		},
+		{
+			name:   "priorityClassName changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.PriorityClassName = func() *string { v := "high"; return &v }()
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "nodeSelector changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.NodeSelector = map[string]string{"key": "value"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "tolerations changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Tolerations = []corev1.Toleration{{Key: "key"}}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "instances changed - not a webhook field",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Instances = func() *int32 { v := int32(4); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasExecutorWebhookFieldChanges(tt.oldApp, tt.newApp)
+			if result != tt.expected {
+				t.Errorf("hasExecutorWebhookFieldChanges() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -26,6 +26,17 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
+const (
+	// PartialRestart enables skipping reconcile for webhook-patched executor fields.
+	// When enabled, changes to executor's PriorityClassName, NodeSelector, Tolerations,
+	// Affinity, and SchedulerName will not trigger application restart since these fields
+	// are applied by the mutating webhook when new pods are created.
+	//
+	// owner: @Kevinz857
+	// alpha: v2.5.0
+	PartialRestart featuregate.Feature = "PartialRestart"
+)
+
 // To add a new feature gate, follow these steps:
 //
 // 1. Define a new feature gate constant:
@@ -60,7 +71,9 @@ func init() {
 //
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
-var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	PartialRestart: {Default: false, PreRelease: featuregate.Alpha},
+}
 
 // SetFeatureGateDuringTest sets the specified feature gate to the specified value during a test.
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {


### PR DESCRIPTION
 ## Summary

  When only webhook-patched executor fields change (PriorityClassName, NodeSelector, Tolerations, Affinity, SchedulerName), skip triggering a reconcile since these fields are automatically applied by the mutating webhook when new pods are created.

  This optimization reduces unnecessary application restarts when users update executor scheduling configurations.

  ## Changes

  - Add `isWebhookPatchedFieldsOnlyChange()` to detect webhook-only field changes
  - Skip reconcile and emit event when only webhook fields changed
  - Add comprehensive unit tests for change detection logic

  ## Supported Fields

  The following executor fields can now be updated without triggering a reconcile:
  - `Executor.PriorityClassName`
  - `Executor.NodeSelector`
  - `Executor.Tolerations`
  - `Executor.Affinity`
  - `Executor.SchedulerName`

  ## How It Works

  These fields are patched by the mutating webhook when executor pods are created. When they change:
  1. Already running pods are not affected
  2. New executor pods will automatically use the updated values
  3. No application restart is needed

  ## Test Plan

  - [x] Unit tests for `isWebhookPatchedFieldsOnlyChange()` function
  - [x] Unit tests for `hasExecutorWebhookFieldChanges()` function
  - [x] All existing tests pass

  Partial fix for #2766