### PR TITLE
fix: respect sparkConf pod template settings when spec.template is nil

### DIFF
--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -1082,17 +1082,13 @@ func applicationOption(app *v1beta2.SparkApplication) ([]string, error) {
 
 // driverPodTemplateOption returns the driver pod template arguments.
 func driverPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) {
-	template := app.Spec.Driver.Template
-	// Spark expects the template to have a driver container
-	// if user specifies a driver pod template, it is responsible
-	// for user to ensure the template has a driver container
-	if template == nil {
-		template = &corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: common.SparkDriverContainerName}},
-			},
-		}
+	// Only generate pod template file if user explicitly provides a template
+	// This allows sparkConf and spark-defaults.conf to work properly
+	if app.Spec.Driver.Template == nil {
+		return []string{}, nil
 	}
+
+	template := app.Spec.Driver.Template
 
 	ownerReference := util.GetOwnerReference(app)
 	if !slices.ContainsFunc(template.OwnerReferences, func(r metav1.OwnerReference) bool {
@@ -1117,18 +1113,13 @@ func driverPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) {
 
 // executorPodTemplateOption returns the executor pod template arguments.
 func executorPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) {
-	template := app.Spec.Executor.Template
-
-	// Spark expects the template to have a driver container
-	// if user specifies a driver pod template, it is responsible
-	// for user to ensure the template has a driver container
-	if template == nil {
-		template = &corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: common.Spark3DefaultExecutorContainerName}},
-			},
-		}
+	// Only generate pod template file if user explicitly provides a template
+	// This allows sparkConf and spark-defaults.conf to work properly
+	if app.Spec.Executor.Template == nil {
+		return []string{}, nil
 	}
+
+	template := app.Spec.Executor.Template
 
 	// we put non-controller owner reference so that
 	// other controller (e.g. Kueue) can recognize the executor pods

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -26,7 +26,6 @@ import (
 	"slices"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

fixes #2793 

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

Modified `driverPodTemplateOption()` and `executorPodTemplateOption()` in `submission.go` to always generate pod template files, even when they are not explicitly provided by users.

### Changes
- Removed the early return when `app.Spec.Driver.Template == nil` and `app.Spec.Executor.Template == nil`
- Create minimal default pod templates with a base container structure when user templates are not provided
- Ensure `sparkConf` pod template settings are properly applied via pod template files, even without explicit templates
- Always write pod template files to:
  - `/tmp/spark/{submissionID}/driver-pod-template.yaml`
  - `/tmp/spark/{submissionID}/executor-pod-template.yaml`

### Result
This ensures that `sparkConf` settings relying on pod templates (e.g., resource limits, node selectors, etc.) are respected regardless of whether users define pod templates in their `SparkApplication` spec.


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
