### PR TITLE
Fix SparkConnect pod update issue

### DIFF
--- a/api/v1alpha1/sparkconnect_types.go
+++ b/api/v1alpha1/sparkconnect_types.go
@@ -155,7 +155,7 @@ type SparkConnectConditionType string
 
 // All possible condition types of the SparkConnect.
 const (
-	SparkConnectConditionServerPodReady   SparkConnectConditionType = "ServerPodReady"
+	SparkConnectConditionServerPodReady    SparkConnectConditionType = "ServerPodReady"
 	SparkConnectConditionServerPodUpdating SparkConnectConditionType = "ServerPodUpdating"
 )
 
@@ -164,8 +164,8 @@ type SparkConnectConditionReason string
 
 // All possible reasons of SparkConnect conditions.
 const (
-	SparkConnectConditionReasonServerPodReady      SparkConnectConditionReason = "ServerPodReady"
-	SparkConnectConditionReasonServerPodNotReady   SparkConnectConditionReason = "ServerPodNotReady"
+	SparkConnectConditionReasonServerPodReady       SparkConnectConditionReason = "ServerPodReady"
+	SparkConnectConditionReasonServerPodNotReady    SparkConnectConditionReason = "ServerPodNotReady"
 	SparkConnectConditionReasonServerPodSpecChanged SparkConnectConditionReason = "ServerPodSpecChanged"
 )
 

--- a/api/v1alpha1/sparkconnect_types.go
+++ b/api/v1alpha1/sparkconnect_types.go
@@ -155,7 +155,8 @@ type SparkConnectConditionType string
 
 // All possible condition types of the SparkConnect.
 const (
-	SparkConnectConditionServerPodReady SparkConnectConditionType = "ServerPodReady"
+	SparkConnectConditionServerPodReady   SparkConnectConditionType = "ServerPodReady"
+	SparkConnectConditionServerPodUpdating SparkConnectConditionType = "ServerPodUpdating"
 )
 
 // SparkConnectConditionReason represents the reason of SparkConnect conditions.
