### PR TITLE
feat: introduce feature gate mechanism

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -28,6 +28,9 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	// Import features package to register feature gates.
+	_ "github.com/kubeflow/spark-operator/v2/pkg/features"
 	"k8s.io/client-go/rest"
 
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,9 @@ require (
 	k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver v0.33.3
 	k8s.io/apimachinery v0.33.3
+	k8s.io/apiserver v0.33.3
 	k8s.io/client-go v0.33.3
+	k8s.io/component-base v0.33.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.4
@@ -127,6 +129,8 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
+	go.opentelemetry.io/otel v1.33.0 // indirect
+	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -146,10 +150,8 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiserver v0.33.3 // indirect
 	k8s.io/cli-runtime v0.33.3 // indirect
 	k8s.io/code-generator v0.32.7 // indirect
-	k8s.io/component-base v0.33.3 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/kubectl v0.33.3 // indirect

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+// To add a new feature gate, follow these steps:
+//
+// 1. Define a new feature gate constant:
+//
+//	const (
+//	    // MyFeature enables some new functionality.
+//	    //
+//	    // owner: @your-github-username
+//	    // alpha: v2.x.0
+//	    MyFeature featuregate.Feature = "MyFeature"
+//	)
+//
+// 2. Add the feature gate to defaultFeatureGates map:
+//
+//	var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+//	    MyFeature: {Default: false, PreRelease: featuregate.Alpha},
+//	}
+//
+// 3. Use the feature gate in your code:
+//
+//	if features.Enabled(features.MyFeature) {
+//	    // feature-specific code
+//	}
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}
+
+// defaultFeatureGates consists of all known spark-operator-specific feature keys.
+// To add a new feature, define a key for it above and add it here. The features will be
+// available throughout spark-operator binaries.
+//
+// Entries are separated from each other with blank lines to avoid sweeping gofmt changes
+// when adding or removing one entry.
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
+
+// SetFeatureGateDuringTest sets the specified feature gate to the specified value during a test.
+func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {
+	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, f, value)
+}
+
+// Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
+func Enabled(f featuregate.Feature) bool {
+	return utilfeature.DefaultFeatureGate.Enabled(f)
+}
+
+// SetEnable helper function that can be used to set the enabled value of a feature gate,
+// it should only be used in integration test pending the merge of
+// https://github.com/kubernetes/kubernetes/pull/118346
+func SetEnable(f featuregate.Feature, v bool) error {
+	return utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=%v", f, v))
+}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+func TestDefaultFeatureGatesRegistered(t *testing.T) {
+	// Verify that defaultFeatureGates is registered with the global feature gate.
+	// This test ensures the init() function ran successfully.
+	assert.NotNil(t, utilfeature.DefaultFeatureGate)
+}
+
+func TestEnabledWithRegisteredFeature(t *testing.T) {
+	// Register a test feature for this test
+	testFeature := featuregate.Feature("TestFeatureForEnabled")
+	err := utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+		testFeature: {Default: false, PreRelease: featuregate.Alpha},
+	})
+	assert.NoError(t, err)
+
+	// Test that Enabled returns false for a disabled feature
+	assert.False(t, Enabled(testFeature))
+}
+
+func TestSetEnableWithRegisteredFeature(t *testing.T) {
+	// Register a test feature for this test
+	testFeature := featuregate.Feature("TestFeatureForSetEnable")
+	err := utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+		testFeature: {Default: false, PreRelease: featuregate.Alpha},
+	})
+	assert.NoError(t, err)
+
+	// Test SetEnable
+	err = SetEnable(testFeature, true)
+	assert.NoError(t, err)
+	assert.True(t, Enabled(testFeature))
+
+	// Disable the feature
+	err = SetEnable(testFeature, false)
+	assert.NoError(t, err)
+	assert.False(t, Enabled(testFeature))
+}
+
+func TestSetFeatureGateDuringTestHelper(t *testing.T) {
+	// Register a test feature for this test
+	testFeature := featuregate.Feature("TestFeatureForDuringTest")
+	err := utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+		testFeature: {Default: false, PreRelease: featuregate.Alpha},
+	})
+	assert.NoError(t, err)
+
+	// Verify the feature is disabled by default
+	assert.False(t, Enabled(testFeature))
+
+	// Enable the feature gate during the test
+	SetFeatureGateDuringTest(t, testFeature, true)
+
+	// Verify the feature is now enabled
+	assert.True(t, Enabled(testFeature))
+
+	// After the test, the feature gate will be automatically restored to its original value
+}


### PR DESCRIPTION
  ## Summary

  Introduce a feature gate mechanism for the Spark Operator to improve stability, mitigate risks, and ensure backward compatibility when introducing new features.

  This implementation follows the pattern used by [kubernetes-sigs/jobset](https://github.com/kubernetes-sigs/jobset/blob/main/pkg/features/features.go) and uses `k8s.io/component-base/featuregate` package.

  ## Changes

  - Add `pkg/features/features.go` with feature gate infrastructure
  - Provide helper functions: `Enabled()`, `SetEnable()`, `SetFeatureGateDuringTest()`
  - Import feature gate package in controller to register gates at startup
  - Add comprehensive unit tests

  ## Usage

  To add a new feature gate:

  ```go
  // 1. Define feature constant
  const (
      MyFeature featuregate.Feature = "MyFeature"
  )

  // 2. Register in defaultFeatureGates
  var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
      MyFeature: {Default: false, PreRelease: featuregate.Alpha},
  }

  // 3. Use in code
  if features.Enabled(features.MyFeature) {
      // feature-specific code
  }
```

Related Issue #2792
