### PR TITLE
fix: explicitly delete executor pods during invalidation

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -1123,6 +1123,11 @@ func (r *Reconciler) updateSparkApplicationStatus(ctx context.Context, app *v1be
 
 // Delete the resources associated with the spark application.
 func (r *Reconciler) deleteSparkResources(ctx context.Context, app *v1beta2.SparkApplication) error {
+	// Delete executor pods first to ensure deterministic cleanup
+	if err := r.deleteExecutorPods(ctx, app); err != nil {
+		return err
+	}
+
 	if err := r.deleteDriverPod(ctx, app); err != nil {
 		return err
 	}
@@ -1160,6 +1165,36 @@ func (r *Reconciler) deleteDriverPod(ctx context.Context, app *v1beta2.SparkAppl
 		return err
 	}
 
+	return nil
+}
+
+func (r *Reconciler) deleteExecutorPods(ctx context.Context, app *v1beta2.SparkApplication) error {
+	logger := log.FromContext(ctx)
+	
+	// Get all executor pods for this application
+	podList, err := r.getExecutorPods(ctx, app)
+	if err != nil {
+		return err
+	}
+	
+	if len(podList.Items) == 0 {
+		logger.V(1).Info("No executor pods found to delete")
+		return nil
+	}
+	
+	logger.Info("Deleting executor pods", "count", len(podList.Items))
+	
+	// Delete all executor pods
+	for _, pod := range podList.Items {
+		logger.V(1).Info("Deleting executor pod", "pod", pod.Name)
+		if err := r.client.Delete(ctx, &pod, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Error(err, "Failed to delete executor pod", "pod", pod.Name)
+				return err
+			}
+		}
+	}
+	
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

fixes #2803 

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Added `deleteExecutorPods()` function that:
   - Retrieves all executor pods using `getExecutorPods()`
   - Iterates and deletes each executor pod explicitly
   - Logs deletion operations for visibility

- Updated cleanup order in `deleteSparkResources()`:
   - Delete executor pods first (deterministic cleanup)
   - Then delete driver pod
   - Finally delete WebUI service and ingress


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
