### PR TITLE
feat: add ingress support for SparkConnect server

### DIFF
--- a/api/v1alpha1/sparkconnect_types.go
+++ b/api/v1alpha1/sparkconnect_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -91,6 +92,10 @@ type ServerSpec struct {
 	// Service exposes the Spark connect server.
 	// +optional
 	Service *corev1.Service `json:"service,omitempty"`
+
+	// Ingress exposes the Spark connect server to external traffic.
+	// +optional
+	Ingress *networkingv1.Ingress `json:"ingress,omitempty"`
 }
 
 // ExecutorSpec is specification of the executor.
@@ -188,4 +193,10 @@ type SparkConnectServerStatus struct {
 
 	// ServiceName is the name of the service that is exposing the Spark Connect server.
 	ServiceName string `json:"serviceName,omitempty"`
+
+	// IngressName is the name of the ingress that is exposing the Spark Connect server externally.
+	IngressName string `json:"ingressName,omitempty"`
+	
+	// IngressURL is the URL of the ingress that is exposing the Spark Connect server externally.
+	IngressURL string `json:"ingressUrl,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -94,6 +95,11 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
 		*out = new(v1.Service)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Ingress != nil {
+		in, out := &in.Ingress, &out.Ingress
+		*out = new(networkingv1.Ingress)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/sparkoperator.k8s.io_sparkconnects.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkconnects.yaml
@@ -139,6 +139,384 @@ spec:
                     format: int32
                     minimum: 1
                     type: integer
+                  ingress:
+                    description: Ingress exposes the Spark connect server to external
+                      traffic.
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        description: |-
+                          spec is the desired state of the Ingress.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                          defaultBackend:
+                            description: |-
+                              defaultBackend is the backend that should handle requests that don't
+                              match any rule. If Rules are not specified, DefaultBackend must be specified.
+                              If DefaultBackend is not set, the handling of requests that do not match any
+                              of the rules will be up to the Ingress controller.
+                            properties:
+                              resource:
+                                description: |-
+                                  resource is an ObjectRef to another Kubernetes resource in the namespace
+                                  of the Ingress object. If resource is specified, a service.Name and
+                                  service.Port must not be specified.
+                                  This is a mutually exclusive setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              service:
+                                description: |-
+                                  service references a service as a backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: |-
+                                      name is the referenced service. The service must exist in
+                                      the same namespace as the Ingress object.
+                                    type: string
+                                  port:
+                                    description: |-
+                                      port of the referenced service. A port name or port number
+                                      is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          name is the name of the port on the Service.
+                                          This is a mutually exclusive setting with "Number".
+                                        type: string
+                                      number:
+                                        description: |-
+                                          number is the numerical port number (e.g. 80) on the Service.
+                                          This is a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          ingressClassName:
+                            description: |-
+                              ingressClassName is the name of an IngressClass cluster resource. Ingress
+                              controller implementations use this field to know whether they should be
+                              serving this Ingress resource, by a transitive connection
+                              (controller -> IngressClass -> Ingress resource). Although the
+                              `kubernetes.io/ingress.class` annotation (simple constant name) was never
+                              formally defined, it was widely supported by Ingress controllers to create
+                              a direct binding between Ingress controller and Ingress resources. Newly
+                              created Ingress resources should prefer using the field. However, even
+                              though the annotation is officially deprecated, for backwards compatibility
+                              reasons, ingress controllers should still honor that annotation if present.
+                            type: string
+                          rules:
+                            description: |-
+                              rules is a list of host rules used to configure the Ingress. If unspecified,
+                              or no rule matches, all traffic is sent to the default backend.
+                            items:
+                              description: |-
+                                IngressRule represents the rules mapping the paths under a specified host to
+                                the related backend services. Incoming requests are first evaluated for a host
+                                match, then routed to the backend associated with the matching IngressRuleValue.
+                              properties:
+                                host:
+                                  description: "host is the fully qualified domain
+                                    name of a network host, as defined by RFC 3986.\nNote
+                                    the following deviations from the \"host\" part
+                                    of the\nURI as defined in RFC 3986:\n1. IPs are
+                                    not allowed. Currently an IngressRuleValue can
+                                    only apply to\n   the IP in the Spec of the parent
+                                    Ingress.\n2. The `:` delimiter is not respected
+                                    because ports are not allowed.\n\t  Currently
+                                    the port of an Ingress is implicitly :80 for http
+                                    and\n\t  :443 for https.\nBoth these may change
+                                    in the future.\nIncoming requests are matched
+                                    against the host before the\nIngressRuleValue.
+                                    If the host is unspecified, the Ingress routes
+                                    all\ntraffic based on the specified IngressRuleValue.\n\nhost
+                                    can be \"precise\" which is a domain name without
+                                    the terminating dot of\na network host (e.g. \"foo.bar.com\")
+                                    or \"wildcard\", which is a domain name\nprefixed
+                                    with a single wildcard label (e.g. \"*.foo.com\").\nThe
+                                    wildcard character '*' must appear by itself as
+                                    the first DNS label and\nmatches only a single
+                                    label. You cannot have a wildcard label by itself
+                                    (e.g. Host == \"*\").\nRequests will be matched
+                                    against the Host field in the following way:\n1.
+                                    If host is precise, the request matches this rule
+                                    if the http host header is equal to Host.\n2.
+                                    If host is a wildcard, then the request matches
+                                    this rule if the http host header\nis to equal
+                                    to the suffix (removing the first label) of the
+                                    wildcard rule."
+                                  type: string
+                                http:
+                                  description: |-
+                                    HTTPIngressRuleValue is a list of http selectors pointing to backends.
+                                    In the example: http://<host>/<path>?<searchpart> -> backend where
+                                    where parts of the url correspond to RFC 3986, this resource will be used
+                                    to match against everything after the last '/' and before the first '?'
+                                    or '#'.
+                                  properties:
+                                    paths:
+                                      description: paths is a collection of paths
+                                        that map requests to backends.
+                                      items:
+                                        description: |-
+                                          HTTPIngressPath associates a path with a backend. Incoming urls matching the
+                                          path are forwarded to the backend.
+                                        properties:
+                                          backend:
+                                            description: |-
+                                              backend defines the referenced service endpoint to which the traffic
+                                              will be forwarded to.
+                                            properties:
+                                              resource:
+                                                description: |-
+                                                  resource is an ObjectRef to another Kubernetes resource in the namespace
+                                                  of the Ingress object. If resource is specified, a service.Name and
+                                                  service.Port must not be specified.
+                                                  This is a mutually exclusive setting with "Service".
+                                                properties:
+                                                  apiGroup:
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              service:
+                                                description: |-
+                                                  service references a service as a backend.
+                                                  This is a mutually exclusive setting with "Resource".
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      name is the referenced service. The service must exist in
+                                                      the same namespace as the Ingress object.
+                                                    type: string
+                                                  port:
+                                                    description: |-
+                                                      port of the referenced service. A port name or port number
+                                                      is required for a IngressServiceBackend.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          name is the name of the port on the Service.
+                                                          This is a mutually exclusive setting with "Number".
+                                                        type: string
+                                                      number:
+                                                        description: |-
+                                                          number is the numerical port number (e.g. 80) on the Service.
+                                                          This is a mutually exclusive setting with "Name".
+                                                        format: int32
+                                                        type: integer
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - name
+                                                type: object
+                                            type: object
+                                          path:
+                                            description: |-
+                                              path is matched against the path of an incoming request. Currently it can
+                                              contain characters disallowed from the conventional "path" part of a URL
+                                              as defined by RFC 3986. Paths must begin with a '/' and must be present
+                                              when using PathType with value "Exact" or "Prefix".
+                                            type: string
+                                          pathType:
+                                            description: |-
+                                              pathType determines the interpretation of the path matching. PathType can
+                                              be one of the following values:
+                                              * Exact: Matches the URL path exactly.
+                                              * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                                done on a path element by element basis. A path element refers is the
+                                                list of labels in the path split by the '/' separator. A request is a
+                                                match for path p if every p is an element-wise prefix of p of the
+                                                request path. Note that if the last element of the path is a substring
+                                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                                the IngressClass. Implementations can treat this as a separate PathType
+                                                or treat it identically to Prefix or Exact path types.
+                                              Implementations are required to support all path types.
+                                            type: string
+                                        required:
+                                        - backend
+                                        - pathType
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - paths
+                                  type: object
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          tls:
+                            description: |-
+                              tls represents the TLS configuration. Currently the Ingress only supports a
+                              single TLS port, 443. If multiple members of this list specify different hosts,
+                              they will be multiplexed on the same port according to the hostname specified
+                              through the SNI TLS extension, if the ingress controller fulfilling the
+                              ingress supports SNI.
+                            items:
+                              description: IngressTLS describes the transport layer
+                                security associated with an ingress.
+                              properties:
+                                hosts:
+                                  description: |-
+                                    hosts is a list of hosts included in the TLS certificate. The values in
+                                    this list must match the name/s used in the tlsSecret. Defaults to the
+                                    wildcard host setting for the loadbalancer controller fulfilling this
+                                    Ingress, if left unspecified.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                secretName:
+                                  description: |-
+                                    secretName is the name of the secret used to terminate TLS traffic on
+                                    port 443. Field is left optional to allow TLS routing based on SNI
+                                    hostname alone. If the SNI host in a listener conflicts with the "Host"
+                                    header field used by an IngressRule, the SNI host is used for termination
+                                    and value of the "Host" header is used for routing.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      status:
+                        description: |-
+                          status is the current state of the Ingress.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                          loadBalancer:
+                            description: loadBalancer contains the current status
+                              of the load-balancer.
+                            properties:
+                              ingress:
+                                description: ingress is a list containing ingress
+                                  points for the load-balancer.
+                                items:
+                                  description: IngressLoadBalancerIngress represents
+                                    the status of a load-balancer ingress point.
+                                  properties:
+                                    hostname:
+                                      description: hostname is set for load-balancer
+                                        ingress points that are DNS based.
+                                      type: string
+                                    ip:
+                                      description: ip is set for load-balancer ingress
+                                        points that are IP based.
+                                      type: string
+                                    ports:
+                                      description: ports provides information about
+                                        the ports exposed by this LoadBalancer.
+                                      items:
+                                        description: IngressPortStatus represents
+                                          the error condition of a service port
+                                        properties:
+                                          error:
+                                            description: |-
+                                              error is to record the problem with the service port
+                                              The format of the error shall comply with the following rules:
+                                              - built-in error values shall be specified in this file and those shall use
+                                                CamelCase names
+                                              - cloud provider specific error values must have names that comply with the
+                                                format foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                          port:
+                                            description: port is the port number of
+                                              the ingress port.
+                                            format: int32
+                                            type: integer
+                                          protocol:
+                                            description: |-
+                                              protocol is the protocol of the ingress port.
+                                              The supported values are: "TCP", "UDP", "SCTP"
+                                            type: string
+                                        required:
+                                        - error
+                                        - port
+                                        - protocol
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                    type: object
                   memory:
                     description: Memory is the amount of memory to request for the
                       pod.
@@ -777,6 +1155,14 @@ spec:
                 description: Server represents the current state of the SparkConnect
                   server.
                 properties:
+                  ingressName:
+                    description: IngressName is the name of the ingress that is exposing
+                      the Spark Connect server externally.
+                    type: string
+                  ingressUrl:
+                    description: IngressURL is the URL of the ingress that is exposing
+                      the Spark Connect server externally.
+                    type: string
                   podIp:
                     description: PodIP is the IP address of the pod that is running
                       the Spark Connect server.

--- a/examples/sparkconnect/spark-connect-ingress.yaml
+++ b/examples/sparkconnect/spark-connect-ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: sparkoperator.k8s.io/v1alpha1
+kind: SparkConnect
+metadata:
+  name: spark-connect-ingress-example
+  namespace: default
+spec:
+  sparkVersion: "4.0.1"
+  image: docker.io/library/spark:4.0.1
+  server:
+    cores: 1
+    memory: "512m"
+    service:
+      type: ClusterIP
+    ingress:
+      metadata:
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: /
+          kubernetes.io/ingress.class: nginx
+      spec:
+        rules:
+        - host: spark-connect.example.com
+          http:
+            paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                service:
+                  name: spark-connect-ingress-example-server
+                  port:
+                    number: 15002
+  executor:
+    cores: 1
+    memory: "512m"
+    instances: 1

--- a/internal/controller/sparkconnect/ingress_test.go
+++ b/internal/controller/sparkconnect/ingress_test.go
@@ -1,0 +1,106 @@
+package sparkconnect
+
+import (
+	"testing"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetServerIngressName(t *testing.T) {
+	tests := []struct {
+		name     string
+		conn     *v1alpha1.SparkConnect
+		expected string
+	}{
+		{
+			name: "no ingress specified",
+			conn: &v1alpha1.SparkConnect{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-connect",
+				},
+				Spec: v1alpha1.SparkConnectSpec{
+					Server: v1alpha1.ServerSpec{},
+				},
+			},
+			expected: "test-connect-server",
+		},
+		{
+			name: "ingress with custom name",
+			conn: &v1alpha1.SparkConnect{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-connect",
+				},
+				Spec: v1alpha1.SparkConnectSpec{
+					Server: v1alpha1.ServerSpec{
+						Ingress: &networkingv1.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "custom-ingress-name",
+							},
+						},
+					},
+				},
+			},
+			expected: "custom-ingress-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetServerIngressName(tt.conn)
+			if result != tt.expected {
+				t.Errorf("GetServerIngressName() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetServerServiceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		conn     *v1alpha1.SparkConnect
+		expected string
+	}{
+		{
+			name: "no service specified",
+			conn: &v1alpha1.SparkConnect{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-connect",
+				},
+				Spec: v1alpha1.SparkConnectSpec{
+					Server: v1alpha1.ServerSpec{},
+				},
+			},
+			expected: "test-connect-server",
+		},
+		{
+			name: "service with custom name",
+			conn: &v1alpha1.SparkConnect{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-connect",
+				},
+				Spec: v1alpha1.SparkConnectSpec{
+					Server: v1alpha1.ServerSpec{
+						Service: &corev1.Service{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "custom-service-name",
+							},
+						},
+					},
+				},
+			},
+			expected: "custom-service-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetServerServiceName(tt.conn)
+			if result != tt.expected {
+				t.Errorf("GetServerServiceName() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -111,6 +112,14 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 				}),
 			),
 		).
+		Owns(
+			&networkingv1.Ingress{},
+			builder.WithPredicates(
+				util.NewLabelPredicate(map[string]string{
+					common.LabelCreatedBySparkOperator: "true",
+				}),
+			),
+		).
 		Watches(
 			&corev1.Pod{},
 			&handler.TypedFuncs[client.Object, reconcile.Request]{
@@ -174,6 +183,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 // +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;create;update;delete
 // +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=,resources=services,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects/status,verbs=get;update;patch
 
@@ -212,6 +222,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile
 	}
 
 	if err := r.createOrUpdateServerService(ctx, conn); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.createOrUpdateServerIngress(ctx, conn); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -537,6 +551,135 @@ func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.Spark
 		return fmt.Errorf("failed to set controller reference: %v", err)
 	}
 
+	return nil
+}
+
+// createOrUpdateServerIngress creates or updates the server ingress for the SparkConnect resource.
+func (r *Reconciler) createOrUpdateServerIngress(ctx context.Context, conn *v1alpha1.SparkConnect) error {
+	logger := ctrl.LoggerFrom(ctx)
+
+	// Check if ingress is specified in the spec.
+	ingress := conn.Spec.Server.Ingress
+	if ingress == nil {
+		// No ingress specified, delete any existing ingress.
+		return r.deleteServerIngress(ctx, conn)
+	}
+
+	// Create or update the ingress.
+	ingress.Name = GetServerIngressName(conn)
+	// Namespace provided by user will be ignored.
+	ingress.Namespace = conn.Namespace
+
+	opResult, err := controllerutil.CreateOrUpdate(ctx, r.client, ingress, func() error {
+		if err := r.mutateServerIngress(ctx, conn, ingress); err != nil {
+			return fmt.Errorf("failed to mutate server ingress: %v", err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to create or update server ingress: %v", err)
+	}
+
+	switch opResult {
+	case controllerutil.OperationResultCreated:
+		logger.Info("Server ingress created")
+	case controllerutil.OperationResultUpdated:
+		logger.Info("Server ingress updated")
+	}
+
+	// Update SparkConnect status with ingress information.
+	conn.Status.Server.IngressName = ingress.Name
+
+	// Try to determine the ingress URL
+	if len(ingress.Spec.Rules) > 0 && ingress.Spec.Rules[0].Host != "" {
+		scheme := "http"
+		if len(ingress.Spec.TLS) > 0 {
+			scheme = "https"
+		}
+		conn.Status.Server.IngressURL = fmt.Sprintf("%s://%s", scheme, ingress.Spec.Rules[0].Host)
+	}
+
+	return nil
+}
+
+// mutateServerIngress mutates the server ingress for the SparkConnect resource.
+func (r *Reconciler) mutateServerIngress(_ context.Context, conn *v1alpha1.SparkConnect, ingress *networkingv1.Ingress) error {
+	if ingress.CreationTimestamp.IsZero() {
+		// Ensure the ingress spec has at least one rule if not provided by user
+		if len(ingress.Spec.Rules) == 0 {
+			pathTypePrefix := networkingv1.PathTypePrefix
+			ingress.Spec.Rules = []networkingv1.IngressRule{
+				{
+					Host: fmt.Sprintf("%s.%s.example.com", conn.Name, conn.Namespace),
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathTypePrefix,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: GetServerServiceName(conn),
+											Port: networkingv1.ServiceBackendPort{
+												Number: 15002, // Spark Connect server port
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+	}
+
+	// Ensure the ingress targets the correct service
+	for i := range ingress.Spec.Rules {
+		if ingress.Spec.Rules[i].HTTP != nil {
+			for j := range ingress.Spec.Rules[i].HTTP.Paths {
+				if ingress.Spec.Rules[i].HTTP.Paths[j].Backend.Service != nil {
+					ingress.Spec.Rules[i].HTTP.Paths[j].Backend.Service.Name = GetServerServiceName(conn)
+				}
+			}
+		}
+	}
+
+	// Set labels on server ingress.
+	if ingress.Labels == nil {
+		ingress.Labels = make(map[string]string)
+	}
+	for key, val := range GetCommonLabels(conn) {
+		ingress.Labels[key] = val
+	}
+
+	// Set controller owner reference on server ingress.
+	if err := ctrl.SetControllerReference(conn, ingress, r.scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference: %v", err)
+	}
+
+	return nil
+}
+
+// deleteServerIngress deletes the server ingress for the SparkConnect resource.
+func (r *Reconciler) deleteServerIngress(ctx context.Context, conn *v1alpha1.SparkConnect) error {
+	ingressName := GetServerIngressName(conn)
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: conn.Namespace,
+		},
+	}
+
+	if err := r.client.Delete(ctx, ingress); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete server ingress: %v", err)
+	}
+
+	ctrl.LoggerFrom(ctx).Info("Deleted server ingress")
 	return nil
 }
 

--- a/internal/controller/sparkconnect/util.go
+++ b/internal/controller/sparkconnect/util.go
@@ -79,3 +79,15 @@ func GetServerServiceName(conn *v1alpha1.SparkConnect) string {
 func GetServerServiceHost(conn *v1alpha1.SparkConnect) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local", GetServerServiceName(conn), conn.Namespace)
 }
+
+// GetServerIngressName returns the name of the server ingress for SparkConnect.
+func GetServerIngressName(conn *v1alpha1.SparkConnect) string {
+	// Use the ingress specified in the server spec if provided.
+	ingress := conn.Spec.Server.Ingress
+	if ingress != nil && ingress.Name != "" {
+		return ingress.Name
+	}
+
+	// Otherwise, use the default ingress name.
+	return fmt.Sprintf("%s-server", conn.Name)
+}


### PR DESCRIPTION
### Summary

this pr adds ingress support for exposing spark connect servers externally.

Fixed issue: #2715 

### What this PR does:

- Adds a new `.spec.server.ingress` field to the SparkConnect CRD, following the same embedding pattern as `.spec.server.service`
- Implements controller logic to automatically create/update/delete Ingress resources
- Adds Ingress status tracking (`ingressName` and `ingressURL`) to `SparkConnectServerStatus`
- Updates RBAC permissions to manage Ingress resources
- Includes an example manifest demonstrating Ingress configuration

### Key Features:

- embedded ingress spec - users can provide a full `networking.k8s.io/v1/Ingress` specification
- automatic management - controller handles Ingress lifecycle (create/update/delete)
- default configuration-If no rules are specified, defaults to port 15002 (Spark Connect server)
- status tracking- ingress name and url are reported in the status
- bakward compatible - no changes required for existing sparkconnect manifests

Example Usage:

```bash
apiVersion: sparkoperator.k8s.io/v1alpha1
kind: SparkConnect
spec:
  server:
    ingress:
      spec:
        ingressClassName: nginx
        rules:
        - host: spark-connect.example.com
          http:
            paths:
            - path: /
              pathType: Prefix
              backend:
                service:
                  name: spark-connect-server
                  port:
                    number: 15002
```

Implementation details:

- follows the same pattern as existing service embedding 
- uses controllerutil.CreateOrUpdate() for idempotent ingress managment 
- sets proper owner references for garbage collections
- updates crd schema to include iingress field