### PR TITLE
fix: allow same ServicePort with different hosts in driverIngressOptions

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -377,8 +377,8 @@ func (r *Reconciler) reconcileSubmittedSparkApplication(ctx context.Context, req
 				}
 			}
 
-			for _, driverIngressConfiguration := range app.Spec.DriverIngressOptions {
-				service, err := r.createDriverIngressServiceFromConfiguration(ctx, app, &driverIngressConfiguration)
+			for i, driverIngressConfiguration := range app.Spec.DriverIngressOptions {
+				service, err := r.createDriverIngressServiceFromConfiguration(ctx, app, &driverIngressConfiguration, i)
 				if err != nil {
 					return fmt.Errorf("failed to create driver ingress service for SparkApplication: %v", err)
 				}
@@ -389,7 +389,7 @@ func (r *Reconciler) reconcileSubmittedSparkApplication(ctx context.Context, req
 					if err != nil {
 						return fmt.Errorf("failed to get driver ingress url: %v", err)
 					}
-					_, err = r.createDriverIngress(ctx, app, &driverIngressConfiguration, *service, ingressURL, r.options.IngressClassName)
+					_, err = r.createDriverIngress(ctx, app, &driverIngressConfiguration, *service, ingressURL, r.options.IngressClassName, i)
 					if err != nil {
 						return fmt.Errorf("failed to create driver ingress: %v", err)
 					}

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -139,16 +139,11 @@ func (v *SparkApplicationValidator) validateSpec(ctx context.Context, app *v1bet
 		return fmt.Errorf("node selector cannot be defined at both SparkApplication and Driver/Executor")
 	}
 
-	servicePorts := make(map[int32]bool)
 	ingressURLFormats := make(map[string]bool)
 	for _, item := range app.Spec.DriverIngressOptions {
 		if item.ServicePort == nil {
-			return fmt.Errorf("DriverIngressOptions has nill ServicePort")
+			return fmt.Errorf("DriverIngressOptions has nil ServicePort")
 		}
-		if servicePorts[*item.ServicePort] {
-			return fmt.Errorf("DriverIngressOptions has duplicate ServicePort: %d", *item.ServicePort)
-		}
-		servicePorts[*item.ServicePort] = true
 
 		if item.IngressURLFormat == "" {
 			return fmt.Errorf("DriverIngressOptions has empty IngressURLFormat")


### PR DESCRIPTION


Fixes #2662


## Purpose of this PR
Users want to expose the same Spark driver port (e.g 4040 for Spark UI) through multiple ingresses with different hostnames. The current validation incorrectly rejects this configuration as "duplicate ServicePort".

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Modified validation to check `(ServicePort, IngressURLFormat)` pairs instead of just `ServicePort`, allowing same port with different hosts
- Updated service and ingress naming to include index for multiple entries with the same port to ensure unique resource names
- Added tests for the new behavior

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
With this fix, the following configuration is now valid:

```yaml
driverIngressOptions:
  - servicePort: 4040
    ingressURLFormat: "private.domain.com"
  - servicePort: 4040
    ingressURLFormat: "public.domain.com"
```