### PR TITLE
Replace `tini` in entrypoint.sh with `catatonit`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG SPARK_GID=185
 USER root
 
 RUN apt-get update \
-    && apt-get install -y tini \
+    && apt-get install -y catatonit \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/k8s-webhook-server/serving-certs /home/spark && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,4 +23,6 @@ if ! getent passwd "$myuid" &> /dev/null; then
     done
 fi
 
-exec /usr/bin/tini -s -- /usr/bin/spark-operator "$@"
+# Path for catatonit may differ depending on base container OS
+CATATONIT=$(which catatonit)
+exec "$CATATONIT" -- /usr/bin/spark-operator "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->
Swap `tini` for `catatonit` in `entrypoint.sh`. The following are some reasons why `catatonit` should be used instead of `tini`:

- `catatonit`'s use of signalfd is more performant than `tini`'s use of sigwait due to its event driven approach to receiving signals.
- `catatonit` also verifies the child is alive with after fork() whereas tini blindly trusts it worked.
- `catatonit` also closes all filedescriptors in the parent process, though entrypoint.sh does not currently open any fd's, having thise close be automatic in the future would be valuable in case any are opened in the entrypoint script in the future for whatever reason.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
