### PR TITLE
fix(rbac): Tighten controller RBAC markers to enforce least privilege

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,11 +8,11 @@ rules:
   - configmaps
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
   - update
+  - watch
 - resources:
   - events
   verbs:
@@ -20,25 +20,13 @@ rules:
   - patch
   - update
 - resources:
-  - nodes
-  verbs:
-  - get
-- resources:
   - pods
   verbs:
   - create
   - delete
-  - deletecollection
   - get
   - list
-  - patch
   - update
-  - watch
-- resources:
-  - resourcequotas
-  verbs:
-  - get
-  - list
   - watch
 - resources:
   - services
@@ -47,6 +35,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -64,37 +53,34 @@ rules:
   - create
   - delete
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - sparkoperator.k8s.io
   resources:
   - scheduledsparkapplications
-  - sparkapplications
   - sparkconnects
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - sparkoperator.k8s.io
   resources:
   - scheduledsparkapplications/finalizers
+  - scheduledsparkapplications/status
   - sparkapplications/finalizers
+  - sparkapplications/status
+  - sparkconnects/finalizers
+  - sparkconnects/status
   verbs:
   - update
 - apiGroups:
   - sparkoperator.k8s.io
   resources:
-  - scheduledsparkapplications/status
-  - sparkapplications/status
-  - sparkconnects/status
+  - sparkapplications
   verbs:
+  - create
+  - delete
   - get
-  - patch
-  - update
+  - list
+  - watch

--- a/internal/controller/scheduledsparkapplication/controller.go
+++ b/internal/controller/scheduledsparkapplication/controller.go
@@ -103,8 +103,9 @@ func NewReconciler(
 	}
 }
 
-// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=scheduledsparkapplications,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=scheduledsparkapplications/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications,verbs=create;list;delete
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=scheduledsparkapplications,verbs=get;list;watch
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=scheduledsparkapplications/status,verbs=update
 // +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=scheduledsparkapplications/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -108,17 +108,15 @@ func NewReconciler(
 	}
 }
 
-// +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update;patch;delete;deletecollection
-// +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;create;update;patch;delete
-// +kubebuilder:rbac:groups=,resources=services,verbs=get;create;delete
-// +kubebuilder:rbac:groups=,resources=nodes,verbs=get
+// +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=,resources=services,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups=,resources=events,verbs=create;update;patch
-// +kubebuilder:rbac:groups=,resources=resourcequotas,verbs=get;list;watch
-// +kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;create;update;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;create;update;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
-// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications/status,verbs=update
 // +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -182,12 +182,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 		Complete(r)
 }
 
-// +kubebuilder:rbac:groups=,resources=events,verbs=create;update;patch
-// +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;create;update;delete
-// +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=,resources=services,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=,resources=services,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects,verbs=get;list;watch
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects/status,verbs=update
+// +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkconnects/finalizers,verbs=update
 
 // Reconcile implements reconcile.TypedReconciler.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile.Result, error) {


### PR DESCRIPTION
## Purpose of this PR

The controller's ClusterRole (`config/rbac/role.yaml`) granted significantly more permissions than the controller code actually requires. This PR audits every `+kubebuilder:rbac` marker across all three controllers against the actual Go code (`r.client.*` calls, `Watches`, `Owns`, `controllerutil.*` usage, `blockOwnerDeletion` owner references, and spark-submit subprocess behavior), removes excess verbs, removes entire resource blocks that are never accessed, and adds missing permissions that were previously absent.

**Proposed changes:**

- Tighten `+kubebuilder:rbac` markers in `sparkapplication/controller.go`
- Tighten `+kubebuilder:rbac` markers in `scheduledsparkapplication/controller.go`
- Tighten `+kubebuilder:rbac` markers in `sparkconnect/reconciler.go`
- Regenerate `config/rbac/role.yaml` via `make manifests` to reflect all marker changes

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The existing RBAC markers were scaffolded with overly broad defaults and never pruned to match actual controller behavior. This violates the principle of least privilege. Each change was verified against the Go source code:

**Removed (not used by any controller):**

