### PR TITLE
feat(pdb): Add PodDisruptionBudget Kustomize resource for controller-manager

### DIFF
--- a/config/pdb/kustomization.yaml
+++ b/config/pdb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- poddisruptionbudget.yaml

--- a/config/pdb/poddisruptionbudget.yaml
+++ b/config/pdb/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: controller-manager-pdb
+  labels:
+    app.kubernetes.io/name: spark-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  # Keeps at least 1 controller-manager pod available with only 1 replica
+  # Run controller-manager with >=2 replicas when applying this PDB
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->
Add a modular Kustomize PDB resource under `config/pdb/` to protect the controller-manager Deployment from voluntary disruptions during maintenance. The Helm chart already supports PDBs via `controller.podDisruptionBudget.enable` and `webhook.podDisruptionBudget.enable` (added in #2078). Kustomize deployments currently have no equivalent, leaving operators without resilience guarantees.

**Proposed changes:**

- Add `config/pdb/poddisruptionbudget.yaml`: PDB with `minAvailable: 1` targeting `control-plane: controller-manager`
- Add `config/pdb/kustomization.yaml`: Kustomization file referencing the PDB resource

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
## PDB Validation
1. Verify kustomize build renders a valid `policy/v1` PodDisruptionBudget:
```bash
kustomize build config/pdb
```
2. Create a Kind cluster and verify context:
```bash
kind create cluster --name pdb-test
kubectl cluster-info
```
3. Run server-side dry-run to validate the API server accepts the resource:
```bash
kustomize build config/pdb | kubectl apply --dry-run=server -f -
# Expected: poddisruptionbudget.policy/controller-manager-pdb created (server dry run)
```
4. Confirm no resource was persisted:
```bash
kubectl get pdb -n system
# Expected: No resources found in system namespace.
```
5. Clean up resources:
```bash
kind delete cluster --name pdb-test
```