### PR TITLE
feat: Add webhook namespace-selector for multi-tenant deployments

### DIFF
--- a/charts/spark-operator-chart/templates/webhook/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/webhook/_helpers.tpl
@@ -126,6 +126,29 @@ Create the name of the pod disruption budget to be used by webhook
 {{- end -}}
 
 {{/*
+Render the namespaceSelector field for a webhook entry in the
+MutatingWebhookConfiguration / ValidatingWebhookConfiguration. Emits nothing
+if neither `spark.webhookNamespaceSelector` is set nor `spark.jobNamespaces`
+holds a concrete list (an entry of "" is the all-namespaces sentinel and
+disables the name-based selector). Callers indent the result with `nindent`.
+*/}}
+{{- define "spark-operator.webhook.namespaceSelector" -}}
+{{- if .Values.spark.webhookNamespaceSelector -}}
+namespaceSelector:
+{{ toYaml .Values.spark.webhookNamespaceSelector | indent 2 -}}
+{{- else if and .Values.spark.jobNamespaces (not (has "" .Values.spark.jobNamespaces)) -}}
+namespaceSelector:
+  matchExpressions:
+  - key: kubernetes.io/metadata.name
+    operator: In
+    values:
+{{- range $jobNamespace := .Values.spark.jobNamespaces }}
+    - {{ $jobNamespace }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the role policy rules for the webhook in every Spark job namespace
 */}}
 {{- define "spark-operator.webhook.policyRules" -}}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - --namespaces={{ . | join "," }}
         {{- end }}
         {{- end }}
+        {{- with .Values.spark.jobNamespaceSelector }}
+        - --namespace-selector={{ . }}
+        {{- end }}
         - --webhook-secret-name={{ include "spark-operator.webhook.secretName" . }}
         - --webhook-secret-namespace={{ .Release.Namespace }}
         - --webhook-svc-name={{ include "spark-operator.webhook.serviceName" . }}

--- a/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -38,17 +38,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   objectSelector:
     matchLabels:
@@ -73,17 +64,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]
@@ -105,17 +87,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]
@@ -137,17 +110,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]

