### PR TITLE
Fix(SparkConnect): Add BlockManager port to match Service definition

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -178,6 +178,7 @@ func driverConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 	driverHost := "$(host=${POD_IP}; if [[ $host == *:* ]] && [[ $host != \\[* ]]; then echo \"[$host]\"; else echo \"$host\"; fi)"
 	args = append(args, "--conf", fmt.Sprintf("spark.driver.host=%s", driverHost))
 	args = append(args, "--conf", "spark.driver.port=7078")
+	args = append(args, "--conf", "spark.driver.blockManager.port=7079")
 
 	// Driver pod name
 	args = append(args, "--conf", fmt.Sprintf("%s=%s", common.SparkKubernetesDriverPodName, fmt.Sprintf("%s-server", conn.Name)))


### PR DESCRIPTION
## Purpose of this PR
Set spark.driver.blockManager.port=7079 in the SparkConnect controller's driverConfOption, consistent with how spark.driver.port=7078 is already set. Without this, Spark assigns a random BlockManager port that does not match the Service's targetPort (7079), causing broadcast fetch failures when executors try to retrieve data from the driver's BlockManager through the Service.

**Proposed changes:**

- Add spark.driver.blockManager.port=7079 in driverConfOption() in internal/controller/sparkconnect/options.go
## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale
The SparkConnect Service definition in mutateServerService (reconciler.go) hardcodes the BlockManager port as 7079:
```
{
    Name:       "blockmanager",
    Port:       7079,
    TargetPort: intstr.FromInt(7079),
}
```
However, driverConfOption does not set spark.driver.blockManager.port, so Spark assigns a random port at startup. The Service forwards traffic to port 7079 where nothing is listening, causing INTERNAL_ERROR_BROADCAST failures when executors try to fetch broadcast data from the driver.
<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.