### PR TITLE
fix: include user-defined ports in driver Service

### DIFF
--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -453,6 +453,7 @@ func (r *Reconciler) createDriverIngressServiceFromConfiguration(
 
 // buildDriverServicePorts builds the ServicePort list for a driver Service,
 // including the primary port and any user-defined ports from spec.driver.ports.
+// User-defined ports that collide with the primary port by name or number are skipped.
 func buildDriverServicePorts(app *v1beta2.SparkApplication, portName string, port int32, targetPort int32) []corev1.ServicePort {
 	ports := []corev1.ServicePort{
 		{
@@ -465,13 +466,26 @@ func buildDriverServicePorts(app *v1beta2.SparkApplication, portName string, por
 		},
 	}
 
+	usedNames := map[string]struct{}{portName: {}}
+	usedPorts := map[int32]struct{}{port: {}}
+
 	for _, p := range app.Spec.Driver.Ports {
+		if _, exists := usedNames[p.Name]; exists {
+			continue
+		}
+		if _, exists := usedPorts[p.ContainerPort]; exists {
+			continue
+		}
+
 		ports = append(ports, corev1.ServicePort{
 			Name:       p.Name,
 			Port:       p.ContainerPort,
 			TargetPort: intstr.FromInt32(p.ContainerPort),
 			Protocol:   corev1.Protocol(p.Protocol),
 		})
+
+		usedNames[p.Name] = struct{}{}
+		usedPorts[p.ContainerPort] = struct{}{}
 	}
 
 	return ports

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -320,16 +320,7 @@ func (r *Reconciler) createDriverIngressService(
 			OwnerReferences: []metav1.OwnerReference{util.GetOwnerReference(app)},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name: portName,
-					Port: port,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: targetPort,
-					},
-				},
-			},
+			Ports: buildDriverServicePorts(app, portName, port, targetPort),
 			Selector: map[string]string{
 				common.LabelSparkAppName: app.Name,
 				common.LabelSparkRole:    common.SparkRoleDriver,
@@ -458,4 +449,30 @@ func (r *Reconciler) createDriverIngressServiceFromConfiguration(
 	serviceAnnotations := getDriverIngressServiceAnnotations(driverIngressConfiguration)
 	serviceLabels := getDriverIngressServiceLabels(driverIngressConfiguration)
 	return r.createDriverIngressService(ctx, app, portName, port, port, serviceName, serviceType, serviceAnnotations, serviceLabels)
+}
+
+// buildDriverServicePorts builds the ServicePort list for a driver Service,
+// including the primary port and any user-defined ports from spec.driver.ports.
+func buildDriverServicePorts(app *v1beta2.SparkApplication, portName string, port int32, targetPort int32) []corev1.ServicePort {
+	ports := []corev1.ServicePort{
+		{
+			Name: portName,
+			Port: port,
+			TargetPort: intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: targetPort,
+			},
+		},
+	}
+
+	for _, p := range app.Spec.Driver.Ports {
+		ports = append(ports, corev1.ServicePort{
+			Name:       p.Name,
+			Port:       p.ContainerPort,
+			TargetPort: intstr.FromInt32(p.ContainerPort),
+			Protocol:   corev1.Protocol(p.Protocol),
+		})
+	}
+
+	return ports
 }

--- a/internal/controller/sparkapplication/driveringress_test.go
+++ b/internal/controller/sparkapplication/driveringress_test.go
@@ -411,3 +411,94 @@ func TestCreateDriverIngressService(t *testing.T) {
 		testFn(test, t)
 	}
 }
