### PR TITLE
feat(controller): emit Kubernetes event when driver pod missing after grace period

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -974,6 +974,14 @@ func (r *Reconciler) updateDriverState(ctx context.Context, app *v1beta2.SparkAp
 
 	if driverPod == nil {
 		if app.Status.AppState.State != v1beta2.ApplicationStateSubmitted || metav1.Now().Sub(app.Status.LastSubmissionAttemptTime.Time) > r.options.DriverPodCreationGracePeriod {
+			r.recorder.Eventf(
+				app,
+				corev1.EventTypeWarning,
+				common.EventSparkDriverNotFound,
+				"Driver pod %s not found after grace period %v, marking application as Failing",
+				app.Status.DriverInfo.PodName,
+				r.options.DriverPodCreationGracePeriod,
+			)
 			app.Status.AppState.State = v1beta2.ApplicationStateFailing
 			app.Status.AppState.ErrorMessage = "driver pod not found"
 			app.Status.TerminationTime = metav1.Now()

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -335,7 +335,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				nil,
 				k8sClient.Scheme(),
 				k8sClient,
-				nil,
+				record.NewFakeRecorder(3),
 				nil,
 				&sparkapplication.SparkSubmitter{},
 				sparkapplication.Options{Namespaces: []string{appNamespace}, DriverPodCreationGracePeriod: 0 * time.Second},

--- a/pkg/common/event.go
+++ b/pkg/common/event.go
@@ -35,6 +35,8 @@ const (
 	EventSparkApplicationSuspended = "SparkApplicationSuspended"
 
 	EventSparkApplicationResuming = "SparkApplicationResuming"
+
+	EventSparkDriverNotFound = "SparkDriverNotFound"
 )
 
 // Spark driver events


### PR DESCRIPTION
## Purpose of this PR

When the driver pod is missing past `DriverPodCreationGracePeriod`, `updateDriverState` transitions the `SparkApplication` to `Failing` and returns `nil`. The only signal of *why* this happened is `Status.AppState.ErrorMessage = "driver pod not found"` on the CR, which requires `kubectl describe sparkapplication` to discover. Controller-runtime logs nothing for a `nil` return, and no Kubernetes Event is emitted, so cluster operators relying on `kubectl get events` or event-based monitoring have no visibility into this failure path.

This PR emits a Kubernetes Warning event at the moment of transition, making the failure discoverable via standard Kubernetes observability mechanisms.

**Proposed changes:**

- Add a new event reason constant `EventSparkDriverNotFound` in `pkg/common/event.go`
- Emit a `Warning` event via `r.recorder.Eventf` in `updateDriverState` when the driver pod is not found after the grace period, including the driver pod name and configured grace period in the event message

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

This is a follow-up to [#2947](https://github.com/kubeflow/spark-operator/pull/2947) which added a structured log line for the same failure path. Kubernetes Events are the standard cloud-native mechanism for surfacing state transitions and are visible via `kubectl get events`, event watchers, and monitoring integrations without needing access to controller logs.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

The event follows the same pattern used throughout the controller (e.g., `EventSparkApplicationFailed`, `EventSparkDriverFailed`) using `r.recorder.Eventf` with `corev1.EventTypeWarning`.