### PR TITLE
sparkconnect: SIGTERM the foreground JVM in preStop instead of calling stop-connect-server.sh

### DIFF
--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -411,13 +411,25 @@ func (r *Reconciler) mutateServerPod(_ context.Context, conn *v1alpha1.SparkConn
 			},
 		)
 
+		// stop-connect-server.sh only works in daemon mode because it
+		// locates the JVM via the PID file that spark-daemon.sh writes.
+		// The operator runs the server with SPARK_NO_DAEMONIZE=true
+		// (foreground), so no PID file exists and the stop script fails
+		// with `no org.apache.spark.sql.connect.service.SparkConnectServer
+		// to stop`, leaving the JVM to be SIGKILLed at the end of the
+		// termination grace period without finalizing event logs.
+		//
+		// Send SIGTERM to the foreground JVM instead so Spark's shutdown
+		// hook runs (finalizes the .inprogress event log, closes the
+		// listener, etc.) and the pod exits cleanly. See
+		// kubeflow/spark-operator#2903.
 		container.Lifecycle = &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
 						"bash",
 						"-c",
-						"${SPARK_HOME}/sbin/stop-connect-server.sh",
+						"pkill -TERM -f org.apache.spark.sql.connect.service.SparkConnectServer || true",
 					},
 				},
 			},


### PR DESCRIPTION
## Description

The SparkConnect server container is started with `SPARK_NO_DAEMONIZE=true` (foreground mode), so `spark-daemon.sh` does not write the PID file that `${SPARK_HOME}/sbin/stop-connect-server.sh` uses to locate the process. The `preStop` hook therefore always fails with:

```
no org.apache.spark.sql.connect.service.SparkConnectServer to stop
```

The JVM is left to be SIGKILLed at the end of the termination grace period, event logs never finalize from `.inprogress`, the run shows as incomplete in Spark History Server, and any other shutdown hooks only run partially.

## Fix

Replace the `stop-connect-server.sh` invocation with a targeted `pkill -TERM` against the server class. That delivers SIGTERM to the foreground JVM, which triggers Spark's normal shutdown hook so event logs finalize and the listener bus drains before the container exits.

Fixes #2903.

## Test

- `go build ./internal/controller/sparkconnect/...` green.
- `go test ./internal/controller/sparkconnect/...` failure is pre-existing (envtest required) and unchanged by this PR (confirmed by stashing the diff and rerunning).

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>