### PR TITLE
fix(metrics): use sanitized labels for executor/application metric vecs

### DIFF
--- a/internal/metrics/sparkapplication_metrics.go
+++ b/internal/metrics/sparkapplication_metrics.go
@@ -368,7 +368,7 @@ func (m *SparkApplicationMetrics) getMetricLabels(app *v1beta2.SparkApplication)
 	// Convert spark application validLabels to valid metric validLabels.
 	validLabels := make(map[string]string)
 	for key, val := range app.Labels {
-		newKey := util.CreateValidMetricNameLabel(m.prefix, key)
+		newKey := util.CreateValidMetricNameLabel("", key)
 		validLabels[newKey] = val
 	}
 

--- a/internal/metrics/sparkpod_metrics.go
+++ b/internal/metrics/sparkpod_metrics.go
@@ -44,7 +44,7 @@ func NewSparkExecutorMetrics(prefix string, labels []string) *SparkExecutorMetri
 
 	return &SparkExecutorMetrics{
 		prefix: prefix,
-		labels: labels,
+		labels: validLabels,
 
 		runningCount: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

SparkExecutorMetrics stored the unsanitized label list while registering the Prometheus vecs with the sanitized list, so any user label containing '-' resolved to an unknown key in getMetricLabels and silently failed GetMetricWith — the data point was dropped instead of recorded.

SparkApplicationMetrics had the symmetric bug in getMetricLabels: it re-applied the metric prefix when sanitizing pod label keys while the constructor sanitized with an empty prefix, so when prefix was non-empty every label collapsed to "Unknown".

Align both paths so labels are sanitized once with an empty prefix and the stored label set matches the keys produced at observation time.

**Proposed changes:**

- Fixes in the metrics.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