- **`nodes: get`** and **`resourcequotas: get;list;watch`**: No `r.client.Get/List` calls for these resources exist anywhere in the controller code.
- **`pods: deletecollection`**: The controller deletes pods individually via `r.client.Delete(ctx, pod)` in `deleteDriverPod()`, never via `DeleteAllOf`.
- **`pods: patch`**: No `r.client.Patch(ctx, pod, ...)` calls exist. Pods are created (via spark-submit), updated (via `controllerutil.CreateOrUpdate` in SparkConnect), or deleted, but never patched.
- **`configmaps: delete`**: ConfigMaps are created/updated/patched (`monitoring_config.go:71`) but never deleted. Cleanup relies on Kubernetes GC via owner references.
- **`sparkapplications: update;patch`** (SparkApplication controller): The controller only reads and deletes SparkApplications. Spec mutations never occur; only `Status().Update()` is used via the `/status` subresource.
- **`sparkapplications: create`** (SparkApplication controller): Moved to ScheduledSparkApplication controller where creation actually happens (`controller.go:290`).
- **`sparkconnects: create;update;patch;delete`**: The SparkConnect controller watches/reconciles the CR but never mutates it; it only calls `Status().Update()`.
- **`events: create;update;patch`** (SparkConnect): The SparkConnect reconciler has no `r.recorder.Event`/`Eventf` calls; only the SparkApplication controller records events.
- **`ingresses: list;watch`**: No `Watches(&Ingress{})` or `Owns(&Ingress{})` in `SetupWithManager`. Controller only performs direct `Get`/`Create`/`Update`/`Delete` in `driveringress.go`.
- **`/status: get;patch`** (all controllers): No `Status().Get()` or `Status().Patch()` calls exist. Only `Status().Update()` is used.
- **`/finalizers: patch`** (ScheduledSparkApplication): No direct finalizer manipulation (`AddFinalizer`/`RemoveFinalizer`). Only `update` is retained (see below).

**Added (previously missing):**

- **`services: update;patch`** (SparkApplication controller): `r.client.Update(ctx, existing)` on Services in `driveringress.go:376` requires `update`. The `spark-submit` subprocess (Spark's Java Kubernetes client) performs server-side apply when creating driver headless services, which is a PATCH operation requiring the `patch` verb. The original marker had only `get;create;delete`.
- **`configmaps: watch`** (SparkConnect controller): `Owns(&corev1.ConfigMap{})` in `SetupWithManager` requires informer `list`/`watch`.
- **`sparkapplications: create;list;delete`** (ScheduledSparkApplication controller): `r.client.Create` (line 290), `r.client.List` (line 415), `r.client.Delete` (line 343).
- **`sparkconnects/finalizers: update`** (SparkConnect controller): Required by Kubernetes admission check when `ctrl.SetControllerReference()` sets `blockOwnerDeletion: true` on owned ConfigMaps, Pods, and Services (lines 275, 448, 552).

**Retained with rationale:**

- **`/finalizers: update`** (all three controllers): None of the controllers use explicit `AddFinalizer`/`RemoveFinalizer` calls. However, all three create child objects with `blockOwnerDeletion: true` in owner references. Since Kubernetes 1.20 (GA), the API server enforces that the creating SA has `update` on the owner's `/finalizers` subresource when `blockOwnerDeletion` is set. Without this, child object creation fails with Forbidden.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

- All 45 controller unit tests pass (24 SparkApplication, 8 ScheduledSparkApplication, 13 SparkConnect) with 0 failures and 0 regressions.
- `make manifests` was run and confirmed idempotent (no drift between markers and generated `role.yaml`).
- `go build ./...`, `go vet ./...`, and `go fmt ./...` all pass cleanly.
- The `services: patch` addition was validated via Helm E2E tests on a Kind cluster — the `namespace filtering` test fails with `403 Forbidden: cannot patch resource "services"` without it, confirming spark-submit's server-side apply requires this verb.
- To verify locally:

```bash
make setup-envtest
KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.32.0-darwin-arm64" \
  go test ./internal/controller/sparkapplication/... \
          ./internal/controller/scheduledsparkapplication/... \
          ./internal/controller/sparkconnect/... \
          -v -count=1
```