### PR TITLE
feat: Implement resource quota validation for SparkConnect

### DIFF
--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -47,6 +47,7 @@ import (
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	sparkoperator "github.com/kubeflow/spark-operator/v2"
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/internal/controller/mutatingwebhookconfiguration"
 	"github.com/kubeflow/spark-operator/v2/internal/controller/validatingwebhookconfiguration"
@@ -306,6 +307,15 @@ func start() {
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Spark pod")
+		os.Exit(1)
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.SparkConnect{}).
+		WithValidator(webhook.NewSparkConnectValidator(mgr.GetClient(), enableResourceQuotaEnforcement)).
+		WithLogConstructor(webhook.LogConstructor).
+		Complete(); err != nil {
+		logger.Error(err, "Failed to create validating webhook for SparkConnect")
 		os.Exit(1)
 	}
 

--- a/internal/webhook/sparkconnect_resourcequota.go
+++ b/internal/webhook/sparkconnect_resourcequota.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"math"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+)
+
+const (
+	// Default memory overhead factor for SparkConnect
+	defaultSparkConnectMemoryOverheadFactor = 0.4
+)
+
+// getSparkConnectResourceList returns the resource requests of the given SparkConnect.
+func getSparkConnectResourceList(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	serverCoresRequests, err := getSparkConnectServerCoresRequests(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	serverCoresLimits, err := getSparkConnectServerCoresLimits(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	serverMemoryRequests, err := getSparkConnectServerMemoryRequests(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	executorCoresRequests, err := getSparkConnectExecutorCoresRequests(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	executorCoresLimits, err := getSparkConnectExecutorCoresLimits(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	executorMemoryRequests, err := getSparkConnectExecutorMemoryRequests(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceList := util.SumResourceList([]corev1.ResourceList{
+		serverCoresRequests,
+		serverCoresLimits,
+		serverMemoryRequests,
+		executorCoresRequests,
+		executorCoresLimits,
+		executorMemoryRequests,
+	})
+
+	return resourceList, nil
+}
+
+func getSparkConnectServerCoresRequests(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	var milliCores int64
+	if conn.Spec.Server.Cores != nil {
+		milliCores = int64(*conn.Spec.Server.Cores) * 1000
+	} else {
+		milliCores = common.DefaultCPUMilliCores
+	}
+
+	// Check if template has explicit resource requests
+	if conn.Spec.Server.Template != nil && len(conn.Spec.Server.Template.Spec.Containers) > 0 {
+		for _, container := range conn.Spec.Server.Template.Spec.Containers {
+			if container.Name == common.SparkDriverContainerName {
+				if cpuRequest, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+					milliCores = cpuRequest.MilliValue()
+				}
+				break
+			}
+		}
+	}
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceCPU:         *resource.NewMilliQuantity(milliCores, resource.DecimalSI),
+		corev1.ResourceRequestsCPU: *resource.NewMilliQuantity(milliCores, resource.DecimalSI),
+	}
+	return resourceList, nil
+}
+
+func getSparkConnectServerCoresLimits(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	var milliCores int64
+	if conn.Spec.Server.Cores != nil {
+		milliCores = int64(*conn.Spec.Server.Cores) * 1000
+	} else {
+		milliCores = common.DefaultCPUMilliCores
+	}
+
+	// Check if template has explicit resource limits
+	if conn.Spec.Server.Template != nil && len(conn.Spec.Server.Template.Spec.Containers) > 0 {
+		for _, container := range conn.Spec.Server.Template.Spec.Containers {
+			if container.Name == common.SparkDriverContainerName {
+				if cpuLimit, ok := container.Resources.Limits[corev1.ResourceCPU]; ok {
+					milliCores = cpuLimit.MilliValue()
+				}
+				break
+			}
+		}
+	}
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceLimitsCPU: *resource.NewMilliQuantity(milliCores, resource.DecimalSI),
+	}
+	return resourceList, nil
+}
+
+func getSparkConnectServerMemoryRequests(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	var memoryBytes, memoryOverheadBytes int64
+
+	if conn.Spec.Server.Memory != nil {
+		parsed, err := parseJavaMemoryString(*conn.Spec.Server.Memory)
+		if err != nil {
+			return nil, err
+		}
+		memoryBytes = parsed
+	}
+
+	// Check if template has explicit memory requests
+	if conn.Spec.Server.Template != nil && len(conn.Spec.Server.Template.Spec.Containers) > 0 {
+		for _, container := range conn.Spec.Server.Template.Spec.Containers {
+			if container.Name == common.SparkDriverContainerName {
+				if memRequest, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+					resourceList := corev1.ResourceList{
+						corev1.ResourceMemory:         memRequest,
+						corev1.ResourceRequestsMemory: memRequest,
+					}
+					return resourceList, nil
+				}
+				break
+			}
+		}
+	}
+
+	// Calculate memory overhead
+	memoryOverheadBytes = int64(math.Max(float64(memoryBytes)*defaultSparkConnectMemoryOverheadFactor, common.MinMemoryOverhead))
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceMemory:         *resource.NewQuantity(memoryBytes+memoryOverheadBytes, resource.BinarySI),
+		corev1.ResourceRequestsMemory: *resource.NewQuantity(memoryBytes+memoryOverheadBytes, resource.BinarySI),
+	}
+	return resourceList, nil
+}
+
+func getSparkConnectExecutorCoresRequests(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	var replicas int64 = 1
+	if conn.Spec.Executor.Instances != nil {
+		replicas = int64(*conn.Spec.Executor.Instances)
+	}
+
+	var milliCores int64
+	if conn.Spec.Executor.Cores != nil {
+		milliCores = int64(*conn.Spec.Executor.Cores) * 1000
+	} else {
+		milliCores = common.DefaultCPUMilliCores
+	}
+
+	// Check if template has explicit resource requests
+	if conn.Spec.Executor.Template != nil && len(conn.Spec.Executor.Template.Spec.Containers) > 0 {
+		for _, container := range conn.Spec.Executor.Template.Spec.Containers {
+			if cpuRequest, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+				milliCores = cpuRequest.MilliValue()
+			}
+			break
+		}
+	}
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceCPU:         *resource.NewMilliQuantity(milliCores*replicas, resource.DecimalSI),
+		corev1.ResourceRequestsCPU: *resource.NewMilliQuantity(milliCores*replicas, resource.DecimalSI),
+	}
+	return resourceList, nil
+}
+
+func getSparkConnectExecutorCoresLimits(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	var replicas int64 = 1
+	if conn.Spec.Executor.Instances != nil {
+		replicas = int64(*conn.Spec.Executor.Instances)
+	}
+
+	var milliCores int64
+	if conn.Spec.Executor.Cores != nil {
+		milliCores = int64(*conn.Spec.Executor.Cores) * 1000
+	} else {
+		milliCores = common.DefaultCPUMilliCores
+	}
+
+	// Check if template has explicit resource limits
+	if conn.Spec.Executor.Template != nil && len(conn.Spec.Executor.Template.Spec.Containers) > 0 {
+		for _, container := range conn.Spec.Executor.Template.Spec.Containers {
+			if cpuLimit, ok := container.Resources.Limits[corev1.ResourceCPU]; ok {
+				milliCores = cpuLimit.MilliValue()
+			}
+			break
+		}
+	}
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceLimitsCPU: *resource.NewMilliQuantity(milliCores*replicas, resource.DecimalSI),
+	}
+	return resourceList, nil
+}
+
+func getSparkConnectExecutorMemoryRequests(conn *v1alpha1.SparkConnect) (corev1.ResourceList, error) {
+	var replicas int64 = 1
+	if conn.Spec.Executor.Instances != nil {
+		replicas = int64(*conn.Spec.Executor.Instances)
+	}
+
+	var memoryBytes, memoryOverheadBytes int64
+
+	if conn.Spec.Executor.Memory != nil {
+		parsed, err := parseJavaMemoryString(*conn.Spec.Executor.Memory)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse executor memory: %v", err)
+		}
+		memoryBytes = parsed
+	}
+
+	// Check if template has explicit memory requests
+	if conn.Spec.Executor.Template != nil && len(conn.Spec.Executor.Template.Spec.Containers) > 0 {
+		for _, container := range conn.Spec.Executor.Template.Spec.Containers {
+			if memRequest, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+				totalMemory := memRequest.DeepCopy()
+				totalMemory.Set(totalMemory.Value() * replicas)
+				resourceList := corev1.ResourceList{
+					corev1.ResourceMemory:         totalMemory,
+					corev1.ResourceRequestsMemory: totalMemory,
+				}
+				return resourceList, nil
+			}
+			break
+		}
+	}
+
+	// Calculate memory overhead
+	memoryOverheadBytes = int64(math.Max(float64(memoryBytes)*defaultSparkConnectMemoryOverheadFactor, common.MinMemoryOverhead))
+
+	resourceList := corev1.ResourceList{
+		corev1.ResourceMemory:         *resource.NewQuantity((memoryBytes+memoryOverheadBytes)*replicas, resource.BinarySI),
+		corev1.ResourceRequestsMemory: *resource.NewQuantity((memoryBytes+memoryOverheadBytes)*replicas, resource.BinarySI),
+	}
+	return resourceList, nil
+}

