### PR TITLE
fix: EmptyDir medium field is not forwarded to Spark configuration

### DIFF
--- a/examples/spark-pi-emptydir.yaml
+++ b/examples/spark-pi-emptydir.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: SparkApplication
+metadata:
+  name: spark-pi
+  namespace: default
+spec:
+  type: Scala
+  mode: cluster
+  image: docker.io/library/spark:4.0.1
+  imagePullPolicy: IfNotPresent
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples.jar
+  arguments:
+  - "5000"
+  sparkVersion: 4.0.1
+  volumes:
+    - name: spark-local-dir-1
+      emptyDir:
+        medium: Memory
+        sizeLimit: 1Gi
+  driver:
+    labels:
+      version: 4.0.0
+    cores: 1
+    memory: 512m
+    serviceAccount: spark-operator-spark
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      runAsGroup: 185
+      runAsUser: 185
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+    volumeMounts:
+          - mountPath: /datadir
+            name: spark-local-dir-1
+  executor:
+    labels:
+      version: 4.0.0
+    instances: 1
+    cores: 1
+    memory: 512m
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      runAsGroup: 185
+      runAsUser: 185
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+    volumeMounts:
+      - mountPath: /datadir
+        name: spark-local-dir-1

--- a/examples/spark-pi-emptydir.yaml
+++ b/examples/spark-pi-emptydir.yaml
@@ -50,8 +50,8 @@ spec:
       seccompProfile:
         type: RuntimeDefault
     volumeMounts:
-          - mountPath: /datadir
-            name: spark-local-dir-1
+      - mountPath: /datadir
+        name: spark-local-dir-1
   executor:
     labels:
       version: 4.0.0

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -550,6 +550,22 @@ func driverVolumeMountsOption(app *v1beta2.SparkApplication) ([]string, error) {
 					),
 				)
 			}
+			if volume.EmptyDir.Medium != corev1.StorageMediumDefault {
+				args = append(
+					args,
+					"--conf",
+					fmt.Sprintf(
+						"%s=%s",
+						fmt.Sprintf(
+							common.SparkKubernetesDriverVolumesOptionsTemplate,
+							common.VolumeTypeEmptyDir,
+							volume.Name,
+							"medium",
+						),
+						volume.EmptyDir.Medium,
+					),
+				)
+			}
 		case common.VolumeTypeHostPath:
 			args = append(
 				args,
@@ -890,6 +906,22 @@ func executorVolumeMountsOption(app *v1beta2.SparkApplication) ([]string, error)
 							"sizeLimit",
 						),
 						volume.EmptyDir.SizeLimit.String(),
+					),
+				)
+			}
+			if volume.EmptyDir.Medium != corev1.StorageMediumDefault {
+				args = append(
+					args,
+					"--conf",
+					fmt.Sprintf(
+						"%s=%s",
+						fmt.Sprintf(
+							common.SparkKubernetesExecutorVolumesOptionsTemplate,
+							common.VolumeTypeEmptyDir,
+							volume.Name,
+							"medium",
+						),
+						volume.EmptyDir.Medium,
 					),
 				)
 			}

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -231,6 +231,45 @@ func TestDriverVolumeMountsOption(t *testing.T) {
 					"10Gi"),
 			},
 		},
+		{
+			name: "emptydir volume with memory medium",
+			app: &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spark-emptydir-memory",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: fmt.Sprintf("%semptydir", common.SparkLocalDirVolumePrefix),
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+					},
+					Driver: v1beta2.DriverSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      fmt.Sprintf("%semptydir", common.SparkLocalDirVolumePrefix),
+									MountPath: "/tmp/scratch",
+									ReadOnly:  false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{
+				"--conf", fmt.Sprintf("%s=%s",
+					fmt.Sprintf(common.SparkKubernetesDriverVolumesMountPathTemplate, common.VolumeTypeEmptyDir, fmt.Sprintf("%semptydir", common.SparkLocalDirVolumePrefix)),
+					"/tmp/scratch"),
+				"--conf", fmt.Sprintf("%s=%s",
+					fmt.Sprintf(common.SparkKubernetesDriverVolumesOptionsTemplate, common.VolumeTypeEmptyDir, fmt.Sprintf("%semptydir", common.SparkLocalDirVolumePrefix), "medium"),
+					string(corev1.StorageMediumMemory)),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -494,4 +494,73 @@ var _ = Describe("Example SparkApplication", func() {
 			Expect(strings.Contains(string(bytes), "Pi is roughly 3")).To(BeTrue())
 		})
 	})
