### PR TITLE
fix(sparkapplication): backfill terminationTime when missing so TTL applies

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -675,6 +675,8 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 		return ctrl.Result{}, nil
 	}
 
+	util.EnsureTerminationTimeForTerminalState(app)
+
 	if util.IsExpired(app) {
 		logger.Info("Deleting expired SparkApplication", "state", app.Status.AppState.State)
 		if err := r.client.Delete(ctx, app); err != nil {

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -60,6 +60,26 @@ func IsTerminated(app *v1beta2.SparkApplication) bool {
 		app.Status.AppState.State == v1beta2.ApplicationStateFailed
 }
 
+// EnsureTerminationTimeForTerminalState sets status.terminationTime when the app is
+// Completed or Failed but terminationTime was never recorded. Without this,
+// timeToLiveSeconds never applies because expiry uses terminationTime.
+//
+// If the app never recorded a driver execution (executionAttempts == 0) but did
+// attempt submission (submissionAttempts > 0), failure is tied to submission time
+// and we reuse lastSubmissionAttemptTime. Otherwise we use the current time so TTL
+// is not measured from an old submission after a long-running app.
+func EnsureTerminationTimeForTerminalState(app *v1beta2.SparkApplication) {
+	if !IsTerminated(app) || !app.Status.TerminationTime.IsZero() {
+		return
+	}
+	if app.Status.ExecutionAttempts == 0 && app.Status.SubmissionAttempts > 0 &&
+		!app.Status.LastSubmissionAttemptTime.IsZero() {
+		app.Status.TerminationTime = app.Status.LastSubmissionAttemptTime
+		return
+	}
+	app.Status.TerminationTime = metav1.Now()
+}
+
 // IsExpired returns whether the given SparkApplication is expired.
 func IsExpired(app *v1beta2.SparkApplication) bool {
 	// The application has no TTL defined and will never expire.

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -194,6 +194,94 @@ var _ = Describe("IsExpired", func() {
 	})
 })
 
+var _ = Describe("EnsureTerminationTimeForTerminalState", func() {
+	It("does nothing when not terminated", func() {
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				AppState: v1beta2.ApplicationState{State: v1beta2.ApplicationStateSubmitted},
+			},
+		}
+		util.EnsureTerminationTimeForTerminalState(app)
+		Expect(app.Status.TerminationTime.IsZero()).To(BeTrue())
+	})
+
+	It("does nothing when termination time is already set", func() {
+		t := metav1.NewTime(time.Now().Add(-time.Hour))
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				AppState:                    v1beta2.ApplicationState{State: v1beta2.ApplicationStateFailed},
+				TerminationTime:             t,
+				LastSubmissionAttemptTime: metav1.NewTime(time.Now()),
+			},
+		}
+		util.EnsureTerminationTimeForTerminalState(app)
+		Expect(app.Status.TerminationTime).To(Equal(t))
+	})
+
+	It("sets termination time from last submission when failed before any driver execution", func() {
+		submitAt := metav1.NewTime(time.Date(2026, 4, 26, 16, 40, 39, 0, time.UTC))
+		app := &v1beta2.SparkApplication{
+			Spec: v1beta2.SparkApplicationSpec{
+				TimeToLiveSeconds: ptr.To[int64](3600),
+			},
+			Status: v1beta2.SparkApplicationStatus{
+				AppState:                    v1beta2.ApplicationState{State: v1beta2.ApplicationStateFailed},
+				LastSubmissionAttemptTime: submitAt,
+				SubmissionAttempts:        1,
+				ExecutionAttempts:         0,
+			},
+		}
+		util.EnsureTerminationTimeForTerminalState(app)
+		Expect(app.Status.TerminationTime).To(Equal(submitAt))
+	})
+
+	It("uses current time when failed after driver execution even if last submission is old", func() {
+		oldSubmit := metav1.NewTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		before := time.Now()
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				AppState:                    v1beta2.ApplicationState{State: v1beta2.ApplicationStateFailed},
+				LastSubmissionAttemptTime: oldSubmit,
+				SubmissionAttempts:        1,
+				ExecutionAttempts:         1,
+			},
+		}
+		util.EnsureTerminationTimeForTerminalState(app)
+		Expect(app.Status.TerminationTime.Time.After(before.Add(-time.Second))).To(BeTrue())
+		Expect(time.Since(app.Status.TerminationTime.Time)).To(BeNumerically("<", 5*time.Second))
+	})
+
+	It("uses current time for completed when termination time was missing", func() {
+		submitAt := metav1.NewTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		before := time.Now()
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				AppState:                    v1beta2.ApplicationState{State: v1beta2.ApplicationStateCompleted},
+				LastSubmissionAttemptTime: submitAt,
+				SubmissionAttempts:        1,
+				ExecutionAttempts:         1,
+			},
+		}
+		util.EnsureTerminationTimeForTerminalState(app)
+		Expect(app.Status.TerminationTime.Time.After(before.Add(-time.Second))).To(BeTrue())
+		Expect(time.Since(app.Status.TerminationTime.Time)).To(BeNumerically("<", 5*time.Second))
+	})
+
+	It("uses current time when last submission time is missing", func() {
+		before := time.Now()
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				AppState:             v1beta2.ApplicationState{State: v1beta2.ApplicationStateFailed},
+				SubmissionAttempts: 1,
+				ExecutionAttempts:    0,
+			},
+		}
+		util.EnsureTerminationTimeForTerminalState(app)
+		Expect(app.Status.TerminationTime.Time.After(before.Add(-time.Second))).To(BeTrue())
+		Expect(time.Since(app.Status.TerminationTime.Time)).To(BeNumerically("<", 5*time.Second))
+	})
+})
+
 var _ = Describe("IsDriverRunning", func() {
 	Context("SparkApplication with completed state", func() {
 		app := &v1beta2.SparkApplication{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Terminal `SparkApplication` resources (`FAILED` or `COMPLETED`) sometimes have `status.terminationTime` unset. Expiry and TTL deletion are based on `terminationTime`, so `timeToLiveSeconds` never applies and the CR (and related resources) are never garbage-collected.

This change backfills `terminationTime` when the app is already in a terminal state but the field is missing, preferring `lastSubmissionAttemptTime` (appropriate for submission-time failures).

**Proposed changes:**

- Add `EnsureTerminationTimeForTerminalState` in `pkg/util` and call it from `reconcileTerminatedSparkApplication` before `IsExpired` / TTL handling.
- Add unit tests for the helper.

Example (redacted manifest excerpt: `spec.timeToLiveSeconds` and `status` only):

```yaml
spec:
  timeToLiveSeconds: 3600
status:
  applicationState:
    errorMessage: "failed to submit spark application: failed to run spark-submit: driver pod already exist"
    state: FAILED
  lastSubmissionAttemptTime: "2026-04-26T16:40:39Z"
  submissionAttempts: 1
  terminationTime: null
```

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

`reconcileTerminatedSparkApplication` returns early when `terminationTime` is zero, so TTL requeue and `IsExpired` never run. Backfilling from `lastSubmissionAttemptTime` aligns the clock with when the run actually stopped for submission failures, and allows overdue TTLs to delete immediately on the next reconcile.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

**Risk:** Low

`pkg/util` tests were run locally. Controller integration tests require envtest binaries.
