### PR TITLE
fix: detect spec changes in ScheduledSparkApplication controller

### DIFF
--- a/api/v1beta2/scheduledsparkapplication_types.go
+++ b/api/v1beta2/scheduledsparkapplication_types.go
@@ -75,6 +75,10 @@ type ScheduledSparkApplicationStatus struct {
 	ScheduleState ScheduleState `json:"scheduleState,omitempty"`
 	// Reason tells why the ScheduledSparkApplication is in the particular ScheduleState.
 	Reason string `json:"reason,omitempty"`
+	// ObservedGeneration is the most recent generation observed for this ScheduledSparkApplication.
+	// It is used to detect spec changes and trigger re-evaluation of the schedule.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -12442,6 +12442,12 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this ScheduledSparkApplication.
+                  It is used to detect spec changes and trigger re-evaluation of the schedule.
+                format: int64
+                type: integer
               pastFailedRunNames:
                 description: PastFailedRunNames keeps the names of SparkApplications
                   for past failed runs.

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -12442,6 +12442,12 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this ScheduledSparkApplication.
+                  It is used to detect spec changes and trigger re-evaluation of the schedule.
+                format: int64
+                type: integer
               pastFailedRunNames:
                 description: PastFailedRunNames keeps the names of SparkApplications
                   for past failed runs.

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2254,6 +2254,19 @@ string
 <p>Reason tells why the ScheduledSparkApplication is in the particular ScheduleState.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>observedGeneration</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the most recent generation observed for this ScheduledSparkApplication.
+It is used to detect spec changes and trigger re-evaluation of the schedule.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.SecretInfo">SecretInfo


### PR DESCRIPTION


Fixes #2555


## Purpose of this PR
The `ScheduledSparkApplication` controller ignores spec changes (e.g. `schedule`, `timeZone`) once in `ScheduleStateScheduled`, and provides no recovery from `ScheduleStateFailedValidation`.
<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**
- Add `status.observedGeneration` to detect spec changes via the standard Kubernetes generation pattern
- Recalculate `status.nextRun` when a spec change is detected in `ScheduleStateScheduled`
- Reset `FailedValidation` to `New` on spec change, allowing re-validation
- Add two regression tests covering both scenarios


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
