### PR TITLE
fix: handle nil Executor.Instances in GetExecutorRequestResource

### DIFF
--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -465,8 +465,10 @@ func GetExecutorRequestResource(app *v1beta2.SparkApplication) corev1.ResourceLi
 		}
 	}
 
+	instances := GetInitialExecutorNumber(app)
+
 	resourceList := []corev1.ResourceList{{}}
-	for i := int32(0); i < *app.Spec.Executor.Instances; i++ {
+	for i := int32(0); i < instances; i++ {
 		resourceList = append(resourceList, minResource)
 	}
 	return SumResourceList(resourceList)


### PR DESCRIPTION
Fixes #2832


## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->
When dynamic allocation is enabled `Executor.Instances` is intentionally left as `nil` by the defaulting logic in 
`api/v1beta2/defaults.go`. However, `GetExecutorRequestResource` dereferences this field without a nil check, causing a panic when used with batch schedulers (like Volcano/kube-scheduler)

**Proposed changes:**
- Add nil check for `Executor.Instances` in `GetExecutorRequestResource` function
- Return empty `ResourceList{}` when Instances is `nil` 
- Add unit tests covering both nil and non-nil Instances scenarios


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.


### Additional Notes
Verified in Kind cluster with Volcano scheduler - SparkApplication with `dynamicAllocation.enabled: true` and `batchScheduler: volcano` now processes successfully without panic
<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
