### PR TITLE
fix(controller): avoid invalidating apps on TTL updates

### DIFF
--- a/internal/controller/scheduledsparkapplication/event_filter_test.go
+++ b/internal/controller/scheduledsparkapplication/event_filter_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -339,39 +338,6 @@ func TestEventFilter_Update_NonScheduledSparkApplication(t *testing.T) {
 
 	if result != false {
 		t.Errorf("Update() with non-ScheduledSparkApplication = %v, expected false", result)
-	}
-}
-
-func TestEventFilter_Update_TemplateTimeToLiveSeconds(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = v1beta2.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	filter, err := NewEventFilter(fakeClient, []string{"default"}, "")
-	if err != nil {
-		t.Fatalf("NewEventFilter() unexpected error: %v", err)
-	}
-
-	oldApp := &v1beta2.ScheduledSparkApplication{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-app",
-			Namespace: "default",
-		},
-		Spec: v1beta2.ScheduledSparkApplicationSpec{
-			Template: v1beta2.SparkApplicationSpec{
-				Type:         v1beta2.SparkApplicationTypeScala,
-				SparkVersion: "3.5.0",
-			},
-		},
-	}
-	newApp := oldApp.DeepCopy()
-	newApp.Spec.Template.TimeToLiveSeconds = ptr.To[int64](60)
-
-	result := filter.Update(event.UpdateEvent{ObjectOld: oldApp, ObjectNew: newApp})
-
-	if result != true {
-		t.Errorf("Update() = %v, expected true", result)
 	}
 }
 

--- a/internal/controller/scheduledsparkapplication/event_filter_test.go
+++ b/internal/controller/scheduledsparkapplication/event_filter_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -338,6 +339,39 @@ func TestEventFilter_Update_NonScheduledSparkApplication(t *testing.T) {
 
 	if result != false {
 		t.Errorf("Update() with non-ScheduledSparkApplication = %v, expected false", result)
+	}
+}
+
+func TestEventFilter_Update_TemplateTimeToLiveSeconds(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1beta2.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	filter, err := NewEventFilter(fakeClient, []string{"default"}, "")
+	if err != nil {
+		t.Fatalf("NewEventFilter() unexpected error: %v", err)
+	}
+
+	oldApp := &v1beta2.ScheduledSparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+		Spec: v1beta2.ScheduledSparkApplicationSpec{
+			Template: v1beta2.SparkApplicationSpec{
+				Type:         v1beta2.SparkApplicationTypeScala,
+				SparkVersion: "3.5.0",
+			},
+		},
+	}
+	newApp := oldApp.DeepCopy()
+	newApp.Spec.Template.TimeToLiveSeconds = ptr.To[int64](60)
+
+	result := filter.Update(event.UpdateEvent{ObjectOld: oldApp, ObjectNew: newApp})
+
+	if result != true {
+		t.Errorf("Update() = %v, expected true", result)
 	}
 }
 

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -179,9 +179,11 @@ func (f *EventFilter) Update(e event.UpdateEvent) bool {
 	// This is currently best effort as we can potentially miss updates and end up in an inconsistent state.
 	if !equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) {
 
-		// Only Spec.Suspend can be updated without any action
+		// Spec.Suspend and Spec.TimeToLiveSeconds can be updated without invalidating
+		// the running application.
 		oldAppCopy := oldApp.DeepCopy()
 		oldAppCopy.Spec.Suspend = newApp.Spec.Suspend
+		oldAppCopy.Spec.TimeToLiveSeconds = newApp.Spec.TimeToLiveSeconds
 		if equality.Semantic.DeepEqual(oldAppCopy.Spec, newApp.Spec) {
 			return true
 		}

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -175,7 +175,7 @@ func (f *EventFilter) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	// The spec has changed except for Spec.Suspend.
+	// The spec has changed except for Spec.Suspend and Spec.TimeToLiveSeconds.
 	// This is currently best effort as we can potentially miss updates and end up in an inconsistent state.
 	if !equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) {
 
@@ -286,9 +286,11 @@ func (f *EventFilter) isWebhookPatchedFieldsOnlyChange(oldApp, newApp *v1beta2.S
 	clearWebhookPatchedExecutorFields(&oldCopy.Spec.Executor)
 	clearWebhookPatchedExecutorFields(&newCopy.Spec.Executor)
 
-	// Also zero out Suspend field as it's handled separately
+	// Also zero out Suspend field and TimeToLiveSeconds as it's handled separately
 	oldCopy.Spec.Suspend = nil
 	newCopy.Spec.Suspend = nil
+	oldCopy.Spec.TimeToLiveSeconds = nil
+	newCopy.Spec.TimeToLiveSeconds = nil
 
 	// If specs are equal after clearing webhook-patched fields,
 	// then only webhook-patched fields changed

--- a/internal/controller/sparkapplication/event_filter_test.go
+++ b/internal/controller/sparkapplication/event_filter_test.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -1085,6 +1087,51 @@ func TestSparkApplicationEventFilter_Create_NonSparkApplication(t *testing.T) {
 
 	if result != false {
 		t.Errorf("Create() with non-SparkApplication = %v, expected false", result)
+	}
+}
+
+func TestSparkApplicationEventFilter_Update_TimeToLiveSecondsDoesNotInvalidate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1beta2.AddToScheme(scheme)
+
+	oldApp := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-app",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Type:         v1beta2.SparkApplicationTypeScala,
+			SparkVersion: "3.5.0",
+		},
+		Status: v1beta2.SparkApplicationStatus{
+			AppState: v1beta2.ApplicationState{
+				State: v1beta2.ApplicationStateCompleted,
+			},
+		},
+	}
+	newApp := oldApp.DeepCopy()
+	newApp.ResourceVersion = "2"
+	newApp.Spec.TimeToLiveSeconds = ptr.To[int64](60)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1beta2.SparkApplication{}).
+		WithObjects(newApp.DeepCopy()).
+		Build()
+	filter, err := NewSparkApplicationEventFilter(fakeClient, record.NewFakeRecorder(10), []string{"default"}, "")
+	if err != nil {
+		t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
+	}
+
+	result := filter.Update(event.UpdateEvent{ObjectOld: oldApp, ObjectNew: newApp})
+
+	if result != true {
+		t.Errorf("Update() = %v, expected true", result)
+	}
+	if newApp.Status.AppState.State == v1beta2.ApplicationStateInvalidating {
+		t.Errorf("Update() moved application to %s for TimeToLiveSeconds-only change", v1beta2.ApplicationStateInvalidating)
 	}
 }
 


### PR DESCRIPTION
## Purpose of this PR
This PR prevents `SparkApplication` updates that only change `spec.timeToLiveSeconds` from moving the application into the `INVALIDATING` state.
**Proposed changes:**
- Treat `spec.timeToLiveSeconds` like `spec.suspend`, allowing it to be updated without invalidating the running application.
- Add regression coverage to verify TTL-only `SparkApplication` updates do not trigger invalidation.
- Add `ScheduledSparkApplication` coverage for updates to `spec.template.timeToLiveSeconds`.
## Change Category
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update
### Rationale
`timeToLiveSeconds` only controls garbage collection after a SparkApplication has terminated. Updating this field should not require rerunning or invalidating the application because it does not affect the running driver or executor pods.
## Checklist
- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
### Additional Notes
Tested locally with:
`go test ./internal/controller/sparkapplication ./internal/controller/scheduledsparkapplication`