### PR TITLE
fix: Add label selector to ConfigMap cache to prevent OOM via informer flooding

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -415,7 +415,11 @@ func newCacheOptions() cache.Options {
 					common.LabelLaunchedBySparkOperator: "true",
 				}),
 			},
-			&corev1.ConfigMap{}:                  {},
+			&corev1.ConfigMap{}: {
+				Label: labels.SelectorFromSet(labels.Set{
+					common.LabelCreatedBySparkOperator: "true",
+				}),
+			},
 			&corev1.PersistentVolumeClaim{}:      {},
 			&corev1.Service{}:                    {},
 			&v1beta2.SparkApplication{}:          {},

--- a/internal/controller/sparkapplication/monitoring_config.go
+++ b/internal/controller/sparkapplication/monitoring_config.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
-func configPrometheusMonitoring(ctx context.Context, app *v1beta2.SparkApplication, client client.Client) error {
+func configPrometheusMonitoring(ctx context.Context, app *v1beta2.SparkApplication, c client.Client) error {
 	logger := log.FromContext(ctx)
 	port := common.DefaultPrometheusJavaAgentPort
 	if app.Spec.Monitoring.Prometheus != nil && app.Spec.Monitoring.Prometheus.Port != nil {
@@ -47,14 +47,41 @@ func configPrometheusMonitoring(ctx context.Context, app *v1beta2.SparkApplicati
 		key := types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}
 		if retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			cm := &corev1.ConfigMap{}
-			if err := client.Get(ctx, key, cm); err != nil {
+			if err := c.Get(ctx, key, cm); err != nil {
 				if errors.IsNotFound(err) {
-					return client.Create(ctx, configMap)
+					if createErr := c.Create(ctx, configMap); createErr != nil {
+						// Handle upgrade scenario: ConfigMap exists in the cluster but is not
+						// visible in the filtered cache because it was created before the
+						// LabelCreatedBySparkOperator label selector was added to the informer.
+						// Use Patch (merge patch) instead of Update because we cannot Get the
+						// object from the filtered cache to obtain its resourceVersion.
+						if errors.IsAlreadyExists(createErr) {
+							base := &corev1.ConfigMap{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      key.Name,
+									Namespace: key.Namespace,
+								},
+							}
+							desired := base.DeepCopy()
+							desired.Labels = map[string]string{
+								common.LabelCreatedBySparkOperator: "true",
+							}
+							desired.Data = configMap.Data
+							desired.OwnerReferences = configMap.OwnerReferences
+							return c.Patch(ctx, desired, client.MergeFrom(base))
+						}
+						return createErr
+					}
+					return nil
 				}
 				return err
 			}
 			cm.Data = configMap.Data
-			return client.Update(ctx, cm)
+			if cm.Labels == nil {
+				cm.Labels = map[string]string{}
+			}
+			cm.Labels[common.LabelCreatedBySparkOperator] = "true"
+			return c.Update(ctx, cm)
 		}); retryErr != nil {
 			return retryErr
 		}
@@ -146,6 +173,9 @@ func buildPrometheusConfigMap(app *v1beta2.SparkApplication, prometheusConfigMap
 			Name:            prometheusConfigMapName,
 			Namespace:       app.Namespace,
 			OwnerReferences: []metav1.OwnerReference{util.GetOwnerReference(app)},
+			Labels: map[string]string{
+				common.LabelCreatedBySparkOperator: "true",
+			},
 		},
 		Data: configMapData,
 	}