+
+	Context("spark-pi-emptydir-medium", func() {
+		ctx := context.Background()
+		path := filepath.Join("..", "..", "examples", "spark-pi-emptydir.yaml")
+		app := &v1beta2.SparkApplication{}
+
+		BeforeEach(func() {
+			By("Parsing SparkApplication from file")
+			file, err := os.Open(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).NotTo(BeNil())
+
+			decoder := yaml.NewYAMLOrJSONDecoder(file, 4096)
+			Expect(decoder.Decode(app)).To(Succeed())
+
+			By("Creating SparkApplication")
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			By("Deleting SparkApplication")
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+		})
+
+		It("should mount emptyDir with Memory medium on driver pod", func() {
+			By("Waiting for SparkApplication to complete")
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			Expect(waitForSparkApplicationCompleted(ctx, key)).NotTo(HaveOccurred())
+
+			By("Waiting for SparkApplication to complete")
+
+			checkVolumeAndMount := func(pod corev1.Pod, containerName string) {
+				volumeFound := false
+				for _, vol := range pod.Spec.Volumes {
+					if vol.Name == "spark-local-dir-1" {
+						volumeFound = true
+						Expect(vol.EmptyDir).NotTo(BeNil(), "pod %s: spark-local-dir-1 is not an emptyDir", pod.Name)
+						Expect(vol.EmptyDir.Medium).To(Equal(corev1.StorageMediumMemory), "pod %s", pod.Name)
+						break
+					}
+				}
+				Expect(volumeFound).To(BeTrue(), "pod %s: volume spark-local-dir-1 not found", pod.Name)
+
+				mountFound := false
+				for _, container := range pod.Spec.Containers {
+					if container.Name != containerName {
+						continue
+					}
+					for _, mount := range container.VolumeMounts {
+						if mount.Name == "spark-local-dir-1" {
+							mountFound = true
+							break
+						}
+					}
+				}
+				Expect(mountFound).To(BeTrue(), "pod %s: volumeMount spark-local-dir-1 not found in container %s", pod.Name, containerName)
+			}
+
+			By("Checking driver pod has spark-local-dir-1 with Memory medium and volumeMount")
+			driverPodName := util.GetDriverPodName(app)
+			driverPodKey := types.NamespacedName{Namespace: app.Namespace, Name: driverPodName}
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, driverPodKey, driverPod)).NotTo(HaveOccurred())
+			checkVolumeAndMount(*driverPod, common.SparkDriverContainerName)
+		})
+	})
 })

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -526,8 +526,6 @@ var _ = Describe("Example SparkApplication", func() {
 			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
 			Expect(waitForSparkApplicationCompleted(ctx, key)).NotTo(HaveOccurred())
 
-			By("Waiting for SparkApplication to complete")
-
 			checkVolumeAndMount := func(pod corev1.Pod, containerName string) {
 				volumeFound := false
 				for _, vol := range pod.Spec.Volumes {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

https://github.com/kubeflow/spark-operator/issues/2924

The `medium` field of an `emptyDir` volume was not forwarded to the Spark submission arguments, causing memory-backed volumes (`medium: Memory`) to be silently ignored.

- Medium field add to the driver and executor mounts option
- E2e test to verify it's correctly added with a simple manifest (`examples/spark-pi-emptydir.yaml`)

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

The Spark operator processes `emptyDir` volumes with the `spark-local-dir-` prefix by translating them into `--conf spark.kubernetes.{driver,executor}.volumes.emptyDir.<name>.options.*` arguments. The `sizeLimit` option was already handled, but `medium` was missing for executor and driver volumes.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly. (documentation let think it's already possible)
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

The unit test covers the driver (`TestDriverVolumeMountsOption`) with a `StorageMediumMemory` emptyDir. The e2e test (`spark-pi-emptydir-medium`) deploys a `SparkApplication` with a memory-backed local dir volume and asserts that the driver pod have the volume with `emptyDir.medium: Memory` and the corresponding `VolumeMount`.
