### PR TITLE
Fix duplicate webhook patch and add missing ScheduledSparkApplication Patches

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 - path: patches/webhook_in_sparkapplications.yaml
-- path: patches/webhook_in_sparkapplications.yaml
+- path: patches/webhook_in_scheduledsparkapplications.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.

--- a/config/crd/patches/cainjection_in_scheduledsparkapplications.yaml
+++ b/config/crd/patches/cainjection_in_scheduledsparkapplications.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+  name: scheduledsparkapplications.sparkoperator.k8s.io

--- a/config/crd/patches/webhook_in_scheduledsparkapplications.yaml
+++ b/config/crd/patches/webhook_in_scheduledsparkapplications.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: scheduledsparkapplications.sparkoperator.k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1


### PR DESCRIPTION
## Purpose of this PR

The file `config/crd/kustomization.yaml` contained a duplicate entry for `patches/webhook_in_sparkapplications.yaml`. This was a copy-paste error introduced during the controller-runtime refactor (commit 0dc641b). The comment states "patches here are for enabling the conversion webhook for each CRD", but the second entry was a duplicate rather than a patch for ScheduledSparkApplication.

**Proposed changes:**

- Fix duplicate webhook patch entry in `config/crd/kustomization.yaml`
- Add `webhook_in_scheduledsparkapplications.yaml` for conversion webhook support
- Add `cainjection_in_scheduledsparkapplications.yaml` for cert-manager CA injection

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Both CRDs (SparkApplication and ScheduledSparkApplication) should have corresponding webhook and CA injection patch files to match the intended kustomize configuration pattern. The CA injection section already referenced `cainjection_in_scheduledsparkapplications.yaml` but the file didn't exist.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

This is a configuration-only fix. No tests are needed as these are kustomize patch files that follow the existing pattern. The changes ensure proper kustomize scaffolding for both CRDs when webhooks or cert-manager integration are enabled.