### PR TITLE
feat(webhook): Add webhook validation for SparkConnect CRD

### DIFF
--- a/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -125,4 +125,36 @@ webhooks:
   {{- with .Values.webhook.timeoutSeconds }}
   timeoutSeconds: {{ . }}
   {{- end }}
+- name: mutate-sparkoperator-k8s-io-v1alpha1-sparkconnect.sparkoperator.k8s.io
+  admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: {{ include "spark-operator.webhook.serviceName" . }}
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.webhook.port }}
+      path: /mutate-sparkoperator-k8s-io-v1alpha1-sparkconnect
+  sideEffects: NoneOnDryRun
+  {{- with .Values.webhook.failurePolicy }}
+  failurePolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  rules:
+  - apiGroups: ["sparkoperator.k8s.io"]
+    apiVersions: ["v1alpha1"]
+    resources: ["sparkconnects"]
+    operations: ["CREATE", "UPDATE"]
+  {{- with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
@@ -90,4 +90,36 @@ webhooks:
   {{- with .Values.webhook.timeoutSeconds }}
   timeoutSeconds: {{ . }}
   {{- end }}
+- name: validate-sparkoperator-k8s-io-v1alpha1-sparkconnect.sparkoperator.k8s.io
+  admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: {{ include "spark-operator.webhook.serviceName" . }}
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.webhook.port }}
+      path: /validate-sparkoperator-k8s-io-v1alpha1-sparkconnect
+  sideEffects: NoneOnDryRun
+  {{- with .Values.webhook.failurePolicy }}
+  failurePolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  rules:
+  - apiGroups: ["sparkoperator.k8s.io"]
+    apiVersions: ["v1alpha1"]
+    resources: ["sparkconnects"]
+    operations: ["CREATE", "UPDATE"]
+  {{- with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{- end }}
 {{- end }}

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -46,6 +46,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/internal/controller/mutatingwebhookconfiguration"
 	"github.com/kubeflow/spark-operator/v2/internal/controller/validatingwebhookconfiguration"
@@ -278,6 +279,16 @@ func start() {
 			logger.Error(err, "Failed to create controller", "controller", "ValidatingWebhookConfiguration")
 			os.Exit(1)
 		}
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.SparkConnect{}).
+		WithDefaulter(webhook.NewSparkConnectDefaulter()).
+		WithValidator(webhook.NewSparkConnectValidator()).
+		WithLogConstructor(webhook.LogConstructor).
+		Complete(); err != nil {
+		logger.Error(err, "Failed to create mutating webhook for SparkConnect")
+		os.Exit(1)
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -48,6 +48,28 @@ webhooks:
     resources:
     - sparkapplications
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-sparkoperator-k8s-io-v1alpha1-sparkconnect
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: mutate-sparkconnect.sparkoperator.k8s.io
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - sparkoperator.k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - sparkconnects
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -116,4 +138,25 @@ webhooks:
     - UPDATE
     resources:
     - sparkapplications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-sparkoperator-k8s-io-v1alpha1-sparkconnect
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: validate-sparkconnect.sparkoperator.k8s.io
+  rules:
+  - apiGroups:
+    - sparkoperator.k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - sparkconnects
   sideEffects: None

--- a/internal/webhook/sparkconnect_defaulter.go
+++ b/internal/webhook/sparkconnect_defaulter.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	operatorscheme "github.com/kubeflow/spark-operator/v2/pkg/scheme"
+)
+
+// +kubebuilder:webhook:admissionReviewVersions=v1,failurePolicy=fail,groups=sparkoperator.k8s.io,matchPolicy=Exact,mutating=true,name=mutate-sparkconnect.sparkoperator.k8s.io,path=/mutate-sparkoperator-k8s-io-v1alpha1-sparkconnect,reinvocationPolicy=Never,resources=sparkconnects,sideEffects=None,verbs=create;update,versions=v1alpha1,webhookVersions=v1
+
+// SparkConnectDefaulter sets default values for a SparkConnect.
+type SparkConnectDefaulter struct{}
+
+// NewSparkConnectDefaulter creates a new SparkConnectDefaulter instance.
+func NewSparkConnectDefaulter() *SparkConnectDefaulter {
+	return &SparkConnectDefaulter{}
+}
+
+// SparkConnectDefaulter implements admission.CustomDefaulter.
+var _ admission.CustomDefaulter = &SparkConnectDefaulter{}
+
+// Default implements admission.CustomDefaulter.
+func (d *SparkConnectDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	sc, ok := obj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Defaulting SparkConnect", "name", sc.Name, "namespace", sc.Namespace)
+
+	// Apply scheme defaults
+	operatorscheme.WebhookScheme.Default(sc)
+
+	return nil
+}