--- a/charts/spark-operator-chart/templates/webhook/rbac.yaml
+++ b/charts/spark-operator-chart/templates/webhook/rbac.yaml
@@ -28,6 +28,17 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
+{{- if .Values.spark.jobNamespaceSelector }}
+# When namespace selector is used, webhook needs permissions to discover namespaces
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
@@ -38,17 +38,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]
@@ -70,17 +61,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]
@@ -102,17 +84,8 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- with .Values.spark.jobNamespaces }}
-  {{- if not (has "" .) }}
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: In
-      values:
-      {{- range $jobNamespace := . }}
-      - {{ $jobNamespace }}
-      {{- end }}
-  {{- end }}
+  {{- with (include "spark-operator.webhook.namespaceSelector" .) }}
+  {{- . | nindent 2 }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -456,8 +456,28 @@ spark:
   # Namespaces matching this selector will be watched in addition to those in jobNamespaces.
   # When specified, requires ClusterRole permission to list and watch namespaces.
   # Leave empty to disable namespace selector functionality.
+  # Drives the --namespace-selector flag for both the controller and the webhook deployments.
   jobNamespaceSelector: ""
 
+  # -- Structured label selector embedded into the `namespaceSelector` field of every
+  # MutatingWebhookConfiguration / ValidatingWebhookConfiguration webhook entry.
+  # When set, replaces the default name-based selector built from `jobNamespaces`.
+  # For multi-tenant deployments, this should match `jobNamespaceSelector` (which is a string)
+  # in structured form -- the Kubernetes API requires `matchLabels` / `matchExpressions`
+  # and Helm cannot reliably parse arbitrary label-selector strings.
+  # Combining this with a non-empty `jobNamespaces` is not supported.
+  webhookNamespaceSelector: {}
+  # webhookNamespaceSelector:
+  #   matchLabels:
+  #     example.com/tenant: tenantA
+
+  # Note: the chart only renders Spark ServiceAccount/Role/RoleBinding for namespaces
+  # listed explicitly in `jobNamespaces`. When `jobNamespaces` is unset, empty, or
+  # contains the "" wildcard, or when `jobNamespaceSelector` / `webhookNamespaceSelector`
+  # is used, no Spark RBAC is rendered and the cluster admin must provision a
+  # ServiceAccount + Role + RoleBinding in every namespace where Spark jobs will run.
+  # ServiceAccount is intrinsically namespaced, so there is no Helm-only way to
+  # bootstrap RBAC into a label-selected set of namespaces.
   serviceAccount:
     # -- Specifies whether to create a service account for spark applications.
     create: true

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -45,6 +45,7 @@ import (
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
@@ -54,6 +55,7 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/certificate"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	operatorscheme "github.com/kubeflow/spark-operator/v2/pkg/scheme"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
 	"github.com/kubeflow/spark-operator/v2/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
@@ -63,8 +65,8 @@ var (
 )
 
 var (
-	namespaces          []string
-	labelSelectorFilter string
+	namespaces        []string
+	namespaceSelector string
 
 	// Controller
 	controllerThreads int
@@ -128,7 +130,7 @@ func NewStartCommand() *cobra.Command {
 	// Controller
 	command.Flags().IntVar(&controllerThreads, "controller-threads", 10, "Number of worker threads used by the SparkApplication controller.")
 	command.Flags().StringSliceVar(&namespaces, "namespaces", []string{}, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset or contains empty string.")
-	command.Flags().StringVar(&labelSelectorFilter, "label-selector-filter", "", "A comma-separated list of key=value, or key labels to filter resources during watch and list based on the specified labels.")
+	command.Flags().StringVar(&namespaceSelector, "namespace-selector", "", "Label selector for namespaces to watch (e.g., 'spark-operator=enabled,env in (prod,staging)'). Namespaces matching this selector will be watched in addition to those specified via --namespaces. Requires ClusterRole permission to list and watch namespaces.")
 	command.Flags().DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 30*time.Second, "Informer cache sync timeout.")
 
 	command.Flags().Float32Var(&kubeAPIQPS, "kube-api-qps", 20, "Maximum QPS to the API server from the controller client.")
@@ -291,10 +293,23 @@ func start() {
 		}
 	}
 
+	namespaceMatcher, err := util.NewNamespaceMatcher(namespaces, namespaceSelector)
+	if err != nil {
+		logger.Error(err, "Failed to build namespace matcher")
+		os.Exit(1)
+	}
+
+	wrapDefaulterWithNamespaceFiltering := func(d admission.CustomDefaulter) admission.CustomDefaulter {
+		return webhook.NewNamespaceFilteringDefaulter(d, namespaceMatcher, mgr.GetClient())
+	}
+	wrapValidatorWithNamespaceFiltering := func(v admission.CustomValidator) admission.CustomValidator {
+		return webhook.NewNamespaceFilteringValidator(v, namespaceMatcher, mgr.GetClient())
+	}
+
 	if err := ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.SparkConnect{}).
-		WithDefaulter(webhook.NewSparkConnectDefaulter()).
-		WithValidator(webhook.NewSparkConnectValidator()).
+		WithDefaulter(wrapDefaulterWithNamespaceFiltering(webhook.NewSparkConnectDefaulter())).
+		WithValidator(wrapValidatorWithNamespaceFiltering(webhook.NewSparkConnectValidator())).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for SparkConnect")
@@ -303,8 +318,8 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
 		For(&v1beta2.SparkApplication{}).
-		WithDefaulter(webhook.NewSparkApplicationDefaulter()).
-		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement)).
+		WithDefaulter(wrapDefaulterWithNamespaceFiltering(webhook.NewSparkApplicationDefaulter())).
+		WithValidator(wrapValidatorWithNamespaceFiltering(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement))).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Spark application")
@@ -313,8 +328,8 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
 		For(&v1beta2.ScheduledSparkApplication{}).
