### PR TITLE
feat(sparkapplication): resolve Spark config values from secrets reference

### DIFF
--- a/charts/spark-operator-chart/templates/controller/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/controller/_helpers.tpl
@@ -136,6 +136,12 @@ Create the role policy rules for the controller in every Spark job namespace
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,7 @@ rules:
   - update
 - resources:
   - nodes
+  - secrets
   verbs:
   - get
 - resources:

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -954,7 +954,7 @@ func (r *Reconciler) submitSparkApplication(ctx context.Context, app *v1beta2.Sp
 		}
 	}()
 
-	if err := r.submitter.Submit(ctx, app); err != nil {
+	if err := r.submitter.Submit(ctx, app, r.client); err != nil {
 		r.recordSparkApplicationEvent(app)
 		submitErr = fmt.Errorf("failed to submit spark application: %v", err)
 		return

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -110,6 +110,7 @@ func NewReconciler(
 
 // +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;create;update;patch;delete
+// +kubebuilder:rbac:groups=,resources=secrets,verbs=get
 // +kubebuilder:rbac:groups=,resources=services,verbs=get;create;delete
 // +kubebuilder:rbac:groups=,resources=nodes,verbs=get
 // +kubebuilder:rbac:groups=,resources=events,verbs=create;update;patch

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -23,12 +23,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
@@ -39,7 +41,7 @@ import (
 
 // SparkApplicationSubmitter is the interface for submitting a SparkApplication.
 type SparkApplicationSubmitter interface {
-	Submit(ctx context.Context, app *v1beta2.SparkApplication) error
+	Submit(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) error
 }
 
 // SparkSubmitter submits a SparkApplication by calling spark-submit.
@@ -50,11 +52,16 @@ type SparkSubmitter struct {
 // This interface is highly experimental and may go under significant changes or removed in the future.
 var _ SparkApplicationSubmitter = &SparkSubmitter{}
 
+// Secrets ref regexp supports the following secret ref formats:
+//  1. Specific namespace: {secrets:namespace/secret-name:secret-key}
+//  2. Default namespace: {secrets:secret-name:secret-key}
+var confSecretRefRegexp = regexp.MustCompile(`\${secrets:(?P<namespace>[a-z_-]+?/)?(?P<secret>[a-z_-]+):(?P<key>[a-z_-]+)}`)
+
 // Submit implements SparkApplicationSubmitter interface.
-func (*SparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication) error {
+func (*SparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) error {
 	logger := log.FromContext(ctx)
 
-	args, err := buildSparkSubmitArgs(app)
+	args, err := buildSparkSubmitArgs(ctx, app, client)
 	if err != nil {
 		return fmt.Errorf("failed to build spark-submit arguments: %v", err)
 	}
@@ -94,7 +101,7 @@ func runSparkSubmit(args []string) error {
 }
 
 // buildSparkSubmitArgs builds the arguments for spark-submit.
-func buildSparkSubmitArgs(app *v1beta2.SparkApplication) ([]string, error) {
+func buildSparkSubmitArgs(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) ([]string, error) {
 	optionFuncs := []sparkSubmitOptionFunc{
 		masterOption,
 		deployModeOption,
@@ -107,7 +114,6 @@ func buildSparkSubmitArgs(app *v1beta2.SparkApplication) ([]string, error) {
 		pythonVersionOption,
 		memoryOverheadFactorOption,
 		submissionWaitAppCompletionOption,
-		sparkConfOption,
 		hadoopConfOption,
 		driverPodTemplateOption,
 		driverPodNameOption,
@@ -135,6 +141,12 @@ func buildSparkSubmitArgs(app *v1beta2.SparkApplication) ([]string, error) {
 		}
 		args = append(args, option...)
 	}
+
+	option, err := sparkConfOption(ctx, app, client)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, option...)
 
 	return args, nil
 }
@@ -285,7 +297,7 @@ func submissionWaitAppCompletionOption(_ *v1beta2.SparkApplication) ([]string, e
 	return args, nil
 }
 
-func sparkConfOption(app *v1beta2.SparkApplication) ([]string, error) {
+func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) ([]string, error) {
 	if app.Spec.SparkConf == nil {
 		return nil, nil
 	}
@@ -294,10 +306,55 @@ func sparkConfOption(app *v1beta2.SparkApplication) ([]string, error) {
 	for key, value := range app.Spec.SparkConf {
 		// Configuration property for the driver pod name has already been set.
 		if key != common.SparkKubernetesDriverPodName {
+			match := confSecretRefRegexp.FindStringSubmatch(value)
+			if match != nil {
+				resolvedValue, err := resolveConfValueFromSecretRef(match, ctx, client)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve config value for: %s from secret ref: %s due to: %w", key, value, err)
+				}
+				value = resolvedValue
+			}
 			args = append(args, "--conf", fmt.Sprintf("%s=%s", key, value))
 		}
 	}
 	return args, nil
+}
+
+func resolveConfValueFromSecretRef(matches []string, ctx context.Context, k8sClient client.Client) (string, error) {
+	result := parseConfSecretRefValue(matches)
+	namespace := result["namespace"]
+	secretName := result["secret"]
+	secretKey := result["key"]
+	secret := &corev1.Secret{}
+	objectKey := client.ObjectKey{Namespace: namespace, Name: secretName}
+	err := k8sClient.Get(ctx, objectKey, secret)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve secret %s/%s: %w", namespace, secretName, err)
+	}
+	if value, ok := secret.Data[secretKey]; ok {
+		return string(value), nil
+	}
+	return "", fmt.Errorf("key %s not found in secret %s/%s", secretKey, namespace, secretName)
+}
+
+func parseConfSecretRefValue(matches []string) map[string]string {
+	// Create a map to store the named results
+	result := make(map[string]string)
+	for i, name := range confSecretRefRegexp.SubexpNames() {
+		// Index 0 is the full match, so we skip it and ensure the name is not empty
+		if i != 0 && name != "" && matches != nil {
+			match := matches[i]
+			if name == "namespace" {
+				if match == "" {
+					match = "default"
+				} else {
+					match = strings.TrimSuffix(match, "/")
+				}
+			}
+			result[name] = match
+		}
+	}
+	return result
 }
 
 func hadoopConfOption(app *v1beta2.SparkApplication) ([]string, error) {

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -319,10 +319,11 @@ func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client 
 				}
 				args = append(args, "--conf", fmt.Sprintf("%s=%s", key, resolvedValue))
 				sanitizedArgs = append(sanitizedArgs, "--conf", fmt.Sprintf("%s=*****", key))
+			} else {
+				confValue := fmt.Sprintf("%s=%s", key, value)
+				args = append(args, "--conf", confValue)
+				sanitizedArgs = append(sanitizedArgs, "--conf", confValue)
 			}
-			confValue := fmt.Sprintf("%s=%s", key, value)
-			args = append(args, "--conf", confValue)
-			sanitizedArgs = append(sanitizedArgs, "--conf", confValue)
 		}
 	}
 	return args, sanitizedArgs, nil

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -62,13 +62,13 @@ var confSecretRefRegexpGroupNames = confSecretRefRegexp.SubexpNames()
 func (*SparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) error {
 	logger := log.FromContext(ctx)
 
-	args, err := buildSparkSubmitArgs(ctx, app, client)
+	args, sanitizedArgs, err := buildSparkSubmitArgs(ctx, app, client)
 	if err != nil {
 		return fmt.Errorf("failed to build spark-submit arguments: %v", err)
 	}
 
 	// Try submitting the application by running spark-submit.
-	logger.Info("Running spark-submit", "arguments", args)
+	logger.Info("Running spark-submit", "arguments", sanitizedArgs)
 	if err := runSparkSubmit(args); err != nil {
 		return fmt.Errorf("failed to run spark-submit: %v", err)
 	}
@@ -102,7 +102,7 @@ func runSparkSubmit(args []string) error {
 }
 
 // buildSparkSubmitArgs builds the arguments for spark-submit.
-func buildSparkSubmitArgs(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) ([]string, error) {
+func buildSparkSubmitArgs(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) ([]string, []string, error) {
 	optionFuncs := []sparkSubmitOptionFunc{
 		masterOption,
 		deployModeOption,
@@ -135,21 +135,24 @@ func buildSparkSubmitArgs(ctx context.Context, app *v1beta2.SparkApplication, cl
 	}
 
 	var args []string
+	var sanitizedArgs []string
 	for _, optionFunc := range optionFuncs {
 		option, err := optionFunc(app)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		args = append(args, option...)
+		sanitizedArgs = append(sanitizedArgs, option...)
 	}
 
-	option, err := sparkConfOption(ctx, app, client)
+	option, sanitizedOptions, err := sparkConfOption(ctx, app, client)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	args = append(args, option...)
+	sanitizedArgs = append(sanitizedArgs, sanitizedOptions...)
 
-	return args, nil
+	return args, sanitizedArgs, nil
 }
 
 type sparkSubmitOptionFunc func(*v1beta2.SparkApplication) ([]string, error)
@@ -298,11 +301,12 @@ func submissionWaitAppCompletionOption(_ *v1beta2.SparkApplication) ([]string, e
 	return args, nil
 }
 
-func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) ([]string, error) {
+func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) ([]string, []string, error) {
 	if app.Spec.SparkConf == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var args []string
+	var sanitizedArgs []string
 	// Add Spark configuration properties.
 	for key, value := range app.Spec.SparkConf {
 		// Configuration property for the driver pod name has already been set.
@@ -311,14 +315,17 @@ func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client 
 			if match != nil {
 				resolvedValue, err := resolveConfValueFromSecretRef(match, ctx, client, app.Namespace)
 				if err != nil {
-					return nil, fmt.Errorf("failed to resolve config value for: %s from secret ref: %s due to: %w", key, value, err)
+					return nil, nil, fmt.Errorf("failed to resolve config value for: %s from secret ref: %s due to: %w", key, value, err)
 				}
-				value = resolvedValue
+				args = append(args, "--conf", fmt.Sprintf("%s=%s", key, resolvedValue))
+				sanitizedArgs = append(sanitizedArgs, "--conf", fmt.Sprintf("%s=*****", key))
 			}
-			args = append(args, "--conf", fmt.Sprintf("%s=%s", key, value))
+			confValue := fmt.Sprintf("%s=%s", key, value)
+			args = append(args, "--conf", confValue)
+			sanitizedArgs = append(sanitizedArgs, "--conf", confValue)
 		}
 	}
-	return args, nil
+	return args, sanitizedArgs, nil
 }
 
 func resolveConfValueFromSecretRef(match []string, ctx context.Context, k8sClient client.Client, appNamespace string) (string, error) {

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -55,7 +55,8 @@ var _ SparkApplicationSubmitter = &SparkSubmitter{}
 // Secrets ref regexp supports the following secret ref formats:
 //  1. Specific namespace: {secrets:namespace/secret-name:secret-key}
 //  2. Default namespace: {secrets:secret-name:secret-key}
-var confSecretRefRegexp = regexp.MustCompile(`\${secrets:(?P<namespace>[a-z_-]+?/)?(?P<secret>[a-z_-]+):(?P<key>[a-z_-]+)}`)
+var confSecretRefRegexp = regexp.MustCompile(`^\${secrets:(?P<namespace>[a-z][-a-z0-9]*/)?(?P<secret>[a-z][-a-z0-9.]*):(?P<key>[a-z][-a-z0-9.]*)}$`)
+var confSecretRefRegexpGroupNames = confSecretRefRegexp.SubexpNames()
 
 // Submit implements SparkApplicationSubmitter interface.
 func (*SparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) error {
@@ -308,7 +309,7 @@ func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client 
 		if key != common.SparkKubernetesDriverPodName {
 			match := confSecretRefRegexp.FindStringSubmatch(value)
 			if match != nil {
-				resolvedValue, err := resolveConfValueFromSecretRef(match, ctx, client)
+				resolvedValue, err := resolveConfValueFromSecretRef(match, ctx, client, app.Namespace)
 				if err != nil {
 					return nil, fmt.Errorf("failed to resolve config value for: %s from secret ref: %s due to: %w", key, value, err)
 				}
@@ -320,9 +321,16 @@ func sparkConfOption(ctx context.Context, app *v1beta2.SparkApplication, client 
 	return args, nil
 }
 
-func resolveConfValueFromSecretRef(matches []string, ctx context.Context, k8sClient client.Client) (string, error) {
-	result := parseConfSecretRefValue(matches)
+func resolveConfValueFromSecretRef(match []string, ctx context.Context, k8sClient client.Client, appNamespace string) (string, error) {
+	result := parseConfSecretRefValue(match)
 	namespace := result["namespace"]
+	if namespace != "" {
+		namespace = strings.TrimSuffix(namespace, "/")
+	} else if appNamespace != "" {
+		namespace = appNamespace
+	} else {
+		namespace = "default"
+	}
 	secretName := result["secret"]
 	secretKey := result["key"]
 	secret := &corev1.Secret{}
@@ -337,22 +345,15 @@ func resolveConfValueFromSecretRef(matches []string, ctx context.Context, k8sCli
 	return "", fmt.Errorf("key %s not found in secret %s/%s", secretKey, namespace, secretName)
 }
 
-func parseConfSecretRefValue(matches []string) map[string]string {
+func parseConfSecretRefValue(match []string) map[string]string {
 	// Create a map to store the named results
 	result := make(map[string]string)
-	for i, name := range confSecretRefRegexp.SubexpNames() {
-		// Index 0 is the full match, so we skip it and ensure the name is not empty
-		if i != 0 && name != "" && matches != nil {
-			match := matches[i]
-			if name == "namespace" {
-				if match == "" {
-					match = "default"
-				} else {
-					match = strings.TrimSuffix(match, "/")
-				}
-			}
-			result[name] = match
+	for i, name := range confSecretRefRegexpGroupNames {
+		// Index 0 is always empty, skip
+		if i == 0 {
+			continue
 		}
+		result[name] = match[i]
 	}
 	return result
 }

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -53,8 +53,8 @@ type SparkSubmitter struct {
 var _ SparkApplicationSubmitter = &SparkSubmitter{}
 
 // Secrets ref regexp supports the following secret ref formats:
-//  1. Specific namespace: {secrets:namespace/secret-name:secret-key}
-//  2. Default namespace: {secrets:secret-name:secret-key}
+//  1. Specific namespace: ${secrets:namespace/secret-name:secret-key}
+//  2. Default namespace: ${secrets:secret-name:secret-key}
 var confSecretRefRegexp = regexp.MustCompile(`^\${secrets:(?P<namespace>[a-z][-a-z0-9]*/)?(?P<secret>[a-z][-a-z0-9.]*):(?P<key>[a-z][-a-z0-9.]*)}$`)
 var confSecretRefRegexpGroupNames = confSecretRefRegexp.SubexpNames()
 

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -152,7 +152,7 @@ func TestSparkConfOptionFromSecretRef(t *testing.T) {
 		name     string
 		app      *v1beta2.SparkApplication
 		given    []client.Object
-		expected []string
+		expected map[string][]string
 	}{
 		{
 			name: "spark conf value from secret ref",
@@ -188,10 +188,17 @@ func TestSparkConfOptionFromSecretRef(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{
-				"--conf", fmt.Sprintf("%sfs.objectStorage.access.key=%s", common.SparkHadoopPropertiesPrefix, "abc"),
-				"--conf", fmt.Sprintf("%sfs.objectStorage.secret.key=%s", common.SparkHadoopPropertiesPrefix, "xyz"),
-				"--conf", fmt.Sprintf("%sfs.objectStorage.encryption.key=%s", common.SparkHadoopPropertiesPrefix, "kms"),
+			expected: map[string][]string{
+				"args": {
+					"--conf", fmt.Sprintf("%sfs.objectStorage.access.key=%s", common.SparkHadoopPropertiesPrefix, "abc"),
+					"--conf", fmt.Sprintf("%sfs.objectStorage.secret.key=%s", common.SparkHadoopPropertiesPrefix, "xyz"),
+					"--conf", fmt.Sprintf("%sfs.objectStorage.encryption.key=%s", common.SparkHadoopPropertiesPrefix, "kms"),
+				},
+				"sanitizedArgs": {
+					"--conf", fmt.Sprintf("%sfs.objectStorage.access.key=%s", common.SparkHadoopPropertiesPrefix, "abc"),
+					"--conf", fmt.Sprintf("%sfs.objectStorage.secret.key=%s", common.SparkHadoopPropertiesPrefix, "*****"),
+					"--conf", fmt.Sprintf("%sfs.objectStorage.encryption.key=%s", common.SparkHadoopPropertiesPrefix, "*****"),
+				},
 			},
 		},
 	}
@@ -199,15 +206,20 @@ func TestSparkConfOptionFromSecretRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockK8sClient := fake.NewClientBuilder().WithObjects(tt.given...).Build()
-			options, err := sparkConfOption(context.TODO(), tt.app, mockK8sClient)
+			options, sanitizedOptions, err := sparkConfOption(context.TODO(), tt.app, mockK8sClient)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			expectedOptions := tt.expected["args"]
+			expectedSanitizedOptions := tt.expected["sanitizedArgs"]
 			slices.Sort(options)
-			slices.Sort(tt.expected)
+			slices.Sort(sanitizedOptions)
+			slices.Sort(expectedOptions)
+			slices.Sort(expectedSanitizedOptions)
 
-			assert.Equal(t, tt.expected, options, "Spark config options do not match expected values")
+			assert.Equal(t, expectedOptions, options, "Spark config options do not match expected values")
+			assert.Equal(t, expectedSanitizedOptions, sanitizedOptions, "Spark satinized config options do not match expected values")
 		})
 	}
 }

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"slices"
@@ -30,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
@@ -140,6 +143,71 @@ func TestExecutorConfOption(t *testing.T) {
 			slices.Sort(testCase.expected)
 
 			assert.Equal(t, testCase.expected, options, "Executor configuration options do not match expected values")
+		})
+	}
+}
+
+func TestSparkConfOptionFromSecretRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      *v1beta2.SparkApplication
+		given    []client.Object
+		expected []string
+	}{
+		{
+			name: "spark conf value from secret ref",
+			app: &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spark-conf-value-from-secret-ref",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					SparkConf: map[string]string{
+						fmt.Sprintf("%sfs.objectStorage.access.key", common.SparkHadoopPropertiesPrefix):     "abc",
+						fmt.Sprintf("%sfs.objectStorage.secret.key", common.SparkHadoopPropertiesPrefix):     "${secrets:object-storage:secret-key}",
+						fmt.Sprintf("%sfs.objectStorage.encryption.key", common.SparkHadoopPropertiesPrefix): "${secrets:ops/object-storage-kms:encryption-key}",
+					},
+				},
+			},
+			given: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "object-storage",
+					},
+					Data: map[string][]byte{
+						"secret-key": []byte("xyz"),
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ops",
+						Name:      "object-storage-kms",
+					},
+					Data: map[string][]byte{
+						"encryption-key": []byte("kms"),
+					},
+				},
+			},
+			expected: []string{
+				"--conf", fmt.Sprintf("%sfs.objectStorage.access.key=%s", common.SparkHadoopPropertiesPrefix, "abc"),
+				"--conf", fmt.Sprintf("%sfs.objectStorage.secret.key=%s", common.SparkHadoopPropertiesPrefix, "xyz"),
+				"--conf", fmt.Sprintf("%sfs.objectStorage.encryption.key=%s", common.SparkHadoopPropertiesPrefix, "kms"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockK8sClient := fake.NewClientBuilder().WithObjects(tt.given...).Build()
+			options, err := sparkConfOption(context.TODO(), tt.app, mockK8sClient)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			slices.Sort(options)
+			slices.Sort(tt.expected)
+
+			assert.Equal(t, tt.expected, options, "Spark config options do not match expected values")
 		})
 	}
 }

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -164,7 +164,7 @@ func TestSparkConfOptionFromSecretRef(t *testing.T) {
 					SparkConf: map[string]string{
 						fmt.Sprintf("%sfs.objectStorage.access.key", common.SparkHadoopPropertiesPrefix):     "abc",
 						fmt.Sprintf("%sfs.objectStorage.secret.key", common.SparkHadoopPropertiesPrefix):     "${secrets:object-storage:secret-key}",
-						fmt.Sprintf("%sfs.objectStorage.encryption.key", common.SparkHadoopPropertiesPrefix): "${secrets:ops/object-storage-kms:encryption-key}",
+						fmt.Sprintf("%sfs.objectStorage.encryption.key", common.SparkHadoopPropertiesPrefix): "${secrets:ops/object-storage-1.kms:encryption.key-2}",
 					},
 				},
 			},
@@ -181,10 +181,10 @@ func TestSparkConfOptionFromSecretRef(t *testing.T) {
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ops",
-						Name:      "object-storage-kms",
+						Name:      "object-storage-1.kms",
 					},
 					Data: map[string][]byte{
-						"encryption-key": []byte("kms"),
+						"encryption.key-2": []byte("kms"),
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR
**New feature**: resolve Spark config values from secrets reference.

Example `SparkApplication`
```yaml
apiVersion: sparkoperator.k8s.io/v1beta2
kind: SparkApplication
metadata:
  name: spark-pi
  namespace: default
spec:
  type: Scala
  mode: cluster
  image: docker.io/library/spark:4.0.1
  imagePullPolicy: IfNotPresent
  mainClass: org.apache.spark.examples.SparkPi
  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples.jar
  arguments:
  - "5000"
  sparkVersion: 4.0.1
  sparkConf:
    "spark.hadoop.fs.s3.access.key": "${secrets:object-storage:access-key}"
    "spark.hadoop.fs.s3a.secret.key": "${secrets:ops/object-storage:secret-key}"
  driver:
    labels:
      version: 4.0.1
    cores: 1
    memory: 512m
    serviceAccount: spark-operator-spark
    securityContext:
      capabilities:
        drop:
        - ALL
      runAsGroup: 185
      runAsUser: 185
      runAsNonRoot: true
      allowPrivilegeEscalation: false
      seccompProfile:
        type: RuntimeDefault
  executor:
    labels:
      version: 4.0.1
    instances: 1
    cores: 1
    memory: 512m
    securityContext:
      capabilities:
        drop:
        - ALL
      runAsGroup: 185
      runAsUser: 185
      runAsNonRoot: true
      allowPrivilegeEscalation: false
      seccompProfile:
        type: RuntimeDefault
```

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- introduce regexp supporting following secrets reference formats (inspired by [Strimzi kafka-kubernetes-config-provider](https://github.com/strimzi/kafka-kubernetes-config-provider)):
  1. specific namespace: `${secrets:namespace/secret-name:secret-key}`
  2. default namespace: `${secrets:secret-name:secret-key}`
- customize `sparkConfOption(...)` to take K8s client/ctx and resolve conf secrets refs using:
  1. regexp
  2. new helper funcs: `resolveConfValueFromSecretRef` and `parseConfSecretRefValue`
- extend `SparkApplicationSubmitter.Submit(...)` to pass K8s client down the call chain to `sparkConfOption(...)` and finally to `resolveConfValueFromSecretRef(...)` helper.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale
It's a pretty common requirement to provide credentials to a Spark application via config values. \
The operator currently lacks support for securely passing these values, everything in the `sparkConfig` must be in clear text.
This was raised in [#559](https://github.com/kubeflow/spark-operator/issues/559)

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

This will need to be documented with good visibility, not certain where to put it.

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
