### PR TITLE
fix(rbac): Replace hardcoded namespace: default with namespace: system

### DIFF
--- a/config/rbac/spark-application-rbac.yaml
+++ b/config/rbac/spark-application-rbac.yaml
@@ -17,12 +17,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: spark-operator-spark
-  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: default
   name: spark-role
 rules:
 - apiGroups:
@@ -46,11 +44,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: spark-role-binding
-  namespace: default
 subjects:
 - kind: ServiceAccount
   name: spark-operator-spark
-  namespace: default
 roleRef:
   kind: Role
   name: spark-role


### PR DESCRIPTION
## Purpose of this PR

The `config/rbac/spark-application-rbac.yaml` file hardcodes `namespace: default` in its ServiceAccount, Role, RoleBinding, and RoleBinding subjects. This locks deployments to the `default` namespace and prevents deployers from controlling the target namespace via Kustomize, Helm, or `kubectl apply -n`.

**Proposed changes:**

- Remove `namespace: default` from ServiceAccount metadata
- Remove `namespace: default` from Role metadata
- Remove `namespace: default` from RoleBinding metadata
- Remove `namespace: default` from RoleBinding subjects

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Hardcoding `namespace: default` breaks multi-tenant and custom-namespace installations. Base manifests should omit explicit namespace fields and let the deployer decide, which is the standard Kubernetes/kubebuilder convention.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.