--- a/internal/webhook/sparkconnect_validator.go
+++ b/internal/webhook/sparkconnect_validator.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+)
+
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:admissionReviewVersions=v1,failurePolicy=fail,groups=sparkoperator.k8s.io,matchPolicy=Exact,mutating=false,name=validate-sparkconnect.sparkoperator.k8s.io,path=/validate-sparkoperator-k8s-io-v1alpha1-sparkconnect,reinvocationPolicy=Never,resources=sparkconnects,sideEffects=None,verbs=create;update,versions=v1alpha1,webhookVersions=v1
+
+// SparkConnectValidator validates SparkConnect resources.
+type SparkConnectValidator struct{}
+
+// NewSparkConnectValidator creates a new SparkConnectValidator instance.
+func NewSparkConnectValidator() *SparkConnectValidator {
+	return &SparkConnectValidator{}
+}
+
+var _ admission.CustomValidator = &SparkConnectValidator{}
+
+// ValidateCreate implements admission.CustomValidator.
+func (v *SparkConnectValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	sc, ok := obj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Validating SparkConnect create", "name", sc.Name, "namespace", sc.Namespace)
+
+	// Validate metadata.name early to prevent downstream Service creation failures
+	if err := v.validateName(sc.Name); err != nil {
+		return nil, err
+	}
+
+	if err := v.validateSpec(sc); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements admission.CustomValidator.
+func (v *SparkConnectValidator) ValidateUpdate(ctx context.Context, oldObj runtime.Object, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	oldSC, ok := oldObj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+
+	newSC, ok := newObj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Validating SparkConnect update", "name", newSC.Name, "namespace", newSC.Namespace)
+
+	// Name is immutable in Kubernetes, but validate anyway for safety
+	if err := v.validateName(newSC.Name); err != nil {
+		return nil, err
+	}
+
+	// Skip validating when spec does not change.
+	if equality.Semantic.DeepEqual(oldSC.Spec, newSC.Spec) {
+		return nil, nil
+	}
+
+	if err := v.validateSpec(newSC); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements admission.CustomValidator.
+func (v *SparkConnectValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	sc, ok := obj.(*v1alpha1.SparkConnect)
+	if !ok {
+		return nil, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Validating SparkConnect delete", "name", sc.Name, "namespace", sc.Namespace)
+
+	return nil, nil
+}
+
+// validateName ensures the SparkConnect metadata.name is a valid DNS-1035 label.
+// This prevents failures later when creating related resources like Services which
+// require DNS-1035 compliant names. The operator derives a default Service name as
+// "<name>-server", so we must also ensure that this derived name does not exceed
+// the DNS-1035 maximum length.
+func (v *SparkConnectValidator) validateName(name string) error {
+	if errs := validation.IsDNS1035Label(name); len(errs) > 0 {
+		return fmt.Errorf("invalid SparkConnect name %q: %s", name, strings.Join(errs, ", "))
+	}
+
+	// Ensure the derived default Service name "<name>-server" also fits within the
+	// DNS-1035 label length limit, so Service creation will not fail downstream.
+	const serviceSuffix = "-server"
+	maxBaseLen := validation.DNS1035LabelMaxLength - len(serviceSuffix)
+	if len(name) > maxBaseLen {
+		return fmt.Errorf("invalid SparkConnect name %q: must be at most %d characters so that the derived Service name %q does not exceed the DNS-1035 label length limit (%d characters)",
+			name, maxBaseLen, name+serviceSuffix, validation.DNS1035LabelMaxLength)
+	}
+
+	return nil
+}
+
+// validateSpec validates the SparkConnect spec.
+func (v *SparkConnectValidator) validateSpec(sc *v1alpha1.SparkConnect) error {
+	// Validate SparkVersion
+	if err := v.validateSparkVersion(sc); err != nil {
+		return err
+	}
+
+	// Validate image availability
+	if err := v.validateImage(sc); err != nil {
+		return err
+	}
+
+	// Validate DynamicAllocation
+	if err := v.validateDynamicAllocation(sc); err != nil {
+		return err
+	}
+
+	// Validate Server spec
+	if err := v.validateServerSpec(sc); err != nil {
+		return err
+	}
+
+	// Validate Executor spec
+	if err := v.validateExecutorSpec(sc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSparkVersion validates the Spark version.
+// Pod templates require Spark 3.0.0 or higher.
+func (v *SparkConnectValidator) validateSparkVersion(sc *v1alpha1.SparkConnect) error {
+	// SparkVersion is required
+	if sc.Spec.SparkVersion == "" {
+		return fmt.Errorf("sparkVersion is required")
+	}
+
+	// If pod templates are used, require Spark 3.0.0+
+	if sc.Spec.Server.Template != nil || sc.Spec.Executor.Template != nil {
+		if util.CompareSemanticVersion(sc.Spec.SparkVersion, "3.0.0") < 0 {
+			return fmt.Errorf("pod template feature requires Spark version 3.0.0 or higher, got %s", sc.Spec.SparkVersion)
+		}
+	}
+
+	return nil
+}
+
+// validateImage validates that container images are available either from the spec-level image
+// or from both the server and executor pod templates. This prevents the controller from entering
+// a retry loop when it tries to reconcile a SparkConnect without valid images.
+func (v *SparkConnectValidator) validateImage(sc *v1alpha1.SparkConnect) error {
+	// If a spec-level image is provided, it will be used for both server and executor.
+	if sc.Spec.Image != nil && *sc.Spec.Image != "" {
+		return nil
+	}
+
+	// Otherwise, require that both server and executor pod templates provide container images.
+	serverImageFound := false
+	if sc.Spec.Server.Template != nil {
+		for _, container := range sc.Spec.Server.Template.Spec.Containers {
+			if container.Image != "" {
+				serverImageFound = true
+				break
+			}
+		}
+	}
+
+	executorImageFound := false
+	if sc.Spec.Executor.Template != nil {
+		for _, container := range sc.Spec.Executor.Template.Spec.Containers {
+			if container.Image != "" {
+				executorImageFound = true
+				break
+			}
+		}
+	}
+
+	if serverImageFound && executorImageFound {
+		return nil
+	}
+
+	return fmt.Errorf("image must be specified in spec.image or both server and executor pod templates must provide container images")
+}
+
+// validateDynamicAllocation validates DynamicAllocation configuration.
+func (v *SparkConnectValidator) validateDynamicAllocation(sc *v1alpha1.SparkConnect) error {
+	da := sc.Spec.DynamicAllocation
+	if da == nil || !da.Enabled {
+		return nil
+	}
+
+	// Validate minExecutors <= maxExecutors
+	if da.MinExecutors != nil && da.MaxExecutors != nil {
+		if *da.MinExecutors > *da.MaxExecutors {
+			return fmt.Errorf("dynamicAllocation.minExecutors (%d) cannot be greater than dynamicAllocation.maxExecutors (%d)",
+				*da.MinExecutors, *da.MaxExecutors)
+		}
+	}
+
+	// Validate initialExecutors is within range
+	if da.InitialExecutors != nil {
+		if da.MinExecutors != nil && *da.InitialExecutors < *da.MinExecutors {
+			return fmt.Errorf("dynamicAllocation.initialExecutors (%d) cannot be less than dynamicAllocation.minExecutors (%d)",
+				*da.InitialExecutors, *da.MinExecutors)
+		}
+		if da.MaxExecutors != nil && *da.InitialExecutors > *da.MaxExecutors {
+			return fmt.Errorf("dynamicAllocation.initialExecutors (%d) cannot be greater than dynamicAllocation.maxExecutors (%d)",
+				*da.InitialExecutors, *da.MaxExecutors)
+		}
+	}
+
+	// Validate non-negative values
+	if da.MinExecutors != nil && *da.MinExecutors < 0 {
+		return fmt.Errorf("dynamicAllocation.minExecutors must be non-negative, got %d", *da.MinExecutors)
+	}
+	if da.MaxExecutors != nil && *da.MaxExecutors < 0 {
+		return fmt.Errorf("dynamicAllocation.maxExecutors must be non-negative, got %d", *da.MaxExecutors)
+	}
+	if da.InitialExecutors != nil && *da.InitialExecutors < 0 {
+		return fmt.Errorf("dynamicAllocation.initialExecutors must be non-negative, got %d", *da.InitialExecutors)
+	}
+
+	return nil
+}
+
+// validateServerSpec validates the Server specification.
+func (v *SparkConnectValidator) validateServerSpec(sc *v1alpha1.SparkConnect) error {
+	server := sc.Spec.Server
+
+	// Validate memory format if specified
+	if server.Memory != nil && *server.Memory != "" {
+		if err := validateMemoryString(*server.Memory); err != nil {
+			return fmt.Errorf("invalid server.memory: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// validateExecutorSpec validates the Executor specification.
+func (v *SparkConnectValidator) validateExecutorSpec(sc *v1alpha1.SparkConnect) error {
+	executor := sc.Spec.Executor
+
+	// Validate memory format if specified
+	if executor.Memory != nil && *executor.Memory != "" {
+		if err := validateMemoryString(*executor.Memory); err != nil {
+			return fmt.Errorf("invalid executor.memory: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// validateMemoryString validates a Java/Spark memory string format.
+// Valid formats: 1g, 512m, 1024k, 1073741824 (bytes)
+func validateMemoryString(memory string) error {
+	if memory == "" {
+		return nil
+	}
+
+	lower := strings.ToLower(strings.TrimSpace(memory))
+
+	// Check for valid suffixes and extract numeric part
+	validSuffixes := []string{"pb", "tb", "gb", "mb", "kb", "p", "t", "g", "m", "k", "b"}
+	numericPart := lower
+	hasValidSuffix := false
+
+	for _, suffix := range validSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			numericPart = strings.TrimSuffix(lower, suffix)
+			hasValidSuffix = true
+			break
+		}
+	}
+
+	// Numeric part must not be empty and must be a valid number
+	if numericPart == "" {
+		return fmt.Errorf("invalid memory format %q: must have a numeric value", memory)
+	}
+
+	// Check that the numeric part is a non-negative integer (no decimals, no negative sign)
+	for _, c := range numericPart {
+		if c < '0' || c > '9' {
+			return fmt.Errorf("invalid memory format %q: must be a non-negative integer with optional suffix (e.g., 1g, 512m, 1024k)", memory)
+		}
+	}
+
+	// If no valid suffix, should be a pure number (bytes)
+	if !hasValidSuffix {
+		for _, c := range lower {
+			if c < '0' || c > '9' {
+				return fmt.Errorf("invalid memory format %q: must be a number with optional suffix (e.g., 1g, 512m, 1024k)", memory)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/webhook/sparkconnect_validator_test.go
+++ b/internal/webhook/sparkconnect_validator_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+)
+
+func TestSparkConnectValidatorValidateCreate_Success(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	if _, err := validator.ValidateCreate(context.Background(), newSparkConnect()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_SparkVersionRequired(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.SparkVersion = ""
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "sparkVersion is required") {
+		t.Fatalf("expected sparkVersion required error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_PodTemplateRequiresSpark3(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.SparkVersion = "2.4.0"
+	sc.Spec.Server.Template = &corev1.PodTemplateSpec{}
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "requires Spark version 3.0.0 or higher") {
+		t.Fatalf("expected spark version validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_ImageRequired(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.Image = nil
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "image must be specified") {
+		t.Fatalf("expected image validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_ImageInBothTemplates(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.Image = nil
+	sc.Spec.Server.Template = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "spark-connect",
+					Image: "spark:3.5.0",
+				},
+			},
+		},
+	}
+	sc.Spec.Executor.Template = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "executor",
+					Image: "spark:3.5.0",
+				},
+			},
+		},
+	}
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err != nil {
+		t.Fatalf("expected success with image in both server and executor templates, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_ImageOnlyInServerTemplate(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.Image = nil
+	sc.Spec.Server.Template = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "spark-connect",
+					Image: "spark:3.5.0",
+				},
+			},
+		},
+	}
+	// No executor template - should fail
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "image must be specified") {
+		t.Fatalf("expected image validation error when only server template has image, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_DynamicAllocationMinGreaterThanMax(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.DynamicAllocation = &v1alpha1.DynamicAllocation{
+		Enabled:      true,
+		MinExecutors: ptr.To[int32](10),
+		MaxExecutors: ptr.To[int32](5),
+	}
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "cannot be greater than") {
+		t.Fatalf("expected min/max executors validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_DynamicAllocationInitialLessThanMin(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.DynamicAllocation = &v1alpha1.DynamicAllocation{
+		Enabled:          true,
+		InitialExecutors: ptr.To[int32](1),
+		MinExecutors:     ptr.To[int32](5),
+		MaxExecutors:     ptr.To[int32](10),
+	}
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "cannot be less than") {
+		t.Fatalf("expected initialExecutors validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_DynamicAllocationInitialGreaterThanMax(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.DynamicAllocation = &v1alpha1.DynamicAllocation{
+		Enabled:          true,
+		InitialExecutors: ptr.To[int32](15),
+		MinExecutors:     ptr.To[int32](5),
+		MaxExecutors:     ptr.To[int32](10),
+	}
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "cannot be greater than") {
+		t.Fatalf("expected initialExecutors validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_DynamicAllocationValid(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.DynamicAllocation = &v1alpha1.DynamicAllocation{
+		Enabled:          true,
+		InitialExecutors: ptr.To[int32](5),
+		MinExecutors:     ptr.To[int32](2),
+		MaxExecutors:     ptr.To[int32](10),
+	}
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err != nil {
+		t.Fatalf("expected success for valid dynamic allocation, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_InvalidServerMemory(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.Server.Memory = ptr.To("invalid-memory")
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "invalid server.memory") {
+		t.Fatalf("expected server memory validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_InvalidExecutorMemory(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	sc.Spec.Executor.Memory = ptr.To("bad-format")
+
+	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "invalid executor.memory") {
+		t.Fatalf("expected executor memory validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_ValidMemoryFormats(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	validMemoryFormats := []string{"1g", "512m", "1024k", "2048mb", "1gb", "100", "1t", "1024"}
+
+	for _, mem := range validMemoryFormats {
+		t.Run(mem, func(t *testing.T) {
+			sc := newSparkConnect()
+			sc.Spec.Server.Memory = ptr.To(mem)
+			sc.Spec.Executor.Memory = ptr.To(mem)
+
+			if _, err := validator.ValidateCreate(context.Background(), sc); err != nil {
+				t.Fatalf("expected success for memory format %q, got %v", mem, err)
+			}
+		})
+	}
+}
+
+func TestSparkConnectValidatorValidateUpdate_SameSpecSkipsValidation(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	sc := newSparkConnect()
+	// Set invalid sparkVersion which would fail validation
+	sc.Spec.SparkVersion = ""
+
+	oldSC := sc.DeepCopy()
+	newSC := sc.DeepCopy()
+
+	// Should skip validation because spec is unchanged
+	// But name validation still happens, so we need a valid name
+	oldSC.Spec.SparkVersion = "3.5.0"
+	newSC.Spec.SparkVersion = "3.5.0"
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldSC, newSC); err != nil {
+		t.Fatalf("expected no error when spec unchanged, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateUpdate_SpecChangedTriggersValidation(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	oldSC := newSparkConnect()
+	newSC := oldSC.DeepCopy()
+	newSC.Spec.SparkVersion = ""
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldSC, newSC); err == nil || !strings.Contains(err.Error(), "sparkVersion is required") {
+		t.Fatalf("expected sparkVersion validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateDelete_Success(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	if _, err := validator.ValidateDelete(context.Background(), newSparkConnect()); err != nil {
+		t.Fatalf("expected successful delete validation, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateName(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	// The operator derives a default Service name as "<name>-server" (7 chars suffix).
+	// So the effective max name length is 63 - 7 = 56 characters.
+	tests := []struct {
+		name      string
+		scName    string
+		wantError bool
+	}{
+		// Valid names
+		{"valid simple name", "test-sc", false},
+		{"valid name with numbers", "test-sc-123", false},
+		{"valid single letter", "a", false},
+		{"valid name ending with number", "my-sc-1", false},
+		{"valid name with multiple hyphens", "my-test-sc-123", false},
+		{"valid 56 char name (max for derived service name)", strings.Repeat("a", 56), false},
+		{"valid name with hyphens in middle", "a-b-c-d-e", false},
+
+		// Invalid names
+		{"name starting with number", "123test-sc", true},
+		{"name with uppercase", "Test-SC", true},
+		{"name with uppercase at start", "TestSC", true},
+		{"name with uppercase in middle", "test-SC", true},
+		{"name starting with hyphen", "-test-sc", true},
+		{"name ending with hyphen", "test-sc-", true},
+		{"empty name", "", true},
+		{"name 57 chars exceeds derived service name limit", strings.Repeat("a", 57), true},
+		{"name 63 chars exceeds derived service name limit", strings.Repeat("a", 63), true},
+		{"name too long for DNS-1035", strings.Repeat("a", 64), true},
+		{"name with special characters", "test@sc", true},
+		{"name with underscore", "test_sc", true},
+		{"name with spaces", "test sc", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newSparkConnect()
+			sc.Name = tt.scName
+
+			_, err := validator.ValidateCreate(context.Background(), sc)
+			hasError := err != nil
+
+			if hasError != tt.wantError {
+				t.Errorf("validateName(%q) = error %v, wantError %v, got error: %v", tt.scName, hasError, tt.wantError, err)
+			}
+
+			if hasError && err.Error() == "" {
+				t.Errorf("validateName(%q) should return a non-empty error message, got: %v", tt.scName, err)
+			}
+		})
+	}
+}
+
+func TestValidateMemoryString(t *testing.T) {
+	tests := []struct {
+		name      string
+		memory    string
+		wantError bool
+	}{
+		// Valid formats
+		{"bytes", "1073741824", false},
+		{"kilobytes lowercase", "1024k", false},
+		{"kilobytes uppercase", "1024K", false},
+		{"kilobytes with kb", "1024kb", false},
+		{"megabytes lowercase", "512m", false},
+		{"megabytes with mb", "512mb", false},
+		{"gigabytes lowercase", "1g", false},
+		{"gigabytes with gb", "1gb", false},
+		{"terabytes lowercase", "1t", false},
+		{"terabytes with tb", "1tb", false},
+		{"petabytes lowercase", "1p", false},
+		{"petabytes with pb", "1pb", false},
+		{"empty string", "", false},
+
+		// Invalid formats
+		{"invalid suffix", "1x", true},
+		{"text only", "invalid", true},
+		{"mixed invalid", "1g2m", true},
+		{"negative value", "-1g", true},
+		{"negative bytes", "-1024", true},
+		{"decimal value", "1.5g", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMemoryString(tt.memory)
+			hasError := err != nil
+
+			if hasError != tt.wantError {
+				t.Errorf("validateMemoryString(%q) = error %v, wantError %v, got error: %v", tt.memory, hasError, tt.wantError, err)
+			}
+		})
+	}
+}
+
+func newTestSparkConnectValidator(t *testing.T) *SparkConnectValidator {
+	t.Helper()
+	return NewSparkConnectValidator()
+}
+
+func newSparkConnect() *v1alpha1.SparkConnect {
+	return &v1alpha1.SparkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sc",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.SparkConnectSpec{
+			Image:        ptr.To("spark:3.5.0"),
+			SparkVersion: "3.5.0",
+			Server: v1alpha1.ServerSpec{
+				SparkPodSpec: v1alpha1.SparkPodSpec{
+					Cores:  ptr.To[int32](1),
+					Memory: ptr.To("1g"),
+				},
+			},
+			Executor: v1alpha1.ExecutorSpec{
+				SparkPodSpec: v1alpha1.SparkPodSpec{
+					Cores:  ptr.To[int32](1),
+					Memory: ptr.To("1g"),
+				},
+				Instances: ptr.To[int32](1),
+			},
+		},
+	}
+}

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -40,6 +40,8 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 
 	utilruntime.Must(clientgoscheme.AddToScheme(WebhookScheme))
+
+	utilruntime.Must(v1alpha1.AddToScheme(WebhookScheme))
 	utilruntime.Must(v1beta2.AddToScheme(WebhookScheme))
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
## Purpose of this PR

This PR introduces admission webhook validation for the SparkConnect CRD, aligning it with the existing validation patterns used for SparkApplication.

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Rationale

The Spark Operator currently includes webhook validation for SparkApplication, but similar validation was not implemented for SparkConnect. This creates inconsistency and requires SDK-side validation that is better suited for controller-side enforcement.

This change:
- Aligns SparkConnect behavior with existing Spark CRDs
- Prevents invalid resource specifications at admission time
- Allows SDK-side validation logic to be simplified or removed

Validation rules implemented:
- Name must be DNS-1035 compliant (required for Service creation)
- SparkVersion is required
- Pod templates require Spark version >= 3.0.0
- DynamicAllocation: minExecutors <= maxExecutors
- DynamicAllocation: initialExecutors within min/max range
- Memory format validation (e.g., 1g, 512m, 1024k)

Helm chart has been updated and `make manifests` has been run to regenerate webhook configs.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

Closes https://github.com/kubeflow/spark-operator/issues/2848.