-		WithDefaulter(webhook.NewScheduledSparkApplicationDefaulter()).
-		WithValidator(webhook.NewScheduledSparkApplicationValidator()).
+		WithDefaulter(wrapDefaulterWithNamespaceFiltering(webhook.NewScheduledSparkApplicationDefaulter())).
+		WithValidator(wrapValidatorWithNamespaceFiltering(webhook.NewScheduledSparkApplicationValidator())).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Scheduled Spark application")
@@ -323,7 +338,7 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
 		For(&corev1.Pod{}).
-		WithDefaulter(webhook.NewSparkPodDefaulter(mgr.GetClient(), namespaces)).
+		WithDefaulter(wrapDefaulterWithNamespaceFiltering(webhook.NewSparkPodDefaulter(mgr.GetClient()))).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Spark pod")
@@ -394,6 +409,7 @@ func newCacheOptions() cache.Options {
 	}
 
 	byObject := map[client.Object]cache.ByObject{
+		&corev1.Namespace{}: {},
 		&corev1.Pod{}: {
 			Label: labels.SelectorFromSet(labels.Set{
 				common.LabelLaunchedBySparkOperator: "true",

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -402,12 +402,6 @@ func newTLSOptions() []func(c *tls.Config) {
 
 // newCacheOptions creates and returns a cache.Options instance configured with default namespaces and object caching settings.
 func newCacheOptions() cache.Options {
-	defaultNamespaces := make(map[string]cache.Config)
-	if !slices.Contains(namespaces, cache.AllNamespaces) {
-		for _, ns := range namespaces {
-			defaultNamespaces[ns] = cache.Config{}
-		}
-	}
 
 	byObject := map[client.Object]cache.ByObject{
 		&corev1.Pod{}: {
@@ -429,11 +423,19 @@ func newCacheOptions() cache.Options {
 		},
 	}
 
+	var defaultNamespaces map[string]cache.Config
+
 	// Only cache Namespaces when a selector is configured; otherwise the
 	// matcher never needs to read them and we'd impose a cluster-scoped
 	// list/watch on installs that don't opt into label-based matching.
 	if strings.TrimSpace(namespaceSelector) != "" {
 		byObject[&corev1.Namespace{}] = cache.ByObject{}
+		defaultNamespaces = nil
+	} else if !slices.Contains(namespaces, cache.AllNamespaces) {
+		defaultNamespaces = make(map[string]cache.Config, len(namespaces))
+		for _, ns := range namespaces {
+			defaultNamespaces[ns] = cache.Config{}
+		}
 	}
 
 	if enableResourceQuotaEnforcement {

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -409,7 +410,6 @@ func newCacheOptions() cache.Options {
 	}
 
 	byObject := map[client.Object]cache.ByObject{
-		&corev1.Namespace{}: {},
 		&corev1.Pod{}: {
 			Label: labels.SelectorFromSet(labels.Set{
 				common.LabelLaunchedBySparkOperator: "true",
@@ -427,6 +427,13 @@ func newCacheOptions() cache.Options {
 				"metadata.name": validatingWebhookName,
 			}),
 		},
+	}
+
+	// Only cache Namespaces when a selector is configured; otherwise the
+	// matcher never needs to read them and we'd impose a cluster-scoped
+	// list/watch on installs that don't opt into label-based matching.
+	if strings.TrimSpace(namespaceSelector) != "" {
+		byObject[&corev1.Namespace{}] = cache.ByObject{}
 	}
 
 	if enableResourceQuotaEnforcement {

--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/internal/webhook/namespace_filter.go
+++ b/internal/webhook/namespace_filter.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+)
+
+// namespaceFilteringDefaulter wraps a CustomDefaulter and skips it when the
+// object's namespace does not match the operator's namespace scope. Objects that
+// do not implement metav1.Object (e.g. cluster-scoped) pass through unchanged.
+type namespaceFilteringDefaulter struct {
+	inner   admission.CustomDefaulter
+	matcher *util.NamespaceMatcher
+	client  client.Client
+}
+
+// NewNamespaceFilteringDefaulter wraps inner with a namespace gate driven by matcher.
+func NewNamespaceFilteringDefaulter(inner admission.CustomDefaulter, matcher *util.NamespaceMatcher, c client.Client) admission.CustomDefaulter {
+	return &namespaceFilteringDefaulter{inner: inner, matcher: matcher, client: c}
+}
+
+func (w *namespaceFilteringDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	matched, err := matchesNamespace(ctx, w.client, w.matcher, obj)
+	if err != nil {
+		return err
+	}
+	if !matched {
+		return nil
+	}
+	return w.inner.Default(ctx, obj)
+}
+
+// namespaceFilteringValidator wraps a CustomValidator with the same semantics
+// as namespaceFilteringDefaulter. For updates the new object's namespace is
+// used (namespace is immutable in Kubernetes).
+type namespaceFilteringValidator struct {
+	inner   admission.CustomValidator
+	matcher *util.NamespaceMatcher
+	client  client.Client
+}
+
+// NewNamespaceFilteringValidator wraps inner with a namespace gate driven by matcher.
+func NewNamespaceFilteringValidator(inner admission.CustomValidator, matcher *util.NamespaceMatcher, c client.Client) admission.CustomValidator {
+	return &namespaceFilteringValidator{inner: inner, matcher: matcher, client: c}
+}
+
+func (w *namespaceFilteringValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	matched, err := matchesNamespace(ctx, w.client, w.matcher, obj)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, nil
+	}
+	return w.inner.ValidateCreate(ctx, obj)
+}
+
+func (w *namespaceFilteringValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	matched, err := matchesNamespace(ctx, w.client, w.matcher, newObj)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, nil
+	}
+	return w.inner.ValidateUpdate(ctx, oldObj, newObj)
+}
+
+func (w *namespaceFilteringValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	matched, err := matchesNamespace(ctx, w.client, w.matcher, obj)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, nil
+	}
+	return w.inner.ValidateDelete(ctx, obj)
+}
+
+func matchesNamespace(ctx context.Context, c client.Client, matcher *util.NamespaceMatcher, obj runtime.Object) (bool, error) {
+	meta, ok := obj.(metav1.Object)
+	if !ok {
+		return true, nil
+	}
+	return matcher.MatchesWithClient(ctx, c, meta.GetNamespace())
+}

--- a/internal/webhook/namespace_filter.go
+++ b/internal/webhook/namespace_filter.go
@@ -28,8 +28,10 @@ import (
 )
 
 // namespaceFilteringDefaulter wraps a CustomDefaulter and skips it when the
-// object's namespace does not match the operator's namespace scope. Objects that
-// do not implement metav1.Object (e.g. cluster-scoped) pass through unchanged.
+// object's namespace does not match the operator's namespace scope. Objects
+// without a namespace (non-metav1.Object or cluster-scoped) are admitted
+// without invoking the inner defaulter, since there is no namespace to filter
+// on and the wrapped CRDs are all namespace-scoped.
 type namespaceFilteringDefaulter struct {
 	inner   admission.CustomDefaulter
 	matcher *util.NamespaceMatcher
@@ -102,7 +104,13 @@ func (w *namespaceFilteringValidator) ValidateDelete(ctx context.Context, obj ru
 func matchesNamespace(ctx context.Context, c client.Client, matcher *util.NamespaceMatcher, obj runtime.Object) (bool, error) {
 	meta, ok := obj.(metav1.Object)
 	if !ok {
-		return true, nil
+		return false, nil
 	}
-	return matcher.MatchesWithClient(ctx, c, meta.GetNamespace())
+
+	namespace := meta.GetNamespace()
+	if namespace == "" {
+		return false, nil
+	}
+
+	return matcher.MatchesWithClient(ctx, c, namespace)
 }

--- a/internal/webhook/namespace_filter_test.go
+++ b/internal/webhook/namespace_filter_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+)
+
+// --- helpers ---
+
+func newClient(t *testing.T, namespaces ...*corev1.Namespace) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, ns := range namespaces {
+		builder = builder.WithObjects(ns)
+	}
+	return builder.Build()
+}
+
+func newNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func newPod(namespace string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: namespace}}
+}
+
+func newMatcher(t *testing.T, namespaces []string, selector string) *util.NamespaceMatcher {
+	t.Helper()
+	m, err := util.NewNamespaceMatcher(namespaces, selector)
+	require.NoError(t, err)
+	return m
+}
+
+// hasNamespace returns a testify argument matcher that succeeds when the
+// runtime.Object argument is a namespaced object with the given namespace.
+func hasNamespace(ns string) interface{} {
+	return mock.MatchedBy(func(o runtime.Object) bool {
+		m, ok := o.(metav1.Object)
+		return ok && m.GetNamespace() == ns
+	})
+}
+
+// --- mocks ---
+
+type mockDefaulter struct {
+	mock.Mock
+}
+
+func (m *mockDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	return m.Called(ctx, obj).Error(0)
+}
+
+type mockValidator struct {
+	mock.Mock
+}
+
+func (m *mockValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	args := m.Called(ctx, obj)
+	return warningsFrom(args, 0), args.Error(1)
+}
+
+func (m *mockValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	args := m.Called(ctx, oldObj, newObj)
+	return warningsFrom(args, 0), args.Error(1)
+}
+
+func (m *mockValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	args := m.Called(ctx, obj)
+	return warningsFrom(args, 0), args.Error(1)
+}
+
+func warningsFrom(args mock.Arguments, idx int) admission.Warnings {
+	if v := args.Get(idx); v != nil {
+		return v.(admission.Warnings)
+	}
+	return nil
+}
+
+// runtime.Object that intentionally does not implement metav1.Object — used to
+// exercise the wrapper's pass-through branch for non-namespaced objects.
+type bareRuntimeObject struct{}
+
+func (*bareRuntimeObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (*bareRuntimeObject) DeepCopyObject() runtime.Object   { return &bareRuntimeObject{} }
+
+// --- defaulter tests ---
+
+func TestNamespaceFilteringDefaulter_MatchesExplicitNamespace(t *testing.T) {
+	inner := &mockDefaulter{}
+	inner.On("Default", mock.Anything, hasNamespace("ns-a")).Return(nil).Once()
+
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	require.NoError(t, w.Default(context.Background(), newPod("ns-a")))
+
+	inner.AssertExpectations(t)
+}
+
+func TestNamespaceFilteringDefaulter_SkipsUnmatchedNamespace(t *testing.T) {
+	inner := &mockDefaulter{}
+	inner.On("Default", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	require.NoError(t, w.Default(context.Background(), newPod("ns-b")))
+
+	inner.AssertNotCalled(t, "Default")
+}
+
+func TestNamespaceFilteringDefaulter_MatchesByLabelSelector(t *testing.T) {
+	c := newClient(t,
+		newNamespace("matched", map[string]string{"tenant": "tenantA"}),
+		newNamespace("unmatched", map[string]string{"tenant": "tenantB"}),
+	)
+
+	inner := &mockDefaulter{}
+	inner.On("Default", mock.Anything, hasNamespace("matched")).Return(nil).Once()
+
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, nil, "tenant=tenantA"), c)
+	require.NoError(t, w.Default(context.Background(), newPod("matched")))
+	require.NoError(t, w.Default(context.Background(), newPod("unmatched")))
+
+	inner.AssertExpectations(t)
+	inner.AssertNumberOfCalls(t, "Default", 1)
+}
+
+func TestNamespaceFilteringDefaulter_EmptyConfigMatchesEverything(t *testing.T) {
+	inner := &mockDefaulter{}
+	inner.On("Default", mock.Anything, mock.Anything).Return(nil).Once()
+
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, nil, ""), newClient(t))
+	require.NoError(t, w.Default(context.Background(), newPod("any-namespace")))
+
+	inner.AssertExpectations(t)
+}
+
+func TestNamespaceFilteringDefaulter_PassesThroughObjectsWithoutMeta(t *testing.T) {
+	inner := &mockDefaulter{}
+	inner.On("Default", mock.Anything, mock.Anything).Return(nil).Once()
+
+	// Explicit namespace list that would normally reject everything; the wrapper
+	// must still pass through objects that don't implement metav1.Object.
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	require.NoError(t, w.Default(context.Background(), &bareRuntimeObject{}))
+
+	inner.AssertExpectations(t)
+}
+
+func TestNamespaceFilteringDefaulter_PropagatesInnerError(t *testing.T) {
+	inner := &mockDefaulter{}
+	inner.On("Default", mock.Anything, mock.Anything).Return(errors.New("boom")).Once()
+
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	err := w.Default(context.Background(), newPod("ns-a"))
+
+	assert.EqualError(t, err, "boom")
+	inner.AssertExpectations(t)
+}
+
+// --- validator tests ---
+
+func TestNamespaceFilteringValidator_GatesAllThreeMethods(t *testing.T) {
+	inner := &mockValidator{}
+	inner.On("ValidateCreate", mock.Anything, hasNamespace("ns-a")).Return(nil, nil).Once()
+	inner.On("ValidateUpdate", mock.Anything, mock.Anything, hasNamespace("ns-a")).Return(nil, nil).Once()
+	inner.On("ValidateDelete", mock.Anything, hasNamespace("ns-a")).Return(nil, nil).Once()
+
+	w := NewNamespaceFilteringValidator(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	ctx := context.Background()
+	matched := newPod("ns-a")
+	unmatched := newPod("ns-b")
+
+	_, err := w.ValidateCreate(ctx, matched)
+	require.NoError(t, err)
+	_, err = w.ValidateUpdate(ctx, matched, matched)
+	require.NoError(t, err)
+	_, err = w.ValidateDelete(ctx, matched)
+	require.NoError(t, err)
+
+	_, err = w.ValidateCreate(ctx, unmatched)
+	require.NoError(t, err)
+	_, err = w.ValidateUpdate(ctx, unmatched, unmatched)
+	require.NoError(t, err)
+	_, err = w.ValidateDelete(ctx, unmatched)
+	require.NoError(t, err)
+
+	inner.AssertExpectations(t)
+	inner.AssertNumberOfCalls(t, "ValidateCreate", 1)
+	inner.AssertNumberOfCalls(t, "ValidateUpdate", 1)
+	inner.AssertNumberOfCalls(t, "ValidateDelete", 1)
+}
+
+func TestNamespaceFilteringValidator_UpdateUsesNewObjectNamespace(t *testing.T) {
+	inner := &mockValidator{}
+	// Expectation only succeeds if the wrapper passes newObj (ns-new) to the inner.
+	// If it ever used oldObj's namespace (ns-old), the expectation would not match.
+	inner.On("ValidateUpdate",
+		mock.Anything,
+		hasNamespace("ns-old"),
+		hasNamespace("ns-new"),
+	).Return(nil, nil).Once()
+
+	w := NewNamespaceFilteringValidator(inner, newMatcher(t, []string{"ns-new"}, ""), newClient(t))
+	_, err := w.ValidateUpdate(context.Background(), newPod("ns-old"), newPod("ns-new"))
+	require.NoError(t, err)
+
+	inner.AssertExpectations(t)
+}
+
+func TestNamespaceFilteringValidator_PropagatesInnerError(t *testing.T) {
+	inner := &mockValidator{}
+	inner.On("ValidateCreate", mock.Anything, mock.Anything).Return(nil, errors.New("boom")).Once()
+
+	w := NewNamespaceFilteringValidator(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	_, err := w.ValidateCreate(context.Background(), newPod("ns-a"))
+
+	assert.EqualError(t, err, "boom")
+	inner.AssertExpectations(t)
+}

--- a/internal/webhook/namespace_filter_test.go
+++ b/internal/webhook/namespace_filter_test.go
@@ -164,16 +164,28 @@ func TestNamespaceFilteringDefaulter_EmptyConfigMatchesEverything(t *testing.T) 
 	inner.AssertExpectations(t)
 }
 
-func TestNamespaceFilteringDefaulter_PassesThroughObjectsWithoutMeta(t *testing.T) {
+func TestNamespaceFilteringDefaulter_SkipsObjectsWithoutMeta(t *testing.T) {
 	inner := &mockDefaulter{}
-	inner.On("Default", mock.Anything, mock.Anything).Return(nil).Once()
 
-	// Explicit namespace list that would normally reject everything; the wrapper
-	// must still pass through objects that don't implement metav1.Object.
-	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, []string{"ns-a"}, ""), newClient(t))
+	// Objects that don't implement metav1.Object have no namespace to filter on;
+	// the wrapper admits them without invoking the inner defaulter. No
+	// expectation is registered so an unexpected call would panic on the mock.
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, nil, ""), newClient(t))
 	require.NoError(t, w.Default(context.Background(), &bareRuntimeObject{}))
 
-	inner.AssertExpectations(t)
+	inner.AssertNotCalled(t, "Default")
+}
+
+func TestNamespaceFilteringDefaulter_SkipsClusterScopedObjects(t *testing.T) {
+	inner := &mockDefaulter{}
+
+	// A label selector is configured so that MatchesWithClient would otherwise
+	// attempt to Get a namespace with name "" — verify we short-circuit before
+	// reaching the client and never call the inner defaulter.
+	w := NewNamespaceFilteringDefaulter(inner, newMatcher(t, nil, "tenant=tenantA"), newClient(t))
+	require.NoError(t, w.Default(context.Background(), newNamespace("cluster-scoped", nil)))
+
+	inner.AssertNotCalled(t, "Default")
 }
 
 func TestNamespaceFilteringDefaulter_PropagatesInnerError(t *testing.T) {

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -45,28 +45,17 @@ const (
 
 // SparkPodDefaulter defaults Spark pods.
 type SparkPodDefaulter struct {
-	client             client.Client
-	sparkJobNamespaces map[string]bool
+	client client.Client
 }
 
 // SparkPodDefaulter implements admission.CustomDefaulter.
 var _ admission.CustomDefaulter = &SparkPodDefaulter{}
 
-// NewSparkPodDefaulter creates a new SparkPodDefaulter instance.
-func NewSparkPodDefaulter(client client.Client, namespaces []string) *SparkPodDefaulter {
-	nsMap := make(map[string]bool)
-	if len(namespaces) == 0 {
-		nsMap[metav1.NamespaceAll] = true
-	} else {
-		for _, ns := range namespaces {
-			nsMap[ns] = true
-		}
-	}
-
-	return &SparkPodDefaulter{
-		client:             client,
-		sparkJobNamespaces: nsMap,
-	}
+// NewSparkPodDefaulter creates a new SparkPodDefaulter instance. Namespace
+// scoping is applied externally via NewNamespaceFilteringDefaulter at
+// registration time.
+func NewSparkPodDefaulter(client client.Client) *SparkPodDefaulter {
+	return &SparkPodDefaulter{client: client}
 }
 
 // Default implements admission.CustomDefaulter.
@@ -78,9 +67,6 @@ func (d *SparkPodDefaulter) Default(ctx context.Context, obj runtime.Object) err
 
 	logger := log.FromContext(ctx)
 	namespace := pod.Namespace
-	if !d.isSparkJobNamespace(namespace) {
-		return nil
-	}
 
 	appName := pod.Labels[common.LabelSparkAppName]
 	if appName == "" {
@@ -130,10 +116,6 @@ func addMemoryLimit(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
 	// Apply the memory limit to the container's resources
 	pod.Spec.Containers[i].Resources.Limits[corev1.ResourceMemory] = limitQuantity
 	return nil
-}
-
-func (d *SparkPodDefaulter) isSparkJobNamespace(ns string) bool {
-	return d.sparkJobNamespaces[metav1.NamespaceAll] || d.sparkJobNamespaces[ns]
 }
 
 type mutateSparkPodOption func(pod *corev1.Pod, app *v1beta2.SparkApplication) error

--- a/pkg/util/namespace_test.go
+++ b/pkg/util/namespace_test.go
@@ -46,6 +46,12 @@ var _ = Describe("NamespaceMatcher", func() {
 			Expect(matcher).NotTo(BeNil())
 		})
 
+		It("should create matcher with empty string explicit namespace (NamespaceAll)", func() {
+			matcher, err := util.NewNamespaceMatcher([]string{""}, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matcher).NotTo(BeNil())
+		})
+
 		It("should create matcher with selector only", func() {
 			matcher, err := util.NewNamespaceMatcher([]string{}, "spark=enabled")
 			Expect(err).NotTo(HaveOccurred())
@@ -91,6 +97,13 @@ var _ = Describe("NamespaceMatcher", func() {
 
 		It("should match all namespaces when namespaces list is empty", func() {
 			matcher, _ := util.NewNamespaceMatcher([]string{}, "")
+			Expect(matcher.Matches("any-namespace", nil)).To(BeTrue())
+			Expect(matcher.Matches("another-namespace", nil)).To(BeTrue())
+			Expect(matcher.Matches("", nil)).To(BeTrue())
+		})
+
+		It("should match all namespaces when namespaces list is just an empty string and has a Selector", func() {
+			matcher, _ := util.NewNamespaceMatcher([]string{""}, "spark=true")
 			Expect(matcher.Matches("any-namespace", nil)).To(BeTrue())
 			Expect(matcher.Matches("another-namespace", nil)).To(BeTrue())
 			Expect(matcher.Matches("", nil)).To(BeTrue())


### PR DESCRIPTION
Enables running multiple spark-operator instances in one cluster, each scoped to a subset of namespaces by label.

Go:
- Add --namespace-selector flag to the webhook, mirroring the controller.
- Introduce namespaceFilteringDefaulter / namespaceFilteringValidator wrappers applied to every webhook handler at registration. Objects in unmatched namespaces skip the inner handler; non-namespaced objects pass through.
- Drop the in-process namespace map in SparkPodDefaulter -- the wrapper is now the single source of truth.
- Remove the dead --label-selector-filter flag.
- Add corev1.Namespace to the webhook cache so the wrapper's MatchesWithClient label lookup goes through the informer.
- Unit tests for both wrappers: explicit-namespace match/miss, label-selector match/miss with a fake client, NamespaceAll fast path, pass-through, and inner-error propagation.

Helm:
- Add spark.webhookNamespaceSelector as a structured LabelSelector embedded into every MutatingWebhookConfiguration / ValidatingWebhookConfiguration webhook entry's namespaceSelector field.
- Pass --namespace-selector to the webhook deployment from spark.jobNamespaceSelector.
- Grant the webhook ClusterRole namespaces get/list/watch when jobNamespaceSelector is set, mirroring the controller's pattern.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

At the moment the only way to install multiple spark-operators in the same Kubernetes cluster is by specifying the following attribute with all the Namespaces that it will be responsible for

```yaml
spark:
  jobNamespaces:
    - ns1
    - ns2
```

The problem with this approach is that it is very static. Each time a new Namespace is created you have to `helm upgrade`.  Additionally, all namespaces declared **must** already exist as the chart will attempt creating Roles and RoleBindings in these namespaces.

Resolves https://github.com/kubeflow/spark-operator/issues/2913

**Proposed changes:**

A more dynamic approach would be for the controller and the webhook to filter events from responsible namespaces based on some labels. Luckily, https://github.com/kubeflow/spark-operator/pull/2808 already implements this but **only** for the controller. The webhook does not take the labels into consideration.

Re-use the same `util.NamespaceMatcher` struct in the webhooks responsible for
- SparkConnect
- SparkApplication
- ScheduledSparkApplication
- Pod

In addition to the webhooks above use the same logic in the `mutatingwebhookconfiguration` and `validatingwebhookconfiguration` controllers.

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

https://github.com/kubeflow/spark-operator/issues/2913

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