--- a/internal/controller/sparkapplication/monitoring_config_test.go
+++ b/internal/controller/sparkapplication/monitoring_config_test.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -32,6 +34,28 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
+
+// filteredCacheClient wraps a client.Client and overrides Get to simulate a
+// label-filtered informer cache. ConfigMaps that lack the required label are
+// invisible to Get (returns NotFound), just like a real ByObject label selector
+// would behave at runtime.
+type filteredCacheClient struct {
+	client.Client
+	requiredLabel string
+	requiredValue string
+}
+
+func (f *filteredCacheClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := f.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if cm, ok := obj.(*corev1.ConfigMap); ok {
+		if cm.Labels[f.requiredLabel] != f.requiredValue {
+			return errors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, key.Name)
+		}
+	}
+	return nil
+}
 
 func TestConfigPrometheusMonitoring(t *testing.T) {
 	type testcase struct {
@@ -56,6 +80,9 @@ func TestConfigPrometheusMonitoring(t *testing.T) {
 		}
 		err = fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(configMap), configMap)
 		assert.NoError(t, err, "failed to get ConfigMap %s", configMapName)
+
+		assert.Equal(t, "true", configMap.Labels[common.LabelCreatedBySparkOperator],
+			"ConfigMap %s should have LabelCreatedBySparkOperator label", configMapName)
 
 		if test.app.Spec.Monitoring.Prometheus != nil && test.app.Spec.Monitoring.Prometheus.ConfigFile == nil &&
 			test.app.Spec.Monitoring.MetricsPropertiesFile == nil {
@@ -341,4 +368,68 @@ func TestConfigPrometheusMonitoring(t *testing.T) {
 	for _, test := range testcases {
 		testFn(test, t)
 	}
+}
+
+func TestConfigPrometheusMonitoring_UpgradeExistingConfigMapWithoutLabel(t *testing.T) {
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-app",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Monitoring: &v1beta2.MonitoringSpec{
+				ExposeDriverMetrics:   true,
+				ExposeExecutorMetrics: true,
+				Prometheus: &v1beta2.PrometheusSpec{
+					JmxExporterJar: "/prometheus/exporter.jar",
+				},
+			},
+		},
+	}
+
+	configMapName := util.GetPrometheusConfigMapName(app)
+
+	// Pre-create a ConfigMap WITHOUT the LabelCreatedBySparkOperator label,
+	// simulating a ConfigMap created by a previous version of the operator.
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: app.Namespace,
+			Labels: map[string]string{
+				"some-other-label": "should-be-preserved",
+			},
+		},
+		Data: map[string]string{
+			"old-key": "old-value",
+		},
+	}
+
+	underlying := fake.NewFakeClient(existingCM)
+
+	// Wrap the fake client to simulate a label-filtered informer cache:
+	// Get returns NotFound for ConfigMaps that lack LabelCreatedBySparkOperator,
+	// forcing the code through the Create -> AlreadyExists -> Patch path.
+	filtered := &filteredCacheClient{
+		Client:        underlying,
+		requiredLabel: common.LabelCreatedBySparkOperator,
+		requiredValue: "true",
+	}
+
+	err := configPrometheusMonitoring(context.TODO(), app, filtered)
+	assert.NoError(t, err, "configPrometheusMonitoring should handle pre-existing ConfigMap without label")
+
+	// Read back from the underlying (unfiltered) client to verify the patch was applied.
+	updatedCM := &corev1.ConfigMap{}
+	err = underlying.Get(context.TODO(), client.ObjectKeyFromObject(existingCM), updatedCM)
+	assert.NoError(t, err, "failed to get updated ConfigMap")
+
+	assert.Equal(t, "true", updatedCM.Labels[common.LabelCreatedBySparkOperator],
+		"Pre-existing ConfigMap should have LabelCreatedBySparkOperator added after upgrade")
+
+	assert.Equal(t, "should-be-preserved", updatedCM.Labels["some-other-label"],
+		"Merge patch should preserve pre-existing labels")
+
+	assert.Contains(t, updatedCM.Data, common.MetricsPropertiesKey,
+		"ConfigMap data should be updated with metrics properties")
 }


### PR DESCRIPTION
## Purpose of this PR

Currently the operator is vulnerable to OOMKill via controller-runtime informer cache flooding.

The `ByObject` cache config in `cmd/operator/controller/start.go` lists `&corev1.ConfigMap{}: {}` with an explicitly **empty** config — no label selector, no field selector, no namespace restriction. This creates an unfiltered cluster-wide ConfigMap informer that caches ALL ConfigMaps in the cluster.

In contrast, Pods in the same `ByObject` map already correctly use a `LaunchedBySparkOperator` label selector. ConfigMaps had no such protection.

A user with permissions to create ConfigMaps can OOMKill the operator (512Mi limit) by pre-loading large ConfigMaps (~900KB each) across multiple namespaces. The unfiltered informer caches all of them, exceeding the memory limit.

**Proposed changes:**

- Add `LabelCreatedBySparkOperator` label selector to the existing `ByObject[ConfigMap]` cache entry, restricting the informer to only cache operator-managed ConfigMaps. This follows the same pattern already used for Pods.
- Add `LabelCreatedBySparkOperator` label to `buildPrometheusConfigMap()` so Prometheus monitoring ConfigMaps pass through the filtered cache.
- Handle the upgrade path: existing Prometheus ConfigMaps created before this fix (without the label) are gracefully updated with the label instead of causing `AlreadyExists` errors when the filtered cache returns `NotFound` for unlabeled ConfigMaps.
- Propagate the label during ConfigMap updates, not just creation.
- Add test coverage for the label assertion on all existing test cases and a new upgrade scenario test.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Without this fix, any user with permissions to create ConfigMaps can OOMKill the operator by pre-loading large ConfigMaps (~900KB each) across multiple namespaces. The unfiltered cluster-wide ConfigMap informer caches all of them, exceeding the 512Mi memory limit (Exit Code 137). Adding a label selector restricts the cache to only operator-managed ConfigMaps, matching the existing pattern used for Pods.

The upgrade path must also be handled because Prometheus ConfigMaps created by previous operator versions lack the new label. After the upgrade, these ConfigMaps become invisible to the filtered cache (`client.Get` returns `NotFound`), but still exist in the cluster (`client.Create` returns `AlreadyExists`). The fix catches this case and updates the existing ConfigMap with the label.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes