### PR TITLE
fix(kustomize): Add missing --metrics-job-submit-latency-buckets arg to controller deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,6 +73,7 @@ spec:
             - --metrics-prefix=
             - --metrics-labels=app_type
             - --metrics-job-start-latency-buckets=30,60,90,120,150,180,210,240,270,300
+            - --metrics-job-submit-latency-buckets=0.5,1,2,4,8,16,32,64,128,256
             - --leader-election=true
             - --leader-election-lock-name=spark-operator-controller-lock
             - --leader-election-lock-namespace=$(CONTROLLER_NAMESPACE)


### PR DESCRIPTION
## Purpose of this PR

PR #2942 added the `spark_application_submit_latency_seconds` metric with a configurable `--metrics-job-submit-latency-buckets` flag to the Helm chart's controller deployment template, but did not add the corresponding default to Kustomize's `config/manager/manager.yaml`. This caused the drift-check CI gate (PR #2933) to fail with a `ControllerArgs` mismatch.

**Proposed changes:**

- Add missing `--metrics-job-submit-latency-buckets=0.5,1,2,4,8,16,32,64,128,256` arg to Kustomize controller deployment (`config/manager/manager.yaml`), using the same default value as Helm's `values.yaml`.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Keeping Kustomize and Helm controller deployments aligned prevents configuration drift. Without this fix, the automated drift-check CI gate introduced in PR #2933 fails because Helm renders an arg that Kustomize is missing.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

- The drift-check test (`make drift-check`) validates this fix — all 21 subtests pass with this change, including `DeploymentSpecs/ControllerArgs`.
- Related PRs: #2942 (introduced the drift), #2933 (drift detection CI gate that caught it).