### PR TITLE
Chore/remove standalone kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ KIND_KUBE_CONFIG ?= $(HOME)/.kube/config
 LOCALBIN ?= $(shell pwd)/bin
 
 ## Versions
-KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 KIND_VERSION ?= v0.31.0
 KIND_K8S_VERSION ?= v1.35.0
@@ -66,7 +65,6 @@ CODE_GENERATOR_VERSION ?= v0.33.1
 ## Binaries
 SPARK_OPERATOR ?= $(LOCALBIN)/spark-operator
 KUBECTL ?= kubectl
-KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 KIND ?= $(LOCALBIN)/kind-$(KIND_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
@@ -270,12 +268,12 @@ kind-delete-cluster: kind ## Delete the created kind cluster.
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME) --kubeconfig $(KIND_KUBE_CONFIG)
 
 .PHONY: install
-install-crd: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) create -f - 2>/dev/null || $(KUSTOMIZE) build config/crd | $(KUBECTL) replace -f -
+install-crd: manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	$(KUBECTL) kustomize config/crd | $(KUBECTL) create -f - 2>/dev/null || $(KUBECTL) kustomize config/crd | $(KUBECTL) replace -f -
 
 .PHONY: uninstall
-uninstall-crd: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+uninstall-crd: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUBECTL) kustomize config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: IMAGE_TAG=local
@@ -290,11 +288,6 @@ undeploy: helm ## Uninstall spark-operator
 
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
-
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
## Purpose of this PR

Remove the standalone `kustomize` binary dependency from the Makefile and standardize on `kubectl`'s embedded kustomize for all operations.

This was decided during the community call as a follow-up to [PR #2919](https://github.com/kubeflow/spark-operator/pull/2919). See [approval comment](https://github.com/kubeflow/spark-operator/pull/2919#pullrequestreview-4212301061)

**Proposed changes:**

- Remove `KUSTOMIZE_VERSION`, `KUSTOMIZE` binary variable, and the `kustomize` download target
- Replace `$(KUSTOMIZE) build` with `$(KUBECTL) kustomize` in `install-crd` and `uninstall-crd` targets
- Remove `kustomize` from `install-crd`/`uninstall-crd` prerequisites

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The standalone `kustomize` binary (`v5.4.1`) was Kubebuilder scaffolding from `kubebuilder init`, used only by two CRD management targets (`install-crd`, `uninstall-crd`). The rest of the project -- e2e tests, lint tests, and the documented user deployment path (`kubectl apply -k config/default/`) -- already uses `kubectl`'s embedded kustomize. This removes the inconsistency and one fewer binary to download.

For the features used in this project (namespace transformer, `images` directive, `replacements`), `kubectl kustomize` and the standalone binary produce identical output.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

**Scope:** Makefile only, No Go code, manifests, or CI workflow changes.

**Verified locally:**
```bash
make install-crd    # CRDs created via kubectl kustomize
make uninstall-crd  # CRDs deleted via kubectl kustomize
make kustomize      # Correctly errors: No rule to make target
ls bin/kustomize-*  # No standalone binary downloaded
```