--- a/internal/webhook/sparkconnect_validator.go
+++ b/internal/webhook/sparkconnect_validator.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+)
+
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:admissionReviewVersions=v1,failurePolicy=fail,groups=sparkoperator.k8s.io,matchPolicy=Exact,mutating=false,name=validate-sparkconnect.sparkoperator.k8s.io,path=/validate-sparkoperator-k8s-io-v1alpha1-sparkconnect,reinvocationPolicy=Never,resources=sparkconnects,sideEffects=None,verbs=create;update,versions=v1alpha1,webhookVersions=v1
+
+type SparkConnectValidator struct {
+	client client.Client
+
+	enableResourceQuotaEnforcement bool
+}
+
+// NewSparkConnectValidator creates a new SparkConnectValidator instance.
+func NewSparkConnectValidator(client client.Client, enableResourceQuotaEnforcement bool) *SparkConnectValidator {
+	return &SparkConnectValidator{
+		client:                         client,
+		enableResourceQuotaEnforcement: enableResourceQuotaEnforcement,
+	}
+}
+
+var _ admission.CustomValidator = &SparkConnectValidator{}
+
+// ValidateCreate implements admission.CustomValidator.
+func (v *SparkConnectValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	conn, ok := obj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+	logger := log.FromContext(ctx)
+	logger.Info("Validating SparkConnect create", "name", conn.Name, "namespace", conn.Namespace)
+
+	// Validate metadata.name early to prevent downstream Service creation failures
+	if err := v.validateName(conn.Name); err != nil {
+		return nil, err
+	}
+
+	if err := v.validateSpec(ctx, conn); err != nil {
+		return nil, err
+	}
+
+	if v.enableResourceQuotaEnforcement {
+		if err := v.validateResourceUsage(ctx, conn); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements admission.CustomValidator.
+func (v *SparkConnectValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	oldConn, ok := oldObj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+
+	newConn, ok := newObj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Validating SparkConnect update", "name", newConn.Name, "namespace", newConn.Namespace)
+
+	// Name is immutable in Kubernetes, but validate anyway for safety
+	if err := v.validateName(newConn.Name); err != nil {
+		return nil, err
+	}
+
+	// Skip validating when spec does not change significantly
+	if oldConn.Spec.SparkVersion == newConn.Spec.SparkVersion &&
+		oldConn.Spec.Server.Cores == newConn.Spec.Server.Cores &&
+		oldConn.Spec.Server.Memory == newConn.Spec.Server.Memory &&
+		oldConn.Spec.Executor.Cores == newConn.Spec.Executor.Cores &&
+		oldConn.Spec.Executor.Memory == newConn.Spec.Executor.Memory &&
+		oldConn.Spec.Executor.Instances == newConn.Spec.Executor.Instances {
+		return nil, nil
+	}
+
+	if err := v.validateSpec(ctx, newConn); err != nil {
+		return nil, err
+	}
+
+	// Validate SparkConnect resource usage when resource quota enforcement is enabled.
+	if v.enableResourceQuotaEnforcement {
+		if err := v.validateResourceUsage(ctx, newConn); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements admission.CustomValidator.
+func (v *SparkConnectValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	conn, ok := obj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+	logger := log.FromContext(ctx)
+	logger.Info("Validating SparkConnect delete", "name", conn.Name, "namespace", conn.Namespace)
+	return nil, nil
+}
+
+func (v *SparkConnectValidator) validateSpec(ctx context.Context, conn *v1alpha1.SparkConnect) error {
+	if conn.Spec.Image == nil || *conn.Spec.Image == "" {
+		return fmt.Errorf("image is required")
+	}
+
+	if conn.Spec.SparkVersion == "" {
+		return fmt.Errorf("sparkVersion is required")
+	}
+
+	return nil
+}
+
+// validateName ensures the SparkConnect metadata.name is a valid DNS-1035 label
+// This prevents failures later when creating related resources like Services which
+// require DNS-1035 compliant names.
+func (v *SparkConnectValidator) validateName(name string) error {
+	if errs := validation.IsDNS1035Label(name); len(errs) > 0 {
+		return fmt.Errorf("invalid SparkConnect name %q: %s", name, strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+func (v *SparkConnectValidator) validateResourceUsage(ctx context.Context, conn *v1alpha1.SparkConnect) error {
+	requests, err := getSparkConnectResourceList(conn)
+	if err != nil {
+		return fmt.Errorf("failed to calculate resource requests: %v", err)
+	}
+
+	resourceQuotaList := &corev1.ResourceQuotaList{}
+	if err := v.client.List(ctx, resourceQuotaList, client.InNamespace(conn.Namespace)); err != nil {
+		return fmt.Errorf("failed to list resource quotas: %v", err)
+	}
+
+	for _, resourceQuota := range resourceQuotaList.Items {
+		// Scope selectors not currently supported, ignore any ResourceQuota that does not match everything.
+		// TODO: Add support for scope selectors.
+		if resourceQuota.Spec.ScopeSelector != nil || len(resourceQuota.Spec.Scopes) > 0 {
+			continue
+		}
+
+		if !validateResourceQuota(requests, resourceQuota) {
+			return fmt.Errorf("failed to validate resource quota \"%s/%s\": requested resources would exceed quota limits. Server needs %v, Executors need %v (total across %d instances). Available quota: %v",
+				resourceQuota.Namespace,
+				resourceQuota.Name,
+				getServerResources(conn),
+				getExecutorResources(conn),
+				getExecutorInstances(conn),
+				resourceQuota.Status.Hard)
+		}
+	}
+
+	return nil
+}
+
+// Helper functions to get resource details for better error messages
+func getServerResources(conn *v1alpha1.SparkConnect) string {
+	cores := "default"
+	if conn.Spec.Server.Cores != nil {
+		cores = fmt.Sprintf("%d cores", *conn.Spec.Server.Cores)
+	}
+	memory := "default"
+	if conn.Spec.Server.Memory != nil {
+		memory = *conn.Spec.Server.Memory
+	}
+	return fmt.Sprintf("%s, %s memory", cores, memory)
+}
+
+func getExecutorResources(conn *v1alpha1.SparkConnect) string {
+	cores := "default"
+	if conn.Spec.Executor.Cores != nil {
+		cores = fmt.Sprintf("%d cores", *conn.Spec.Executor.Cores)
+	}
+	memory := "default"
+	if conn.Spec.Executor.Memory != nil {
+		memory = *conn.Spec.Executor.Memory
+	}
+	return fmt.Sprintf("%s, %s memory per executor", cores, memory)
+}
+
+func getExecutorInstances(conn *v1alpha1.SparkConnect) int32 {
+	if conn.Spec.Executor.Instances != nil {
+		return *conn.Spec.Executor.Instances
+	}
+	return 1
+}

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -40,6 +40,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 
 	utilruntime.Must(clientgoscheme.AddToScheme(WebhookScheme))
+	utilruntime.Must(v1alpha1.AddToScheme(WebhookScheme))
 	utilruntime.Must(v1beta2.AddToScheme(WebhookScheme))
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This PR adds resource quota validation support for SparkConnect to prevent silent pod failures and provide clear error messages to users when quota limits are exceeded.

fixes #2790 

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Add validating admission webhook for SparkConnect to validate resource quotas at creation time
- Implement resource quota calculation logic that accounts for server pod + all executor pods
- Enhance SparkConnect controller to update status with quota validation errors
- Register SparkConnect webhook in operator startup to enable quota enforcement
- Add v1alpha1 scheme support to WebhookScheme for proper SparkConnect object handling

![WhatsApp Image 2026-01-20 at 9 19 19 PM](https://github.com/user-attachments/assets/7c7fba7d-09fa-42ff-9cf1-effaf38e7faf)

- SparkConnect creation is now rejected with clear error messages when it would exceed namespace resource quotas
- Status field shows detailed quota validation errors instead of remaining empty
- Behavior is now consistent with SparkApplication's resource quota enforcement



## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
