### PR TITLE
fix: handle uppercase units in ConvertJavaMemoryStringToK8sMemoryString

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -116,15 +116,16 @@ func WriteObjectToFile(obj interface{}, filePath string) (err error) {
 }
 
 func ConvertJavaMemoryStringToK8sMemoryString(memory string) string {
+	lower := strings.ToLower(strings.TrimSpace(memory))
 
 	for unit, k8sUnit := range unitMap {
-		if strings.HasSuffix(strings.ToLower(memory), unit) {
-			return strings.TrimSuffix(memory, unit) + k8sUnit
+		if strings.HasSuffix(lower, unit) {
+			return strings.TrimSuffix(lower, unit) + k8sUnit
 		}
 	}
 
-	// return original memory value if no conversion is needed
-	return memory
+	// return trimmed memory value if no conversion is needed
+	return strings.TrimSpace(memory)
 }
 
 func SetIfNotExists[K comparable, V any](m map[K]V, key K, value V) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -190,26 +190,36 @@ spec:
 var _ = Describe("ConvertJavaMemoryStringToK8sMemoryString", func() {
 	It("Should return a memory converted in expected K8s unit", func() {
 
-		unitMap := map[string]string{
-			"k":  "Ki",
-			"kb": "Ki",
-			"m":  "Mi",
-			"mb": "Mi",
-			"g":  "Gi",
-			"gb": "Gi",
-			"t":  "Ti",
-			"tb": "Ti",
-			"p":  "Pi",
-			"pb": "Pi",
-			"Ki": "Ki",
-			"Mi": "Mi",
-			"Gi": "Gi",
-			"Ti": "Ti",
-			"Pi": "Pi",
+		testCases := map[string]string{
+			"100k":   "100Ki",
+			"512m":   "512Mi",
+			"2g":     "2Gi",
+			"1t":     "1Ti",
+			"1p":     "1Pi",
+			"100K":   "100Ki",
+			"512M":   "512Mi",
+			"2G":     "2Gi",
+			"1T":     "1Ti",
+			"1P":     "1Pi",
+			"2gb":    "2Gi",
+			"2GB":    "2Gi",
+			"2Gb":    "2Gi",
+			"2gB":    "2Gi",
+			"512mb":  "512Mi",
+			"512MB":  "512Mi",
+			"100Ki":  "100Ki",
+			"512Mi":  "512Mi",
+			"2Gi":    "2Gi",
+			" 2G":    "2Gi",
+			"2G ":    "2Gi",
+			"  2G  ": "2Gi",
+			"1024":   "1024",
+			"":       "",
 		}
 
-		for unit, response := range unitMap {
-			Expect(util.ConvertJavaMemoryStringToK8sMemoryString(unit)).To(Equal(response))
+		for input, expected := range testCases {
+			Expect(util.ConvertJavaMemoryStringToK8sMemoryString(input)).
+				To(Equal(expected), "input: %q", input)
 		}
 	})
 })


### PR DESCRIPTION
## Purpose of this PR

Fixes #2930. The `ConvertJavaMemoryStringToK8sMemoryString` function in `pkg/util/util.go` produces garbage output for memory strings containing uppercase letters (e.g. `"2G"` → `"2GGi"` instead of `"2Gi"`).

**Proposed changes:**

Lowercase the input once and use the lowercased copy for both `HasSuffix` and `TrimSuffix`, so matching and trimming operate on the same casing.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
