### PR TITLE
fix(kustomize): Add namespaceSelector to webhook configurations via kustomize patches

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 
 patches:
   - path: webhook-objectselector-patch.yaml
+  - path: webhook-validating-selector-patch.yaml
 
 configurations:
   - kustomizeconfig.yaml

--- a/config/webhook/webhook-objectselector-patch.yaml
+++ b/config/webhook/webhook-objectselector-patch.yaml
@@ -4,6 +4,33 @@ metadata:
   name: mutating-webhook-configuration
 webhooks:
 - name: mutate-pod.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default
   objectSelector:
     matchLabels:
       sparkoperator.k8s.io/launched-by-spark-operator: "true"
+- name: mutate-sparkapplication.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default
+- name: mutate-scheduledsparkapplication.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default
+- name: mutate-sparkconnect.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default

--- a/config/webhook/webhook-validating-selector-patch.yaml
+++ b/config/webhook/webhook-validating-selector-patch.yaml
@@ -1,0 +1,34 @@
+# Kustomize strategic-merge patch for ValidatingWebhookConfiguration selectors.
+#
+# controller-gen cannot emit namespaceSelector via kubebuilder markers, so we
+# add it here to align with the Helm chart defaults.
+#
+# namespaceSelector limits interception to the listed job namespaces
+# (default: "default"). Adjust the values list to match your deployment.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: validate-sparkapplication.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default
+- name: validate-scheduledsparkapplication.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default
+- name: validate-sparkconnect.sparkoperator.k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default

--- a/test/kustomize/kustomize_build_test.go
+++ b/test/kustomize/kustomize_build_test.go
@@ -254,6 +254,11 @@ func TestKustomizeBuild(t *testing.T) {
 		assert.True(t, hasObjectSelector,
 			"pod mutation webhook should have objectSelector to prevent chicken-and-egg deadlock")
 
+		for _, wh := range mw.Webhooks {
+			assert.NotNil(t, wh.NamespaceSelector,
+				"mutating webhook %s should have namespaceSelector (added via kustomize patch)", wh.Name)
+		}
+
 		svcRefCount := 0
 		for _, wh := range mw.Webhooks {
 			if wh.ClientConfig.Service != nil && wh.ClientConfig.Service.Name == "spark-operator-webhook-svc" {
@@ -264,6 +269,11 @@ func TestKustomizeBuild(t *testing.T) {
 		vwObj := findResource(resources, "ValidatingWebhookConfiguration", "validating-webhook-configuration")
 		require.NotNil(t, vwObj, "ValidatingWebhookConfiguration not found")
 		vw := convertTo[admissionregistrationv1.ValidatingWebhookConfiguration](t, vwObj)
+
+		for _, wh := range vw.Webhooks {
+			assert.NotNil(t, wh.NamespaceSelector,
+				"validating webhook %s should have namespaceSelector (added via kustomize patch)", wh.Name)
+		}
 
 		for _, wh := range vw.Webhooks {
 			if wh.ClientConfig.Service != nil && wh.ClientConfig.Service.Name == "spark-operator-webhook-svc" {


### PR DESCRIPTION
## Purpose of this PR

Follow-up to [#2915 (comment)](https://github.com/kubeflow/spark-operator/pull/2915#discussion_r3169583251) where @nabuskey noted that the Kustomize `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` lack `namespaceSelector` entirely. Since `config/webhook/manifests.yaml` is auto-generated by `controller-gen` (which doesn't support these attributes via kubebuilder markers), any manual edits get overwritten by `make manifests`. This PR adds the selectors via kustomize strategic-merge patches so they survive regeneration.

**Proposed changes:**

- Expanded `webhook-objectselector-patch.yaml` to add `namespaceSelector` (scoped to `default` namespace) on all 4 mutating webhooks, alongside the existing `objectSelector` on the pod webhook
- Created `webhook-validating-selector-patch.yaml` to add `namespaceSelector` on all 3 validating webhooks
- Updated `config/webhook/kustomization.yaml` to include the new patch
- Added test assertions in `kustomize_build_test.go` verifying all webhooks have `namespaceSelector`

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)

### Rationale

The Helm chart adds `namespaceSelector` on every webhook when `spark.jobNamespaces` is configured (default: `["default"]`). The Kustomize manifests were missing this, causing webhooks to intercept operations in all namespaces cluster-wide. This aligns Kustomize with Helm defaults. Users deploying Spark jobs to other namespaces should update the `values` list in the patch files.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

## Test plan

### Automated

```bash
go test ./test/kustomize/ -v -count=1
```

### Manual verification

```bash
kubectl kustomize config/default | grep -A 6 namespaceSelector
```

Expected: every mutating and validating webhook shows `namespaceSelector` scoped to `default`.

### Additional Notes

- `config/webhook/manifests.yaml` is intentionally not modified -- all selector additions are via kustomize patches that survive `make manifests` regeneration.