### PR TITLE
feat(controller): log when SparkApplication is marked Failing after driver-pod grace period

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -982,6 +982,19 @@ func (r *Reconciler) updateDriverState(ctx context.Context, app *v1beta2.SparkAp
 				app.Status.DriverInfo.PodName,
 				r.options.DriverPodCreationGracePeriod,
 			)
+			logger := log.FromContext(ctx)
+			if app.Status.AppState.State == v1beta2.ApplicationStateSubmitted {
+				logger.Info("Driver pod not found after creation grace period; marking SparkApplication as Failing",
+					"driverPodName", app.Status.DriverInfo.PodName,
+					"lastSubmissionAttemptTime", app.Status.LastSubmissionAttemptTime,
+					"gracePeriod", r.options.DriverPodCreationGracePeriod,
+				)
+			} else {
+				logger.Info("Driver pod not found; marking SparkApplication as Failing",
+					"driverPodName", app.Status.DriverInfo.PodName,
+					"previousState", app.Status.AppState.State,
+				)
+			}
 			app.Status.AppState.State = v1beta2.ApplicationStateFailing
 			app.Status.AppState.ErrorMessage = "driver pod not found"
 			app.Status.TerminationTime = metav1.Now()


### PR DESCRIPTION
 ## Summary

  When the driver pod is missing past `DriverPodCreationGracePeriod`, `updateDriverState`
  transitions the `SparkApplication` to `Failing` and returns `nil`. The only signal of *why* this
  happened is `Status.AppState.ErrorMessage = "driver pod not found"` on the CR, which is invisible
  unless someone runs `kubectl describe sparkapplication`. Controller-runtime logs nothing for a
  `nil` return either, so cluster operators have no way to tell from controller logs why an app was
  marked `Failing`.

  This PR adds a single `logger.Info` line at the moment of the transition, with the namespace/name,
   expected driver pod name, previous state, last submission attempt time, and the configured grace
  period — enough to reconstruct the decision from logs alone.

  ## Changes

  - `internal/controller/sparkapplication/controller.go` — emit an `Info` log when the driver pod is
   missing after the grace period and the app is being marked `Failing`.