### PR TITLE
Set appProtocol on SparkConnect server service ports

### DIFF
--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -490,28 +491,32 @@ func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.Spark
 	if svc.CreationTimestamp.IsZero() {
 		svc.Spec.Ports = []corev1.ServicePort{
 			{
-				Name:       "driver-rpc",
-				Port:       7078,
-				TargetPort: intstr.FromInt(7078),
-				Protocol:   corev1.ProtocolTCP,
+				Name:        "driver-rpc",
+				Port:        7078,
+				TargetPort:  intstr.FromInt(7078),
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: ptr.To("tcp"),
 			},
 			{
-				Name:       "blockmanager",
-				Port:       7079,
-				TargetPort: intstr.FromInt(7079),
-				Protocol:   corev1.ProtocolTCP,
+				Name:        "blockmanager",
+				Port:        7079,
+				TargetPort:  intstr.FromInt(7079),
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: ptr.To("tcp"),
 			},
 			{
-				Name:       "web-ui",
-				Port:       4040,
-				TargetPort: intstr.FromInt(4040),
-				Protocol:   corev1.ProtocolTCP,
+				Name:        "web-ui",
+				Port:        4040,
+				TargetPort:  intstr.FromInt(4040),
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: ptr.To("http"),
 			},
 			{
-				Name:       "spark-connect-server",
-				Port:       15002,
-				TargetPort: intstr.FromInt(15002),
-				Protocol:   corev1.ProtocolTCP,
+				Name:        "spark-connect-server",
+				Port:        15002,
+				TargetPort:  intstr.FromInt(15002),
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: ptr.To("grpc"),
 			},
 		}
 

--- a/internal/controller/sparkconnect/reconciler_test.go
+++ b/internal/controller/sparkconnect/reconciler_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sparkconnect
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+)
+
+var _ = Describe("mutateServerService", func() {
+	var (
+		reconciler *Reconciler
+		conn       *v1alpha1.SparkConnect
+	)
+
+	BeforeEach(func() {
+		reconciler = &Reconciler{
+			scheme: scheme.Scheme,
+		}
+		conn = &v1alpha1.SparkConnect{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-spark-connect",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+			},
+			Spec: v1alpha1.SparkConnectSpec{
+				SparkVersion: "4.0.0",
+				Server: v1alpha1.ServerSpec{
+					SparkPodSpec: v1alpha1.SparkPodSpec{},
+				},
+				Executor: v1alpha1.ExecutorSpec{
+					SparkPodSpec: v1alpha1.SparkPodSpec{},
+				},
+			},
+		}
+	})
+
+	Context("when creating a new service", func() {
+		It("should set appProtocol on all ports", func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conn.Namespace,
+				},
+			}
+			err := reconciler.mutateServerService(context.TODO(), conn, svc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(svc.Spec.Ports).To(HaveLen(4))
+
+			expectedAppProtocols := map[string]string{
+				"driver-rpc":           "tcp",
+				"blockmanager":         "tcp",
+				"web-ui":               "http",
+				"spark-connect-server": "grpc",
+			}
+
+			for _, port := range svc.Spec.Ports {
+				expected, ok := expectedAppProtocols[port.Name]
+				Expect(ok).To(BeTrue(), "unexpected port name: %s", port.Name)
+				Expect(port.AppProtocol).NotTo(BeNil(), "appProtocol should be set for port %s", port.Name)
+				Expect(port.AppProtocol).To(Equal(ptr.To(expected)), "appProtocol mismatch for port %s", port.Name)
+			}
+		})
+
+		It("should set correct port numbers", func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conn.Namespace,
+				},
+			}
+			err := reconciler.mutateServerService(context.TODO(), conn, svc)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedPorts := map[string]int32{
+				"driver-rpc":           7078,
+				"blockmanager":         7079,
+				"web-ui":               4040,
+				"spark-connect-server": 15002,
+			}
+
+			for _, port := range svc.Spec.Ports {
+				Expect(port.Port).To(Equal(expectedPorts[port.Name]))
+				Expect(port.Protocol).To(Equal(corev1.ProtocolTCP))
+			}
+		})
+
+		It("should set selector labels", func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conn.Namespace,
+				},
+			}
+			err := reconciler.mutateServerService(context.TODO(), conn, svc)
+			Expect(err).NotTo(HaveOccurred())
+
+			labels := GetServerSelectorLabels(conn)
+			for key, val := range labels {
+				Expect(svc.Spec.Selector).To(HaveKeyWithValue(key, val))
+			}
+		})
+	})
+
+	Context("when service already exists", func() {
+		It("should not overwrite existing ports", func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conn.Namespace,
+					// Non-zero CreationTimestamp indicates existing service.
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "spark-connect-server",
+							Port: 15002,
+						},
+					},
+				},
+			}
+			err := reconciler.mutateServerService(context.TODO(), conn, svc)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Ports should remain unchanged for existing services.
+			Expect(svc.Spec.Ports).To(HaveLen(1))
+			Expect(svc.Spec.Ports[0].Name).To(Equal("spark-connect-server"))
+		})
+	})
+})


### PR DESCRIPTION
## Purpose of this PR

Service mesh controllers like Istio rely on `appProtocol` to correctly identify and route application-level traffic. Without it, gRPC traffic to the `spark-connect-server` port is treated as opaque TCP, preventing proper HTTP/2 load balancing.

**Proposed changes:**

- Set `appProtocol: grpc` on the `spark-connect-server` port (15002)
- Set `appProtocol: http` on the `web-ui` port (4040)
- Set `appProtocol: tcp` on the `driver-rpc` (7078) and `blockmanager` (7079) ports
- Add unit tests for `mutateServerService` to verify appProtocol is correctly set on all ports

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on ServicePort allows service meshes and ingress controllers to understand the application-level protocol used by each port. For Spark Connect, the server communicates over gRPC (port 15002), and without `appProtocol` set, service meshes like Istio cannot perform proper L7 load balancing or protocol-aware routing.

References:
- [Kubernetes - Application Protocol](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)
- [Kubernetes - Service Protocols](https://kubernetes.io/docs/reference/networking/service-protocols/)
- [Istio - Protocol Selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

This is a non-breaking change. The `appProtocol` field is informational and does not affect clusters without a service mesh or ingress controller that consumes it.