### PR TITLE
Add spark_application_submit_latency_seconds metric

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -115,12 +115,13 @@ var (
 	kubeAPIBurst int
 
 	// Metrics
-	enableMetrics                 bool
-	metricsBindAddress            string
-	metricsEndpoint               string
-	metricsPrefix                 string
-	metricsLabels                 []string
-	metricsJobStartLatencyBuckets []float64
+	enableMetrics                  bool
+	metricsBindAddress             string
+	metricsEndpoint                string
+	metricsPrefix                  string
+	metricsLabels                  []string
+	metricsJobSubmitLatencyBuckets []float64
+	metricsJobStartLatencyBuckets  []float64
 
 	healthProbeBindAddress                      string
 	pprofBindAddress                            string
@@ -203,6 +204,7 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&metricsEndpoint, "metrics-endpoint", "/metrics", "Metrics endpoint.")
 	command.Flags().StringVar(&metricsPrefix, "metrics-prefix", "", "Prefix for the metrics.")
 	command.Flags().StringSliceVar(&metricsLabels, "metrics-labels", []string{}, "Labels to be added to the metrics.")
+	command.Flags().Float64SliceVar(&metricsJobSubmitLatencyBuckets, "metrics-job-submit-latency-buckets", []float64{0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256}, "Buckets for the job submit latency histogram.")
 	command.Flags().Float64SliceVar(&metricsJobStartLatencyBuckets, "metrics-job-start-latency-buckets", []float64{30, 60, 90, 120, 150, 180, 210, 240, 270, 300}, "Buckets for the job start latency histogram.")
 
 	command.Flags().StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -455,7 +457,7 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 	var sparkApplicationMetrics *metrics.SparkApplicationMetrics
 	var sparkExecutorMetrics *metrics.SparkExecutorMetrics
 	if enableMetrics {
-		sparkApplicationMetrics = metrics.NewSparkApplicationMetrics(metricsPrefix, metricsLabels, metricsJobStartLatencyBuckets)
+		sparkApplicationMetrics = metrics.NewSparkApplicationMetrics(metricsPrefix, metricsLabels, metricsJobSubmitLatencyBuckets, metricsJobStartLatencyBuckets)
 		sparkApplicationMetrics.Register()
 		sparkExecutorMetrics = metrics.NewSparkExecutorMetrics(metricsPrefix, metricsLabels)
 		sparkExecutorMetrics.Register()

--- a/internal/metrics/sparkapplication_metrics.go
+++ b/internal/metrics/sparkapplication_metrics.go
@@ -29,9 +29,10 @@ import (
 )
 
 type SparkApplicationMetrics struct {
-	prefix                 string
-	labels                 []string
-	jobStartLatencyBuckets []float64
+	prefix                  string
+	labels                  []string
+	jobSubmitLatencyBuckets []float64
+	jobStartLatencyBuckets  []float64
 
 	count                 *prometheus.CounterVec
 	submitCount           *prometheus.CounterVec
@@ -43,11 +44,14 @@ type SparkApplicationMetrics struct {
 	successExecutionTimeSeconds *prometheus.SummaryVec
 	failureExecutionTimeSeconds *prometheus.SummaryVec
 
+	submitLatencySeconds          *prometheus.SummaryVec
+	submitLatencySecondsHistogram *prometheus.HistogramVec
+
 	startLatencySeconds          *prometheus.SummaryVec
 	startLatencySecondsHistogram *prometheus.HistogramVec
 }
 
-func NewSparkApplicationMetrics(prefix string, labels []string, jobStartLatencyBuckets []float64) *SparkApplicationMetrics {
+func NewSparkApplicationMetrics(prefix string, labels []string, jobSubmitLatencyBuckets []float64, jobStartLatencyBuckets []float64) *SparkApplicationMetrics {
 	validLabels := make([]string, 0, len(labels))
 	for _, label := range labels {
 		validLabel := util.CreateValidMetricNameLabel("", label)
@@ -55,9 +59,10 @@ func NewSparkApplicationMetrics(prefix string, labels []string, jobStartLatencyB
 	}
 
 	return &SparkApplicationMetrics{
-		prefix:                 prefix,
-		labels:                 validLabels,
-		jobStartLatencyBuckets: jobStartLatencyBuckets,
+		prefix:                  prefix,
+		labels:                  validLabels,
+		jobSubmitLatencyBuckets: jobSubmitLatencyBuckets,
+		jobStartLatencyBuckets:  jobStartLatencyBuckets,
 
 		count: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -113,6 +118,22 @@ func NewSparkApplicationMetrics(prefix string, labels []string, jobStartLatencyB
 			},
 			validLabels,
 		),
+		submitLatencySeconds: prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Name:       util.CreateValidMetricNameLabel(prefix, common.MetricSparkApplicationSubmitLatencySeconds),
+				Help:       "Spark App Submit Latency from creation to submitted state",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+			},
+			validLabels,
+		),
+		submitLatencySecondsHistogram: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    util.CreateValidMetricNameLabel(prefix, common.MetricSparkApplicationSubmitLatencySecondsHistogram),
+				Help:    "Spark App Submit Latency counts in buckets from creation to submitted state",
+				Buckets: jobSubmitLatencyBuckets,
+			},
+			validLabels,
+		),
 		startLatencySeconds: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Name: util.CreateValidMetricNameLabel(prefix, common.MetricSparkApplicationStartLatencySeconds),
@@ -155,6 +176,12 @@ func (m *SparkApplicationMetrics) Register() {
 	}
 	if err := metrics.Registry.Register(m.failureExecutionTimeSeconds); err != nil {
 		logger.Error(err, "Failed to register spark application metric", "name", common.MetricSparkApplicationFailureExecutionTimeSeconds)
+	}
+	if err := metrics.Registry.Register(m.submitLatencySeconds); err != nil {
+		logger.Error(err, "Failed to register spark application metric", "name", common.MetricSparkApplicationSubmitLatencySeconds)
+	}
+	if err := metrics.Registry.Register(m.submitLatencySecondsHistogram); err != nil {
+		logger.Error(err, "Failed to register spark application metric", "name", common.MetricSparkApplicationSubmitLatencySecondsHistogram)
 	}
 	if err := metrics.Registry.Register(m.startLatencySeconds); err != nil {
 		logger.Error(err, "Failed to register spark application metric", "name", common.MetricSparkApplicationStartLatencySeconds)
@@ -200,6 +227,7 @@ func (m *SparkApplicationMetrics) HandleSparkApplicationUpdate(oldApp *v1beta2.S
 		m.incCount(newApp)
 	case v1beta2.ApplicationStateSubmitted:
 		m.incSubmitCount(newApp)
+		m.observeSubmitLatencySeconds(newApp)
 	case v1beta2.ApplicationStateFailedSubmission:
 		m.incFailedSubmissionCount(newApp)
 	case v1beta2.ApplicationStateRunning:
@@ -339,6 +367,29 @@ func (m *SparkApplicationMetrics) observeFailureExecutionTimeSeconds(app *v1beta
 	duration := app.Status.TerminationTime.Sub(app.Status.LastSubmissionAttemptTime.Time)
 	observer.Observe(duration.Seconds())
 	logger.V(1).Info("Observed spark application failure execution time seconds", "name", app.Name, "namespace", app.Namespace, "metric", common.MetricSparkApplicationFailureExecutionTimeSeconds, "labels", labels, "value", duration.Seconds())
+}
+
+func (m *SparkApplicationMetrics) observeSubmitLatencySeconds(app *v1beta2.SparkApplication) {
+	// Only export the spark application submit latency seconds metric for the first time
+	if app.Status.SubmissionAttempts != 1 {
+		return
+	}
+
+	labels := m.getMetricLabels(app)
+	latency := time.Since(app.CreationTimestamp.Time)
+	if observer, err := m.submitLatencySeconds.GetMetricWith(labels); err != nil {
+		logger.Error(err, "Failed to collect metric for SparkApplication", "name", app.Name, "namespace", app.Namespace, "metric", common.MetricSparkApplicationSubmitLatencySeconds, "labels", labels)
+	} else {
+		observer.Observe(latency.Seconds())
+		logger.V(1).Info("Observed spark application submit latency seconds", "name", app.Name, "namespace", app.Namespace, "metric", common.MetricSparkApplicationSubmitLatencySeconds, "labels", labels, "value", latency.Seconds())
+	}
+
+	if histogram, err := m.submitLatencySecondsHistogram.GetMetricWith(labels); err != nil {
+		logger.Error(err, "Failed to collect metric for SparkApplication", "name", app.Name, "namespace", app.Namespace, "metric", common.MetricSparkApplicationSubmitLatencySecondsHistogram, "labels", labels)
+	} else {
+		histogram.Observe(latency.Seconds())
+		logger.V(1).Info("Observed spark application submit latency seconds", "name", app.Name, "namespace", app.Namespace, "metric", common.MetricSparkApplicationSubmitLatencySecondsHistogram, "labels", labels, "value", latency.Seconds())
+	}
 }
 
 func (m *SparkApplicationMetrics) observeStartLatencySeconds(app *v1beta2.SparkApplication) {

--- a/pkg/common/metrics.go
+++ b/pkg/common/metrics.go
@@ -34,6 +34,10 @@ const (
 
 	MetricSparkApplicationFailureExecutionTimeSeconds = "spark_application_failure_execution_time_seconds"
 
+	MetricSparkApplicationSubmitLatencySeconds = "spark_application_submit_latency_seconds"
+
+	MetricSparkApplicationSubmitLatencySecondsHistogram = "spark_application_submit_latency_seconds_histogram"
+
 	MetricSparkApplicationStartLatencySeconds = "spark_application_start_latency_seconds"
 
 	MetricSparkApplicationStartLatencySecondsHistogram = "spark_application_start_latency_seconds_histogram"


### PR DESCRIPTION
## Purpose of this PR

Add `spark_application_submit_latency_seconds` metric to measure operator processing time (creation → submission), enabling separation of operator performance from infrastructure delays.

**Proposed changes:**

- Add `spark_application_submit_latency_seconds` (Summary) and histogram metrics
- Add `--metrics-job-submit-latency-buckets` flag (default: `0.5,1,2,4,8,16,32,64,128,256`)
- Observe metric on transition to `Submitted` state (first attempt only)

## Change Category

- [x] Feature (non-breaking change which adds functionality)

## Rationale

### The Problem

The existing `spark_application_start_latency_seconds` measures Creation → Running state, which includes external factors beyond operator control: K8s scheduler delays, resource availability, queue capacity (Yunikorn), node provisioning, image pulls, and pod initialization.

When start latency is high, we cannot determine if the operator is slow or if infrastructure is constrained.

### The Solution

`spark_application_submit_latency_seconds` measures **only operator work** (creation → submitted state), enabling:

- **Root cause analysis**: Separate operator bottlenecks from infrastructure issues
- **Calculate external factors**: `start_latency - submit_latency = K8s scheduling + resources`
- **Accurate operator SLA monitoring**: Track only what the operator controls

**Example:**
```
submit_latency = 2s, start_latency = 5min → Infrastructure issue (scale cluster)
submit_latency = 4min, start_latency = 5min → Operator issue (tune operator)
```

**Prometheus queries:**
```promql
# p99 submit latency
histogram_quantile(0.99, rate(spark_application_submit_latency_seconds_histogram_bucket[5m]))

# External infrastructure delay
histogram_quantile(0.99, rate(spark_application_start_latency_seconds_histogram_bucket[5m]))
- histogram_quantile(0.99, rate(spark_application_submit_latency_seconds_histogram_bucket[5m]))
```

## Implementation Details

**Recording logic:**
- Observed when SparkApplication transitions to `Submitted` state
- Only on first submission (`SubmissionAttempts == 1`) to avoid skewed data on retries
- Follows pattern from PR #852 (`spark_application_start_latency_seconds`)

**Configuration:**
```bash
--metrics-job-submit-latency-buckets=0.5,1,2,4,8,16,32,64,128,256
```

**Files modified:**
- `cmd/operator/controller/start.go` - Added flag and configuration
- `internal/metrics/sparkapplication_metrics.go` - Added metric tracking
- `pkg/common/metrics.go` - Added metric name constants

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

## Additional Notes

Related: PR #852 (start latency), PR #2817 (metrics-labels flag), PR #2450 (latency buckets flag)