@@ -163,8 +164,9 @@ type SparkConnectConditionReason string
 
 // All possible reasons of SparkConnect conditions.
 const (
-	SparkConnectConditionReasonServerPodReady    SparkConnectConditionReason = "ServerPodReady"
-	SparkConnectConditionReasonServerPodNotReady SparkConnectConditionReason = "ServerPodNotReady"
+	SparkConnectConditionReasonServerPodReady      SparkConnectConditionReason = "ServerPodReady"
+	SparkConnectConditionReasonServerPodNotReady   SparkConnectConditionReason = "ServerPodNotReady"
+	SparkConnectConditionReasonServerPodSpecChanged SparkConnectConditionReason = "ServerPodSpecChanged"
 )
 
 // SparkConnectState represents the current state of the SparkConnect.

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -18,6 +18,8 @@ package sparkconnect
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -49,6 +51,8 @@ import (
 
 const (
 	ExecutorPodTemplateFileName = "executor-pod-template.yaml"
+	// ServerPodSpecHashAnnotationKey is the annotation key for storing the server pod spec hash
+	ServerPodSpecHashAnnotationKey = "sparkoperator.k8s.io/server-pod-spec-hash"
 )
 
 // Options defines the options of SparkConnect reconciler.
@@ -275,19 +279,321 @@ func (r *Reconciler) mutateConfigMap(_ context.Context, conn *v1alpha1.SparkConn
 	return nil
 }
 
-// createOrUpdateServerPod creates or updates the server pod for the SparkConnect resource.
-func (r *Reconciler) createOrUpdateServerPod(ctx context.Context, conn *v1alpha1.SparkConnect) error {
-	logger := ctrl.LoggerFrom(ctx)
-	logger.V(1).Info("Create or update server pod")
+// buildServerPodSpec builds the server pod spec from the SparkConnect resource.
+// This is a helper function used for both pod creation and hash computation.
+func (r *Reconciler) buildServerPodSpec(conn *v1alpha1.SparkConnect, pod *corev1.Pod, isNewPod bool) error {
+	// Apply template if provided (only on creation, as pod spec is immutable)
+	if isNewPod {
+		template := conn.Spec.Server.Template
+		if template != nil {
+			// Merge labels and annotations from template
+			if pod.Labels == nil {
+				pod.Labels = make(map[string]string)
+			}
+			for k, v := range template.Labels {
+				pod.Labels[k] = v
+			}
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
+			for k, v := range template.Annotations {
+				pod.Annotations[k] = v
+			}
+			// Apply pod spec from template
+			pod.Spec = template.Spec
+		}
+	}
 
-	pod := &corev1.Pod{
+	// Ensure annotations map exists
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+
+	// Add a default server container if not specified.
+	if len(pod.Spec.Containers) == 0 {
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+			Name: common.SparkDriverContainerName,
+		})
+	}
+
+	index := 0
+	for i, container := range pod.Spec.Containers {
+		if container.Name == common.SparkDriverContainerName {
+			index = i
+			break
+		}
+	}
+
+	// Build Spark connect server container.
+	container := &pod.Spec.Containers[index]
+
+	// Setup image - always use spec image if provided, otherwise use container image from template
+	if conn.Spec.Image != nil && *conn.Spec.Image != "" {
+		container.Image = *conn.Spec.Image
+	} else if container.Image == "" {
+		return fmt.Errorf("image is not specified")
+	}
+
+	// Setup entrypoint - always set from spec
+	container.Command = []string{"bash", "-c"}
+	args, err := buildStartConnectServerArgs(conn)
+	if err != nil {
+		return fmt.Errorf("failed to build spark connection args: %v", err)
+	}
+	container.Args = []string{strings.Join(args, " ")}
+
+	// Setup environment variables - ensure required env vars are present
+	envVars := make(map[string]corev1.EnvVar)
+	// Preserve existing env vars
+	for _, env := range container.Env {
+		envVars[env.Name] = env
+	}
+	// Add/update required env vars
+	envVars["POD_IP"] = corev1.EnvVar{
+		Name: "POD_IP",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "status.podIP",
+			},
+		},
+	}
+	envVars[common.EnvSparkNoDaemonize] = corev1.EnvVar{
+		Name:  common.EnvSparkNoDaemonize,
+		Value: "true",
+	}
+	// Convert back to slice
+	container.Env = make([]corev1.EnvVar, 0, len(envVars))
+	for _, env := range envVars {
+		container.Env = append(container.Env, env)
+	}
+
+	// Setup volumes and volumeMounts - ensure ConfigMap volume is present
+	volumeMounts := make(map[string]corev1.VolumeMount)
+	for _, vm := range container.VolumeMounts {
+		volumeMounts[vm.Name] = vm
+	}
+	volumeMounts[common.SparkConfigMapVolumeMountName] = corev1.VolumeMount{
+		Name:      common.SparkConfigMapVolumeMountName,
+		SubPath:   ExecutorPodTemplateFileName,
+		MountPath: fmt.Sprintf("/tmp/spark/%s", ExecutorPodTemplateFileName),
+		ReadOnly:  true,
+	}
+	container.VolumeMounts = make([]corev1.VolumeMount, 0, len(volumeMounts))
+	for _, vm := range volumeMounts {
+		container.VolumeMounts = append(container.VolumeMounts, vm)
+	}
+
+	// Setup lifecycle hook - always set PreStop hook
+	container.Lifecycle = &corev1.Lifecycle{
+		PreStop: &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{
+					"bash",
+					"-c",
+					"${SPARK_HOME}/sbin/stop-connect-server.sh",
+				},
+			},
+		},
+	}
+
+	// Ensure ConfigMap volume is present
+	volumes := make(map[string]corev1.Volume)
+	for _, vol := range pod.Spec.Volumes {
+		volumes[vol.Name] = vol
+	}
+	volumes[common.SparkConfigMapVolumeMountName] = corev1.Volume{
+		Name: common.SparkConfigMapVolumeMountName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: GetConfigMapName(conn),
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  ExecutorPodTemplateFileName,
+						Path: ExecutorPodTemplateFileName,
+					},
+				},
+			},
+		},
+	}
+	pod.Spec.Volumes = make([]corev1.Volume, 0, len(volumes))
+	for _, vol := range volumes {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
+	}
+
+	return nil
+}
+
+// computeServerPodSpecHash computes a deterministic hash of the server pod spec.
+// This hash is used to detect when the pod spec has changed and needs to be recreated.
+func (r *Reconciler) computeServerPodSpecHash(conn *v1alpha1.SparkConnect) (string, error) {
+	// Create a temporary pod to compute the hash from the desired spec
+	tempPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetServerPodName(conn),
 			Namespace: conn.Namespace,
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.client, pod, func() error {
+	// Build the pod spec without setting annotations or owner references
+	if err := r.buildServerPodSpec(conn, tempPod, true); err != nil {
+		return "", fmt.Errorf("failed to build pod spec for hash computation: %v", err)
+	}
+
+	// Create a hashable representation of the pod spec
+	// We hash the container image, command, args, env vars, volumes, and resources
+	hashData := struct {
+		Image     string
+		Command   []string
+		Args      []string
+		Env       []corev1.EnvVar
+		Resources corev1.ResourceRequirements
+		Volumes   []corev1.Volume
+		Labels    map[string]string
+	}{
+		Image:     "",
+		Command:   []string{},
+		Args:      []string{},
+		Env:       []corev1.EnvVar{},
+		Resources: corev1.ResourceRequirements{},
+		Volumes:   []corev1.Volume{},
+		Labels:    tempPod.Labels,
+	}
+
+	// Find the server container
+	index := 0
+	for i, container := range tempPod.Spec.Containers {
+		if container.Name == common.SparkDriverContainerName {
+			index = i
+			break
+		}
+	}
+	if index < len(tempPod.Spec.Containers) {
+		container := tempPod.Spec.Containers[index]
+		hashData.Image = container.Image
+		hashData.Command = container.Command
+		hashData.Args = container.Args
+		hashData.Env = container.Env
+		hashData.Resources = container.Resources
+	}
+	hashData.Volumes = tempPod.Spec.Volumes
+
+	// Serialize to YAML for hashing
+	hashBytes, err := yaml.Marshal(hashData)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal pod spec for hashing: %v", err)
+	}
+
+	// Compute SHA256 hash
+	hash := sha256.Sum256(hashBytes)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// needsPodRestart checks if the pod needs to be restarted due to spec changes.
+func (r *Reconciler) needsPodRestart(ctx context.Context, conn *v1alpha1.SparkConnect, pod *corev1.Pod) (bool, string, error) {
+	// If pod doesn't exist, no restart needed (will be created)
+	if pod == nil || pod.CreationTimestamp.IsZero() {
+		return false, "", nil
+	}
+
+	// If pod is being deleted, don't restart
+	if !pod.DeletionTimestamp.IsZero() {
+		return false, "", nil
+	}
+
+	// Compute desired spec hash
+	desiredHash, err := r.computeServerPodSpecHash(conn)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to compute desired pod spec hash: %v", err)
+	}
+
+	// Get current hash from pod annotations
+	currentHash := pod.Annotations[ServerPodSpecHashAnnotationKey]
+
+	// If hashes differ, pod needs restart
+	if currentHash != desiredHash {
+		return true, desiredHash, nil
+	}
+
+	return false, desiredHash, nil
+}
+
+// createOrUpdateServerPod creates or updates the server pod for the SparkConnect resource.
+func (r *Reconciler) createOrUpdateServerPod(ctx context.Context, conn *v1alpha1.SparkConnect) error {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.V(1).Info("Create or update server pod")
+
+	podName := GetServerPodName(conn)
+	podKey := types.NamespacedName{
+		Name:      podName,
+		Namespace: conn.Namespace,
+	}
+
+	// Check if pod exists and if it needs restart
+	existingPod := &corev1.Pod{}
+	err := r.client.Get(ctx, podKey, existingPod)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get existing server pod: %v", err)
+	}
+
+	// Check if pod needs restart due to spec changes
+	needsRestart := false
+	desiredHash := ""
+	if err == nil {
+		var err2 error
+		needsRestart, desiredHash, err2 = r.needsPodRestart(ctx, conn, existingPod)
+		if err2 != nil {
+			return fmt.Errorf("failed to check if pod needs restart: %v", err2)
+		}
+	}
+
+	// If pod needs restart, delete it first
+	if needsRestart {
+		logger.Info("Server pod spec changed, deleting pod for recreation",
+			"pod", podName,
+			"oldHash", existingPod.Annotations[ServerPodSpecHashAnnotationKey],
+			"newHash", desiredHash)
+		
+		// Set updating condition
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.SparkConnectConditionServerPodUpdating),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(v1alpha1.SparkConnectConditionReasonServerPodSpecChanged),
+			Message: fmt.Sprintf("Server pod spec changed, restarting pod with new spec hash: %s", desiredHash),
+		}
+		_ = meta.SetStatusCondition(&conn.Status.Conditions, condition)
+		conn.Status.State = v1alpha1.SparkConnectStateNotReady
+
+		// Emit event
+		r.recorder.Eventf(conn, corev1.EventTypeNormal, "SparkConnectServerPodSpecChanged",
+			"Server pod spec changed, restarting pod %s", podName)
+
+		// Delete the pod
+		if err := r.client.Delete(ctx, existingPod); err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete server pod for restart: %v", err)
+			}
+		} else {
+			logger.Info("Deleted server pod for restart", "pod", podName)
+			r.recorder.Eventf(conn, corev1.EventTypeNormal, "SparkConnectServerPodDeleting",
+				"Deleted server pod %s for restart", podName)
+		}
+
+		// Wait for deletion to complete before recreating
+		// The next reconcile will recreate the pod
+		return nil
+	}
+
+	// Create or update the pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: conn.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.client, pod, func() error {
 		// Mutate server pod.
 		if err := r.mutateServerPod(ctx, conn, pod); err != nil {
 			return fmt.Errorf("failed to build server pod: %v", err)
@@ -308,6 +614,8 @@ func (r *Reconciler) createOrUpdateServerPod(ctx context.Context, conn *v1alpha1
 			Message: "Server pod is ready",
 		}
 		_ = meta.SetStatusCondition(&conn.Status.Conditions, condition)
+		// Remove updating condition if present
+		_ = meta.RemoveStatusCondition(&conn.Status.Conditions, string(v1alpha1.SparkConnectConditionServerPodUpdating))
 		conn.Status.State = v1alpha1.SparkConnectStateReady
 	} else {
 		condition := metav1.Condition{
@@ -327,110 +635,22 @@ func (r *Reconciler) createOrUpdateServerPod(ctx context.Context, conn *v1alpha1
 }
 
 // mutateServerPod mutates the server pod for SparkConnect.
+// This function always applies mutations, not just on creation, to ensure the pod spec
+// matches the desired state from the SparkConnect resource.
 func (r *Reconciler) mutateServerPod(_ context.Context, conn *v1alpha1.SparkConnect, pod *corev1.Pod) error {
-	// Server pod not created yet.
-	if pod.CreationTimestamp.IsZero() {
-		template := conn.Spec.Server.Template
-		if template != nil {
-			pod.Labels = template.Labels
-			pod.Annotations = template.Annotations
-			pod.Spec = template.Spec
-		}
+	isNewPod := pod.CreationTimestamp.IsZero()
 
-		// Add a default server container if not specified.
-		if len(pod.Spec.Containers) == 0 {
-			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
-				Name: common.SparkDriverContainerName,
-			})
-		}
-
-		index := 0
-		for i, container := range pod.Spec.Containers {
-			if container.Name == common.SparkDriverContainerName {
-				index = i
-				break
-			}
-		}
-
-		// Build Spark connect server container.
-		container := &pod.Spec.Containers[index]
-
-		// Setup image.
-		if container.Image == "" {
-			if conn.Spec.Image == nil || *conn.Spec.Image == "" {
-				return fmt.Errorf("image is not specified")
-			}
-			container.Image = *conn.Spec.Image
-		}
-
-		// Setup entrypoint.
-		container.Command = []string{"bash", "-c"}
-		args, err := buildStartConnectServerArgs(conn)
-		if err != nil {
-			return fmt.Errorf("failed to build spark connection args: %v", err)
-		}
-		container.Args = []string{strings.Join(args, " ")}
-
-		// Setup environment variables.
-		container.Env = append(
-			container.Env,
-			corev1.EnvVar{
-				Name: "POD_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.podIP",
-					},
-				},
-			},
-			corev1.EnvVar{
-				Name:  common.EnvSparkNoDaemonize,
-				Value: "true",
-			},
-		)
-
-		// Setup volumes and volumeMounts.
-		container.VolumeMounts = append(
-			container.VolumeMounts,
-			corev1.VolumeMount{
-				Name:      common.SparkConfigMapVolumeMountName,
-				SubPath:   ExecutorPodTemplateFileName,
-				MountPath: fmt.Sprintf("/tmp/spark/%s", ExecutorPodTemplateFileName),
-				ReadOnly:  true,
-			},
-		)
-
-		container.Lifecycle = &corev1.Lifecycle{
-			PreStop: &corev1.LifecycleHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"bash",
-						"-c",
-						"${SPARK_HOME}/sbin/stop-connect-server.sh",
-					},
-				},
-			},
-		}
-
-		pod.Spec.Volumes = append(
-			pod.Spec.Volumes,
-			corev1.Volume{
-				Name: common.SparkConfigMapVolumeMountName,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: GetConfigMapName(conn),
-						},
-						Items: []corev1.KeyToPath{
-							{
-								Key:  ExecutorPodTemplateFileName,
-								Path: ExecutorPodTemplateFileName,
-							},
-						},
-					},
-				},
-			},
-		)
+	// Build the pod spec
+	if err := r.buildServerPodSpec(conn, pod, isNewPod); err != nil {
+		return err
 	}
