### PR TITLE
feat(prometheus): Add Prometheus PodMonitor Kustomize resource

### DIFF
--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- podmonitor.yaml

--- a/config/prometheus/podmonitor.yaml
+++ b/config/prometheus/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: spark-operator-podmonitor
+  labels:
+    app.kubernetes.io/name: spark-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: spark-operator


### PR DESCRIPTION
## Purpose of this PR

Add a modular Kustomize PodMonitor resource under `config/prometheus/` to enable native Prometheus Operator integration for metrics scraping. The Helm chart already supports PodMonitor via `prometheus.podMonitor.create` (with configurable interval, scheme, and labels). Kustomize deployments currently have no equivalent, leaving operators without native Prometheus integration.

**Proposed changes:**

- Add `config/prometheus/podmonitor.yaml`: PodMonitor (`monitoring.coreos.com/v1`) with `podMetricsEndpoints` targeting port `metrics`, path `/metrics`, scheme `http`, and a broad selector (`app.kubernetes.io/name: spark-operator`) matching the Helm chart pattern to scrape both controller and webhook pods
- Add `config/prometheus/kustomization.yaml`: Kustomization file referencing the PodMonitor resource


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes
## PodMonitor Validation

1. Verify kustomize build renders a valid `monitoring.coreos.com/v1` PodMonitor:
```bash
Kustomize build config/prometheus
```
2. Create a Kind cluster and verify context:
```bash
kind create cluster --name prometheus-test kubectl cluster-info
```
3. Install the Prometheus Operator PodMonitor CRD as it's not built into Kubernetes:
```bash
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
```
4. Run server-side dry-run to validate the API server accepts the resource:
```bash
kustomize build config/prometheus | kubectl apply --dry-run=server -f -
#Expected: podmonitor.monitoring.coreos.com/spark-operator-podmonitor created (server dry run)
```
5. Confirm no resource was persisted:
```bash
kubectl get podmonitor -A
#Expected: No resources found
```

6. Clean up resources:
```bash
kind delete cluster --name prometheus-test
```
