### PR TITLE
fix(crd): Add missing SparkConnect CRD resource and patches to kustomization

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,6 +4,7 @@
 resources:
 - bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
 - bases/sparkoperator.k8s.io_sparkapplications.yaml
+- bases/sparkoperator.k8s.io_sparkconnects.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
@@ -11,12 +12,14 @@ patches:
 # patches here are for enabling the conversion webhook for each CRD
 - path: patches/webhook_in_sparkapplications.yaml
 - path: patches/webhook_in_scheduledsparkapplications.yaml
+- path: patches/webhook_in_sparkconnects.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- path: patches/cainjection_in_scheduledsparkapplications.yaml
 #- path: patches/cainjection_in_sparkapplications.yaml
+#- path: patches/cainjection_in_sparkconnects.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section

--- a/config/crd/patches/cainjection_in_sparkconnects.yaml
+++ b/config/crd/patches/cainjection_in_sparkconnects.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+  name: sparkconnects.sparkoperator.k8s.io

--- a/config/crd/patches/webhook_in_sparkconnects.yaml
+++ b/config/crd/patches/webhook_in_sparkconnects.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sparkconnects.sparkoperator.k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1


### PR DESCRIPTION
## Purpose of this PR

The `config/crd/kustomization.yaml` was missing the SparkConnect CRD resource and its corresponding webhook and CA injection patches. This caused a significant feature gap where Kustomize users could not access SparkConnect features (Spark 3.4+), despite the base CRD manifest, controller reconciler, and admission webhooks all being in place.

This is a follow-up to PR #2820, which fixed the duplicate webhook patch and added missing ScheduledSparkApplication patches.

**Proposed changes:**
- Add `bases/sparkoperator.k8s.io_sparkconnects.yaml` to the `resources` list in `config/crd/kustomization.yaml`
- Create `patches/webhook_in_sparkconnects.yaml` to enable conversion webhook for the SparkConnect CRD
- Create `patches/cainjection_in_sparkconnects.yaml` to enable cert-manager CA injection for the SparkConnect CRD
- Add both patches to `kustomization.yaml` under the appropriate webhook and certmanager sections

## Change Category
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale
The SparkConnect CRD base manifest (`bases/sparkoperator.k8s.io_sparkconnects.yaml`) already exists and is generated by `controller-gen`. The controller registers a reconciler for SparkConnect in `cmd/operator/controller/start.go`, and the webhook server registers both mutating and validating admission hooks for SparkConnect in `cmd/operator/webhook/start.go` and `config/webhook/manifests.yaml`. However, the Kustomize configuration never included this CRD, meaning `kustomize build config/crd` only produced 2 CRDs instead of the expected 3. This brings Kustomize deployments to full parity with Helm.

## Checklist
- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.