+
+	// Compute and set spec hash annotation
+	specHash, err := r.computeServerPodSpecHash(conn)
+	if err != nil {
+		return fmt.Errorf("failed to compute pod spec hash: %v", err)
+	}
+	pod.Annotations[ServerPodSpecHashAnnotationKey] = specHash
 
 	// Set controller owner reference on server pod.
 	if err := ctrl.SetControllerReference(conn, pod, r.scheme); err != nil {

--- a/internal/controller/sparkconnect/reconciler_test.go
+++ b/internal/controller/sparkconnect/reconciler_test.go
@@ -1,0 +1,496 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sparkconnect
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+)
+
+func setupTestEnv(t *testing.T) {
+	// Set up required environment variables for tests
+	t.Setenv("KUBERNETES_SERVICE_HOST", "localhost")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "6443")
+}
+
+func newTestReconciler(t *testing.T) *Reconciler {
+	setupTestEnv(t)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	return &Reconciler{
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(10),
+	}
+}
+
+// TestMain sets up test environment for all tests
+func TestMain(m *testing.M) {
+	// Set required environment variables
+	os.Setenv("KUBERNETES_SERVICE_HOST", "localhost")
+	os.Setenv("KUBERNETES_SERVICE_PORT", "6443")
+	os.Exit(m.Run())
+}
+
+func newTestSparkConnect() *v1alpha1.SparkConnect {
+	image := "spark:4.0.0"
+	return &v1alpha1.SparkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect",
+			Namespace: "test-namespace",
+		},
+		Spec: v1alpha1.SparkConnectSpec{
+			SparkVersion: "4.0.0",
+			Image:        &image,
+			Server: v1alpha1.ServerSpec{
+				SparkPodSpec: v1alpha1.SparkPodSpec{},
+			},
+			Executor: v1alpha1.ExecutorSpec{
+				SparkPodSpec: v1alpha1.SparkPodSpec{
+					// Template must be initialized to avoid nil pointer dereference
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestComputeServerPodSpecHash_Deterministic(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	hash1, err1 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err1)
+	assert.NotEmpty(t, hash1)
+
+	hash2, err2 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err2)
+	assert.NotEmpty(t, hash2)
+
+	assert.Equal(t, hash1, hash2, "Hash should be deterministic for the same spec")
+}
+
+func TestComputeServerPodSpecHash_ImageChange(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	hash1, err1 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err1)
+
+	// Change image
+	newImage := "spark:4.1.0"
+	conn.Spec.Image = &newImage
+
+	hash2, err2 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err2)
+
+	assert.NotEqual(t, hash1, hash2, "Hash should change when image changes")
+}
+
+func TestComputeServerPodSpecHash_SparkVersionChange(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	hash1, err1 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err1)
+
+	// Change spark version - note: sparkVersion is used in labels not pod spec
+	// The hash is based on pod spec (image, args, etc.) not labels
+	// SparkVersion doesn't directly affect the container spec, so hash may not change
+	conn.Spec.SparkVersion = "4.1.0"
+
+	hash2, err2 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err2)
+
+	// Note: SparkVersion primarily affects metadata labels, not the container spec
+	// For meaningful spec changes that affect runtime, test other fields like image
+	assert.NotEmpty(t, hash1)
+	assert.NotEmpty(t, hash2)
+}
+
+func TestComputeServerPodSpecHash_SparkConfChange(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	hash1, err1 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err1)
+
+	// Add spark conf
+	conn.Spec.SparkConf = map[string]string{
+		"spark.executor.memory": "2g",
+	}
+
+	hash2, err2 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err2)
+
+	assert.NotEqual(t, hash1, hash2, "Hash should change when spark conf changes")
+}
+
+func TestComputeServerPodSpecHash_ExecutorInstancesChange(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	hash1, err1 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err1)
+
+	// Change executor instances
+	instances := int32(5)
+	conn.Spec.Executor.Instances = &instances
+
+	hash2, err2 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err2)
+
+	assert.NotEqual(t, hash1, hash2, "Hash should change when executor instances change")
+}
+
+func TestComputeServerPodSpecHash_ServerMemoryChange(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	hash1, err1 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err1)
+
+	// Change server memory
+	memory := "2g"
+	conn.Spec.Server.Memory = &memory
+
+	hash2, err2 := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err2)
+
+	assert.NotEqual(t, hash1, hash2, "Hash should change when server memory changes")
+}
+
+func TestComputeServerPodSpecHash_NoImage(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+	conn.Spec.Image = nil
+
+	_, err := reconciler.computeServerPodSpecHash(conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image is not specified")
+}
+
+func TestNeedsPodRestart_NilPod(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	needsRestart, _, err := reconciler.needsPodRestart(context.Background(), conn, nil)
+	require.NoError(t, err)
+	assert.False(t, needsRestart, "Should not need restart for nil pod")
+}
+
+func TestNeedsPodRestart_NotCreatedPod(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	needsRestart, _, err := reconciler.needsPodRestart(context.Background(), conn, pod)
+	require.NoError(t, err)
+	assert.False(t, needsRestart, "Should not need restart for pod not created yet")
+}
+
+func TestNeedsPodRestart_DeletingPod(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	now := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-spark-connect-server",
+			Namespace:         "test-namespace",
+			CreationTimestamp: now,
+			DeletionTimestamp: &now,
+		},
+	}
+
+	needsRestart, _, err := reconciler.needsPodRestart(context.Background(), conn, pod)
+	require.NoError(t, err)
+	assert.False(t, needsRestart, "Should not need restart for pod being deleted")
+}
+
+func TestNeedsPodRestart_HashMatches(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	// Compute current hash
+	currentHash, err := reconciler.computeServerPodSpecHash(conn)
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-spark-connect-server",
+			Namespace:         "test-namespace",
+			CreationTimestamp: metav1.Now(),
+			Annotations: map[string]string{
+				ServerPodSpecHashAnnotationKey: currentHash,
+			},
+		},
+	}
+
+	needsRestart, desiredHash, err := reconciler.needsPodRestart(context.Background(), conn, pod)
+	require.NoError(t, err)
+	assert.False(t, needsRestart, "Should not need restart when hash matches")
+	assert.Equal(t, currentHash, desiredHash)
+}
+
+func TestNeedsPodRestart_HashDiffers(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-spark-connect-server",
+			Namespace:         "test-namespace",
+			CreationTimestamp: metav1.Now(),
+			Annotations: map[string]string{
+				ServerPodSpecHashAnnotationKey: "old-hash-value",
+			},
+		},
+	}
+
+	needsRestart, desiredHash, err := reconciler.needsPodRestart(context.Background(), conn, pod)
+	require.NoError(t, err)
+	assert.True(t, needsRestart, "Should need restart when hash differs")
+	assert.NotEqual(t, "old-hash-value", desiredHash)
+}
+
+func TestNeedsPodRestart_NoHashAnnotation(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-spark-connect-server",
+			Namespace:         "test-namespace",
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	needsRestart, desiredHash, err := reconciler.needsPodRestart(context.Background(), conn, pod)
+	require.NoError(t, err)
+	assert.True(t, needsRestart, "Should need restart when no hash annotation exists")
+	assert.NotEmpty(t, desiredHash)
+}
+
+func TestBuildServerPodSpec_SetsImage(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	assert.Len(t, pod.Spec.Containers, 1)
+	assert.Equal(t, "spark:4.0.0", pod.Spec.Containers[0].Image)
+}
+
+func TestBuildServerPodSpec_SetsCommandAndArgs(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"bash", "-c"}, pod.Spec.Containers[0].Command)
+	require.Len(t, pod.Spec.Containers[0].Args, 1)
+	assert.Contains(t, pod.Spec.Containers[0].Args[0], "start-connect-server.sh")
+}
+
+func TestBuildServerPodSpec_SetsLifecycleHook(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	require.NotNil(t, pod.Spec.Containers[0].Lifecycle)
+	require.NotNil(t, pod.Spec.Containers[0].Lifecycle.PreStop)
+	assert.Contains(t, pod.Spec.Containers[0].Lifecycle.PreStop.Exec.Command, "${SPARK_HOME}/sbin/stop-connect-server.sh")
+}
+
+func TestBuildServerPodSpec_SetsEnvVars(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	envVars := make(map[string]corev1.EnvVar)
+	for _, env := range pod.Spec.Containers[0].Env {
+		envVars[env.Name] = env
+	}
+
+	assert.Contains(t, envVars, "POD_IP")
+	assert.Contains(t, envVars, "SPARK_NO_DAEMONIZE")
+}
+
+func TestBuildServerPodSpec_SetsConfigMapVolume(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	volumeNames := make(map[string]bool)
+	for _, vol := range pod.Spec.Volumes {
+		volumeNames[vol.Name] = true
+	}
+	// Volume name is "spark-conf" as defined in common.SparkConfigMapVolumeMountName
+	assert.Contains(t, volumeNames, "spark-conf")
+}
+
+func TestBuildServerPodSpec_MergesTemplateLabels(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+	conn.Spec.Server.Template = &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"custom-label": "custom-value",
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-value", pod.Labels["custom-label"])
+}
+
+func TestBuildServerPodSpec_MergesTemplateAnnotations(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+	conn.Spec.Server.Template = &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"custom-annotation": "custom-value",
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.buildServerPodSpec(conn, pod, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-value", pod.Annotations["custom-annotation"])
+}
+
+func TestMutateServerPod_SetsSpecHashAnnotation(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.mutateServerPod(context.Background(), conn, pod)
+	require.NoError(t, err)
+
+	assert.Contains(t, pod.Annotations, ServerPodSpecHashAnnotationKey)
+	assert.NotEmpty(t, pod.Annotations[ServerPodSpecHashAnnotationKey])
+}
+
+func TestMutateServerPod_SetsLabels(t *testing.T) {
+	reconciler := newTestReconciler(t)
+	conn := newTestSparkConnect()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-connect-server",
+			Namespace: "test-namespace",
+		},
+	}
+
+	err := reconciler.mutateServerPod(context.Background(), conn, pod)
+	require.NoError(t, err)
+
+	// Label key is "sparkoperator.k8s.io/connect-name" as defined in common.LabelSparkConnectName
+	assert.Contains(t, pod.Labels, "sparkoperator.k8s.io/connect-name")
+	assert.Equal(t, "test-spark-connect", pod.Labels["sparkoperator.k8s.io/connect-name"])
+	// spark-version label is set via GetServerSelectorLabels
+	assert.Contains(t, pod.Labels, "spark-version")
+}


### PR DESCRIPTION
## Purpose of this PR

Fixes #2784 - SparkConnect server/executor pods not updated when SparkConnect resource spec changes (e.g., image updates).

**Proposed changes:**

- Add spec hash computation to detect pod spec changes using SHA256

- Implement pod restart logic when spec hash differs from running pod

- Add `ServerPodUpdating` status condition and Kubernetes events for observability

- Add 22 unit tests for spec change detection and pod restart logic

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)

- [ ] Feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that could affect existing functionality)

- [ ] Documentation update

### Rationale

Kubernetes pods are immutable - spec changes cannot be applied to running pods. The reconciler now computes a hash of the desired pod spec and stores it in a pod annotation. On each reconcile, if the hash differs, the pod is deleted and recreated with the new spec. This follows cloud native patterns (declarative configuration, desired vs actual state comparison).

## Checklist

- [x] I have conducted a self-review of my own code.

- [ ] I have updated documentation accordingly.

- [x] I have added tests that prove my changes are effective or that my feature works.

- [x] Existing unit tests pass locally with my changes.

### Additional Notes

- Hash includes: image, command, args, env vars, volumes, and resources
- Graceful shutdown via existing PreStop lifecycle hook
- Executor pods are handled via ConfigMap updates; new executors use updated template automatically