### PR TITLE
feat: hot update Service/Ingress in Running state

### DIFF
--- a/internal/controller/sparkapplication/event_filter_test.go
+++ b/internal/controller/sparkapplication/event_filter_test.go
@@ -26,6 +26,261 @@ import (
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 )
 
+func TestIsServiceIngressFieldsOnlyChange(t *testing.T) {
+	baseApp := func() *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "default",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				Type:         v1beta2.SparkApplicationTypeScala,
+				SparkVersion: "3.5.0",
+				Driver: v1beta2.DriverSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(1); return &v }(),
+					},
+				},
+				Executor: v1beta2.ExecutorSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(2); return &v }(),
+					},
+					Instances: func() *int32 { v := int32(2); return &v }(),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		oldApp   *v1beta2.SparkApplication
+		newApp   *v1beta2.SparkApplication
+		expected bool
+	}{
+		{
+			name:     "no changes",
+			oldApp:   baseApp(),
+			newApp:   baseApp(),
+			expected: false, // No changes at all
+		},
+		{
+			name:   "only SparkUIOptions changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.SparkUIOptions = &v1beta2.SparkUIConfiguration{
+					ServiceAnnotations: map[string]string{"key": "value"},
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only Driver.ServiceAnnotations changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.ServiceAnnotations = map[string]string{"key": "value"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only Driver.ServiceLabels changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.ServiceLabels = map[string]string{"key": "value"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "only DriverIngressOptions changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				port := int32(8080)
+				app.Spec.DriverIngressOptions = []v1beta2.DriverIngressConfiguration{
+					{
+						ServicePort:        &port,
+						ServiceAnnotations: map[string]string{"key": "value"},
+					},
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "multiple service/ingress fields changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.SparkUIOptions = &v1beta2.SparkUIConfiguration{
+					ServiceAnnotations: map[string]string{"key": "value"},
+				}
+				app.Spec.Driver.ServiceAnnotations = map[string]string{"key": "value"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "driver cores changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.Cores = func() *int32 { v := int32(2); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "executor instances changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Instances = func() *int32 { v := int32(4); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "sparkVersion changed - requires full restart",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.SparkVersion = "3.5.1"
+				return app
+			}(),
+			expected: false,
+		},
+		{
+			name:   "service field and non-service field both changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.ServiceAnnotations = map[string]string{"key": "value"}
+				app.Spec.Executor.Instances = func() *int32 { v := int32(4); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isServiceIngressFieldsOnlyChange(tt.oldApp, tt.newApp)
+			if result != tt.expected {
+				t.Errorf("isServiceIngressFieldsOnlyChange() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasServiceIngressFieldChanges(t *testing.T) {
+	baseApp := func() *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "default",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				Type:         v1beta2.SparkApplicationTypeScala,
+				SparkVersion: "3.5.0",
+				Driver: v1beta2.DriverSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(1); return &v }(),
+					},
+				},
+				Executor: v1beta2.ExecutorSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores: func() *int32 { v := int32(2); return &v }(),
+					},
+					Instances: func() *int32 { v := int32(2); return &v }(),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		oldApp   *v1beta2.SparkApplication
+		newApp   *v1beta2.SparkApplication
+		expected bool
+	}{
+		{
+			name:     "no changes",
+			oldApp:   baseApp(),
+			newApp:   baseApp(),
+			expected: false,
+		},
+		{
+			name:   "SparkUIOptions changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.SparkUIOptions = &v1beta2.SparkUIConfiguration{
+					ServicePort: func() *int32 { v := int32(4040); return &v }(),
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "DriverIngressOptions changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				port := int32(8080)
+				app.Spec.DriverIngressOptions = []v1beta2.DriverIngressConfiguration{
+					{ServicePort: &port},
+				}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "Driver.ServiceAnnotations changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.ServiceAnnotations = map[string]string{"key": "value"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "Driver.ServiceLabels changed",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Driver.ServiceLabels = map[string]string{"key": "value"}
+				return app
+			}(),
+			expected: true,
+		},
+		{
+			name:   "executor instances changed - not a service/ingress field",
+			oldApp: baseApp(),
+			newApp: func() *v1beta2.SparkApplication {
+				app := baseApp()
+				app.Spec.Executor.Instances = func() *int32 { v := int32(4); return &v }()
+				return app
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasServiceIngressFieldChanges(tt.oldApp, tt.newApp)
+			if result != tt.expected {
+				t.Errorf("hasServiceIngressFieldChanges() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIsWebhookPatchedFieldsOnlyChange(t *testing.T) {
 	logger := log.Log.WithName("test")
 	filter := &EventFilter{

--- a/pkg/common/event.go
+++ b/pkg/common/event.go
@@ -62,3 +62,22 @@ const (
 
 	EventSparkExecutorUnknown = "SparkExecutorUnknown"
 )
+
+// Service/Ingress events
+const (
+	EventSparkUIServiceUpdated = "SparkUIServiceUpdated"
+
+	EventSparkUIServiceUpdateFailed = "SparkUIServiceUpdateFailed"
+
+	EventSparkUIIngressUpdated = "SparkUIIngressUpdated"
+
+	EventSparkUIIngressUpdateFailed = "SparkUIIngressUpdateFailed"
+
+	EventSparkDriverIngressServiceUpdated = "SparkDriverIngressServiceUpdated"
+
+	EventSparkDriverIngressServiceUpdateFailed = "SparkDriverIngressServiceUpdateFailed"
+
+	EventSparkDriverIngressUpdated = "SparkDriverIngressUpdated"
+
+	EventSparkDriverIngressUpdateFailed = "SparkDriverIngressUpdateFailed"
+)


### PR DESCRIPTION
  ## Summary

  Allow updating Service and Ingress resources without restarting the application when only service/ingress related fields change.

  When the application is in Running state and only service/ingress fields change, the controller will update the Service/Ingress resources directly without transitioning to Invalidating state.

  ## Changes

  - Add `isServiceIngressFieldsOnlyChange()` to detect service/ingress-only changes
  - Skip setting Invalidating state for service/ingress-only changes in Running state
  - Add `updateServiceIngressResources()` to update resources in Running state
  - Add comprehensive unit tests for change detection logic

  ## Supported Fields

  The following fields can now be updated without restarting the application:
  - `SparkUIOptions` (ServiceAnnotations, ServiceLabels, IngressAnnotations, IngressTLS, etc.)
  - `DriverIngressOptions` (ServiceAnnotations, ServiceLabels, IngressAnnotations, IngressTLS, etc.)
  - `Driver.ServiceAnnotations`
  - `Driver.ServiceLabels`

  ## How It Works

  1. When spec changes are detected in event filter, check if only service/ingress fields changed
  2. If application is in Running state and only these fields changed, don't set state to Invalidating
  3. Trigger reconcile which will update Service/Ingress resources using existing create-or-update logic
  4. Application continues running without interruption

  ## Test Plan

  - [x] Unit tests for `isServiceIngressFieldsOnlyChange()` function
  - [x] Unit tests for `hasServiceIngressFieldChanges()` function
  - [x] All existing tests pass
  - [ ] Manual test: Update ServiceAnnotations while app is running

  Partial fix for #2766