+
+func TestBuildDriverServicePorts(t *testing.T) {
+	tests := []struct {
+		name          string
+		app           *v1beta2.SparkApplication
+		portName      string
+		port          int32
+		targetPort    int32
+		expectedPorts []corev1.ServicePort
+	}{
+		{
+			name:       "no user-defined ports",
+			app:        &v1beta2.SparkApplication{},
+			portName:   "spark-ui",
+			port:       4040,
+			targetPort: 4040,
+			expectedPorts: []corev1.ServicePort{
+				{Name: "spark-ui", Port: 4040, TargetPort: intstr.FromInt32(4040)},
+			},
+		},
+		{
+			name: "user-defined ports appended",
+			app: &v1beta2.SparkApplication{
+				Spec: v1beta2.SparkApplicationSpec{
+					Driver: v1beta2.DriverSpec{
+						Ports: []v1beta2.Port{
+							{Name: "metrics", ContainerPort: 9090, Protocol: "TCP"},
+							{Name: "debug", ContainerPort: 5005, Protocol: "TCP"},
+						},
+					},
+				},
+			},
+			portName:   "spark-ui",
+			port:       4040,
+			targetPort: 4040,
+			expectedPorts: []corev1.ServicePort{
+				{Name: "spark-ui", Port: 4040, TargetPort: intstr.FromInt32(4040)},
+				{Name: "metrics", Port: 9090, TargetPort: intstr.FromInt32(9090), Protocol: "TCP"},
+				{Name: "debug", Port: 5005, TargetPort: intstr.FromInt32(5005), Protocol: "TCP"},
+			},
+		},
+		{
+			name: "duplicate port number skipped",
+			app: &v1beta2.SparkApplication{
+				Spec: v1beta2.SparkApplicationSpec{
+					Driver: v1beta2.DriverSpec{
+						Ports: []v1beta2.Port{
+							{Name: "custom-ui", ContainerPort: 4040, Protocol: "TCP"},
+						},
+					},
+				},
+			},
+			portName:   "spark-ui",
+			port:       4040,
+			targetPort: 4040,
+			expectedPorts: []corev1.ServicePort{
+				{Name: "spark-ui", Port: 4040, TargetPort: intstr.FromInt32(4040)},
+			},
+		},
+		{
+			name: "duplicate port name skipped",
+			app: &v1beta2.SparkApplication{
+				Spec: v1beta2.SparkApplicationSpec{
+					Driver: v1beta2.DriverSpec{
+						Ports: []v1beta2.Port{
+							{Name: "spark-ui", ContainerPort: 9090, Protocol: "TCP"},
+						},
+					},
+				},
+			},
+			portName:   "spark-ui",
+			port:       4040,
+			targetPort: 4040,
+			expectedPorts: []corev1.ServicePort{
+				{Name: "spark-ui", Port: 4040, TargetPort: intstr.FromInt32(4040)},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDriverServicePorts(tc.app, tc.portName, tc.port, tc.targetPort)
+			assert.Equal(t, len(tc.expectedPorts), len(got), "unexpected number of ports")
+			for i, expected := range tc.expectedPorts {
+				assert.Equal(t, expected.Name, got[i].Name)
+				assert.Equal(t, expected.Port, got[i].Port)
+				assert.Equal(t, expected.TargetPort.IntVal, got[i].TargetPort.IntVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- User-defined ports in `spec.driver.ports` are correctly added to driver pod containers via the webhook, but the generated driver Service only includes the Spark UI port (4040)
- This makes custom ports (metrics endpoints, debug ports) unreachable via the Service, breaking service mesh strict mode and custom monitoring setups
- Extracted port list construction into `buildDriverServicePorts()` which appends `spec.driver.ports` entries alongside the primary Spark UI port

Fixes #2891

## Reproduction & Verification

Tested on a Kind cluster with spark-operator built from this branch:

**Before (bug):**
```
$ kubectl get svc port-test-ui-svc -o jsonpath='{.spec.ports[*].name}'
spark-driver-ui-port                          # only 4040
```

**After (fix):**
```
$ kubectl get svc port-test-ui-svc -o jsonpath='{.spec.ports[*].name}'
spark-driver-ui-port custom-metrics debug-port   # 4040 + 9090 + 5005
```

## Test plan

- [x] Verified on Kind cluster: custom driver ports now appear in generated Service
- [x] `go build ./...` passes
- [ ] Existing unit tests pass
- [ ] CI checks pass