### PR TITLE
REST-based spark submitter service as pluggable submission strategy

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -173,6 +173,10 @@ func NewStartCommand() *cobra.Command {
 				return fmt.Errorf("invalid value %q for --scheduled-spark-application-timestamp-precision, valid values: %v", scheduledSparkApplicationTimestampPrecision, validPrecisions)
 			}
 
+			if submitterMaxRetries < 1 {
+				return fmt.Errorf("invalid value %d for --submitter-max-retries, must be at least 1", submitterMaxRetries)
+			}
+
 			return nil
 		},
 		Run: func(_ *cobra.Command, args []string) {
@@ -345,7 +349,13 @@ func start() {
 		}
 	}
 
-	sparkSubmitter := newSparkSubmitter()
+	ctx := ctrl.SetupSignalHandler()
+
+	sparkSubmitter, err := newSparkSubmitter(ctx)
+	if err != nil {
+		logger.Error(err, "Failed to create spark submitter")
+		os.Exit(1)
+	}
 
 	// Setup controller for SparkApplication.
 	if err = sparkapplication.NewReconciler(
@@ -398,7 +408,7 @@ func start() {
 	}
 
 	logger.Info("Starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		logger.Error(err, "Failed to start manager")
 		os.Exit(1)
 	}
@@ -518,14 +528,9 @@ func newSparkConnectReconcilerOptions() sparkconnect.Options {
 	return options
 }
 
-func newSparkSubmitter() sparkapplication.SparkApplicationSubmitter {
+func newSparkSubmitter(ctx context.Context) (sparkapplication.SparkApplicationSubmitter, error) {
 	if !features.Enabled(features.RestSubmitter) {
-		return &sparkapplication.SparkSubmitter{}
-	}
-
-	if submitterMaxRetries < 1 {
-		logger.Info("WARNING: --submitter-max-retries is less than 1, defaulting to 1", "configured", submitterMaxRetries)
-		submitterMaxRetries = 1
+		return &sparkapplication.SparkSubmitter{}, nil
 	}
 
 	var tlsCfg *sparkapplication.TLSConfig
@@ -546,17 +551,15 @@ func newSparkSubmitter() sparkapplication.SparkApplicationSubmitter {
 		TLS:             tlsCfg,
 	})
 	if err != nil {
-		logger.Error(err, "Failed to initialize REST submitter")
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to initialize RestSubmitter: %w", err)
 	}
 
-	startupCtx, cancel := context.WithTimeout(context.Background(), submitterStartupTimeout)
+	startupCtx, cancel := context.WithTimeout(ctx, submitterStartupTimeout)
 	defer cancel()
 	if err := submitter.WaitForConnection(startupCtx); err != nil {
-		logger.Error(err, "REST submitter service not reachable at startup")
-		os.Exit(1)
+		return nil, fmt.Errorf("RestSubmitter service not reachable at startup: %w", err)
 	}
 
 	logger.Info("Using REST submitter service", "url", submitterServiceURL)
-	return submitter
+	return submitter, nil
 }

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -141,10 +141,10 @@ var (
 	submitterRequestTimeout time.Duration
 	submitterMaxRetries     int
 	submitterInitialBackoff time.Duration
-	submitterTLSEnabled  bool
-	submitterTLSCertFile string
-	submitterTLSKeyFile  string
-	submitterTLSCAFile   string
+	submitterTLSEnabled     bool
+	submitterTLSCertFile    string
+	submitterTLSKeyFile     string
+	submitterTLSCAFile      string
 )
 
 func NewStartCommand() *cobra.Command {

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"time"
 
@@ -142,10 +141,10 @@ var (
 	submitterRequestTimeout time.Duration
 	submitterMaxRetries     int
 	submitterInitialBackoff time.Duration
-	submitterTLSCertDir     string
-	submitterTLSCertName    string
-	submitterTLSKeyName     string
-	submitterTLSCAName      string
+	submitterTLSEnabled  bool
+	submitterTLSCertFile string
+	submitterTLSKeyFile  string
+	submitterTLSCAFile   string
 )
 
 func NewStartCommand() *cobra.Command {
@@ -173,8 +172,18 @@ func NewStartCommand() *cobra.Command {
 				return fmt.Errorf("invalid value %q for --scheduled-spark-application-timestamp-precision, valid values: %v", scheduledSparkApplicationTimestampPrecision, validPrecisions)
 			}
 
-			if submitterMaxRetries < 1 {
-				return fmt.Errorf("invalid value %d for --submitter-max-retries, must be at least 1", submitterMaxRetries)
+			if features.Enabled(features.RestSubmitter) {
+				if submitterServiceURL == "" {
+					return fmt.Errorf("--submitter-service-url is required when RestSubmitter feature gate is enabled")
+				}
+				if submitterMaxRetries < 1 {
+					return fmt.Errorf("invalid value %d for --submitter-max-retries, must be at least 1", submitterMaxRetries)
+				}
+				if submitterTLSEnabled {
+					if submitterTLSCertFile == "" || submitterTLSKeyFile == "" || submitterTLSCAFile == "" {
+						return fmt.Errorf("--submitter-tls-enabled requires --submitter-tls-cert-file, --submitter-tls-key-file, and --submitter-tls-ca-file")
+					}
+				}
 			}
 
 			return nil
@@ -249,10 +258,10 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().DurationVar(&submitterRequestTimeout, "submitter-request-timeout", 2*time.Minute, "HTTP request timeout per spark submission attempt.")
 	command.Flags().IntVar(&submitterMaxRetries, "submitter-max-retries", 3, "Max retry attempts for transient spark submission failures.")
 	command.Flags().DurationVar(&submitterInitialBackoff, "submitter-initial-backoff", 2*time.Second, "Initial backoff duration before the first retry.")
-	command.Flags().StringVar(&submitterTLSCertDir, "submitter-tls-cert-dir", "", "Directory containing TLS files for the submitter. When set, TLS is enabled.")
-	command.Flags().StringVar(&submitterTLSCertName, "submitter-tls-cert-name", "tls.crt", "File name of the client certificate in the TLS cert directory.")
-	command.Flags().StringVar(&submitterTLSKeyName, "submitter-tls-key-name", "tls.key", "File name of the client private key in the TLS cert directory.")
-	command.Flags().StringVar(&submitterTLSCAName, "submitter-tls-ca-name", "ca.crt", "File name of the CA certificate in the TLS cert directory.")
+	command.Flags().BoolVar(&submitterTLSEnabled, "submitter-tls-enabled", false, "Enable mTLS for communication with the submitter service.")
+	command.Flags().StringVar(&submitterTLSCertFile, "submitter-tls-cert-file", "", "Path to the client certificate file for mTLS with the submitter service.")
+	command.Flags().StringVar(&submitterTLSKeyFile, "submitter-tls-key-file", "", "Path to the client private key file for mTLS with the submitter service.")
+	command.Flags().StringVar(&submitterTLSCAFile, "submitter-tls-ca-file", "", "Path to the CA certificate file for verifying the submitter service.")
 
 	flagSet := flag.NewFlagSet("controller", flag.ExitOnError)
 	ctrl.RegisterFlags(flagSet)
@@ -534,12 +543,12 @@ func newSparkSubmitter(ctx context.Context) (sparkapplication.SparkApplicationSu
 	}
 
 	var tlsCfg *sparkapplication.TLSConfig
-	if submitterTLSCertDir != "" {
+	if submitterTLSEnabled {
 		tlsCfg = &sparkapplication.TLSConfig{
 			Enabled:    true,
-			CertFile:   filepath.Join(submitterTLSCertDir, submitterTLSCertName),
-			KeyFile:    filepath.Join(submitterTLSCertDir, submitterTLSKeyName),
-			CACertFile: filepath.Join(submitterTLSCertDir, submitterTLSCAName),
+			CertFile:   submitterTLSCertFile,
+			KeyFile:    submitterTLSKeyFile,
+			CACertFile: submitterTLSCAFile,
 		}
 	}
 

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -17,10 +17,12 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"time"
 
@@ -29,7 +31,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	// Import features package to register feature gates.
-	_ "github.com/kubeflow/spark-operator/v2/pkg/features"
+	"github.com/kubeflow/spark-operator/v2/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 
@@ -133,6 +135,17 @@ var (
 	scheduledSparkApplicationTimestampPrecision string
 	development                                 bool
 	zapOptions                                  = logzap.Options{}
+
+	// REST submitter (behind RestSubmitter feature gate)
+	submitterServiceURL     string
+	submitterStartupTimeout time.Duration
+	submitterRequestTimeout time.Duration
+	submitterMaxRetries     int
+	submitterInitialBackoff time.Duration
+	submitterTLSCertDir     string
+	submitterTLSCertName    string
+	submitterTLSKeyName     string
+	submitterTLSCAName      string
 )
 
 func NewStartCommand() *cobra.Command {
@@ -225,6 +238,17 @@ func NewStartCommand() *cobra.Command {
 		"If not set, it will be 0 in order to disable the pprof server")
 
 	command.Flags().StringVar(&scheduledSparkApplicationTimestampPrecision, "scheduled-spark-application-timestamp-precision", "nanos", "Timestamp precision for ScheduledSparkApplication run names. Valid values: nanos, micros, millis, seconds, minutes.")
+
+	// REST submitter flags (used when RestSubmitter feature gate is enabled)
+	command.Flags().StringVar(&submitterServiceURL, "submitter-service-url", "", "Full submit endpoint URL of the submitter service (required when RestSubmitter feature gate is enabled).")
+	command.Flags().DurationVar(&submitterStartupTimeout, "submitter-startup-timeout", 5*time.Minute, "How long the controller waits for the submitter service to become reachable at startup.")
+	command.Flags().DurationVar(&submitterRequestTimeout, "submitter-request-timeout", 2*time.Minute, "HTTP request timeout per spark submission attempt.")
+	command.Flags().IntVar(&submitterMaxRetries, "submitter-max-retries", 3, "Max retry attempts for transient spark submission failures.")
+	command.Flags().DurationVar(&submitterInitialBackoff, "submitter-initial-backoff", 2*time.Second, "Initial backoff duration before the first retry.")
+	command.Flags().StringVar(&submitterTLSCertDir, "submitter-tls-cert-dir", "", "Directory containing TLS files for the submitter. When set, TLS is enabled.")
+	command.Flags().StringVar(&submitterTLSCertName, "submitter-tls-cert-name", "tls.crt", "File name of the client certificate in the TLS cert directory.")
+	command.Flags().StringVar(&submitterTLSKeyName, "submitter-tls-key-name", "tls.key", "File name of the client private key in the TLS cert directory.")
+	command.Flags().StringVar(&submitterTLSCAName, "submitter-tls-ca-name", "ca.crt", "File name of the CA certificate in the TLS cert directory.")
 
 	flagSet := flag.NewFlagSet("controller", flag.ExitOnError)
 	ctrl.RegisterFlags(flagSet)
@@ -321,7 +345,7 @@ func start() {
 		}
 	}
 
-	sparkSubmitter := &sparkapplication.SparkSubmitter{}
+	sparkSubmitter := newSparkSubmitter()
 
 	// Setup controller for SparkApplication.
 	if err = sparkapplication.NewReconciler(
@@ -492,4 +516,47 @@ func newSparkConnectReconcilerOptions() sparkconnect.Options {
 		NamespaceSelector: namespaceSelector,
 	}
 	return options
+}
+
+func newSparkSubmitter() sparkapplication.SparkApplicationSubmitter {
+	if !features.Enabled(features.RestSubmitter) {
+		return &sparkapplication.SparkSubmitter{}
+	}
+
+	if submitterMaxRetries < 1 {
+		logger.Info("WARNING: --submitter-max-retries is less than 1, defaulting to 1", "configured", submitterMaxRetries)
+		submitterMaxRetries = 1
+	}
+
+	var tlsCfg *sparkapplication.TLSConfig
+	if submitterTLSCertDir != "" {
+		tlsCfg = &sparkapplication.TLSConfig{
+			Enabled:    true,
+			CertFile:   filepath.Join(submitterTLSCertDir, submitterTLSCertName),
+			KeyFile:    filepath.Join(submitterTLSCertDir, submitterTLSKeyName),
+			CACertFile: filepath.Join(submitterTLSCertDir, submitterTLSCAName),
+		}
+	}
+
+	submitter, err := sparkapplication.NewRestSparkSubmitter(sparkapplication.RestSparkSubmitterConfig{
+		URL:             submitterServiceURL,
+		RetryMaxRetries: submitterMaxRetries,
+		RequestTimeout:  submitterRequestTimeout,
+		InitialBackoff:  submitterInitialBackoff,
+		TLS:             tlsCfg,
+	})
+	if err != nil {
+		logger.Error(err, "Failed to initialize REST submitter")
+		os.Exit(1)
+	}
+
+	startupCtx, cancel := context.WithTimeout(context.Background(), submitterStartupTimeout)
+	defer cancel()
+	if err := submitter.WaitForConnection(startupCtx); err != nil {
+		logger.Error(err, "REST submitter service not reachable at startup")
+		os.Exit(1)
+	}
+
+	logger.Info("Using REST submitter service", "url", submitterServiceURL)
+	return submitter
 }

--- a/internal/controller/sparkapplication/rest_submission.go
+++ b/internal/controller/sparkapplication/rest_submission.go
@@ -317,8 +317,8 @@ func newSubmitRequest(args []string, app *v1beta2.SparkApplication) *submitReque
 	return &submitRequest{
 		SubmissionID:        app.Status.SubmissionID,
 		SparkSubmitArgs:     args,
-		DriverPodTemplate:   app.Spec.Driver.Template,
-		ExecutorPodTemplate: app.Spec.Executor.Template,
+		DriverPodTemplate:   buildDriverPodTemplate(app),
+		ExecutorPodTemplate: buildExecutorPodTemplate(app),
 	}
 }
 
@@ -378,7 +378,7 @@ func (c *RestSparkSubmitter) canRetry(attempt int, err error) bool {
 	if errors.As(err, &submitErr) {
 		return submitErr.IsRetryable()
 	}
-	// Network and TLS errors (connection refused, timeout, cert reload) are transient and retryable.
+	// Network and TLS errors (connection refused, timeout) are transient and retryable.
 	return true
 }
 

--- a/internal/controller/sparkapplication/rest_submission.go
+++ b/internal/controller/sparkapplication/rest_submission.go
@@ -1,0 +1,486 @@
+/*
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// REST Submitter Client
+//
+// Submits SparkApplications to the k8s-spark-submitter service (POST /api/v1/spark-submit).
+//
+// # Contract
+//
+//  1. Submission-only, stateless. The submitter creates the driver pod and returns its identity.
+//     It does not track, monitor, restart, or delete applications. All lifecycle and status
+//     ownership remains with the operator via Kubernetes owner references.
+//  2. The request carries the same spark-submit argument vector the operator already produces
+//     via buildSparkSubmitArgs. There is no parallel spec schema.
+//  3. Every submission carries a client-supplied submission_id for correlation and operator-side
+//     idempotency. The client is responsible for providing a unique id; conflicts lead to failures.
+//  4. Pod templates are sent inline as JSON. The operator omits podTemplateFile --conf entries
+//     from spark_submit_args; the submitter merges the inline template with the args exactly as
+//     Spark does when loading a podTemplateFile (template is base, --conf values layered on top).
+//
+// # Idempotency
+//
+// The submitter is stateless — it creates the driver pod via Spark libraries and returns
+// DRIVER_POD_ALREADY_EXISTS if the pod already exists. It does not track prior submissions.
+//
+// The operator achieves idempotency by comparing the returned submission_id with its own:
+//   - Match → retry of a completed submission, treat as success.
+//   - Mismatch → genuine conflict, treat as failure.
+//
+// # Request Payload
+//
+//	POST /api/v1/spark-submit
+//	Content-Type: application/json
+//
+//	{
+//	  "submission_id": "550e8400-e29b-41d4-a716-446655440000",
+//	  "spark_submit_args": ["--master", "k8s://...", "--deploy-mode", "cluster", "..."],
+//	  "driver_pod_template": { "metadata": {}, "spec": {} },
+//	  "executor_pod_template": { "metadata": {}, "spec": {} }
+//	}
+//
+//	| Field                  | Type                   | Required | Notes                                                  |
+//	| ---------------------- | ---------------------- | -------- | ------------------------------------------------------ |
+//	| submission_id          | string                 | yes      | Correlation + idempotency key. From Status.SubmissionID |
+//	| spark_submit_args      | []string               | yes      | Verbatim spark-submit args                             |
+//	| driver_pod_template    | object (PodTemplateSpec)| no      | Inline driver template (omits podTemplateFile conf)    |
+//	| executor_pod_template  | object (PodTemplateSpec)| no      | Inline executor template                               |
+//
+// # Success Response (201 Created)
+//
+//	{
+//	  "submission_id": "550e8400-e29b-41d4-a716-446655440000",
+//	  "app_name": "spark-pi",
+//	  "spark_app_id": "spark-b992db7da52c42298736dcbb3c9142be",
+//	  "driver_pod_name": "spark-pi-abc123-driver",
+//	  "driver_pod_uid": "0c1f...",
+//	  "namespace": "spark-jobs",
+//	  "submitted_at": "2026-06-16T08:30:00Z"
+//	}
+//
+//	| Field              | Type   | Notes                                                                |
+//	| ------------------ | ------ | -------------------------------------------------------------------- |
+//	| submission_id      | string | Echoes the request value                                             |
+//	| spark_app_id       | string | Spark application id assigned to the submission                      |
+//	| driver_pod_name    | string | Name of the created driver pod                                       |
+//	| driver_pod_uid     | string | UID of the driver pod; lets the operator bind to the exact object    |
+//
+//	Semantics of 201: the driver pod object was persisted to the API server. It does not assert
+//	the driver was scheduled, started, or succeeded.
+//
+// # Error Response
+//
+//	{
+//	  "submission_id": "550e8400-e29b-41d4-a716-446655440000",
+//	  "status": 422,
+//	  "error_code": "POD_TEMPLATE_INVALID",
+//	  "message": "Driver template missing 'spark-kubernetes-driver' container",
+//	  "timestamp": "2026-06-16T08:30:00Z"
+//	}
+//
+//	| error_code                 | HTTP | Retry? | Meaning                                            |
+//	| -------------------------- | ---- | ------ | -------------------------------------------------- |
+//	| BAD_REQUEST                | 400  | No     | Malformed JSON or missing required fields           |
+//	| INVALID_SPARK_SUBMIT_ARGS  | 400  | No     | spark_submit_args failed Spark argument parsing     |
+//	| METHOD_NOT_ALLOWED         | 405  | No     | Non-POST request                                   |
+//	| UNSUPPORTED_MEDIA_TYPE     | 415  | No     | Content-Type is not application/json                |
+//	| DRIVER_POD_ALREADY_EXISTS  | 422  | No     | Pod name conflict (K8s 409)                        |
+//	| INVALID_POD_TEMPLATE       | 422  | No     | Template structurally invalid (K8s 422)            |
+//	| INTERNAL_SERVER_ERROR      | 500  | Yes    | Unexpected server failure                          |
+//	| SUBMITTER_OVERLOADED       | 503  | Yes    | Submitter at capacity; back off and retry          |
+
+package sparkapplication
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+const (
+	contentTypeJSON          = "application/json"
+	maxResponseBodySizeBytes = 1048576 // 1MB
+	maxErrorBodyLength       = 200
+	startupPollInterval      = 1 * time.Second
+	maxIdleConns             = 100
+	maxIdleConnsPerHost      = 100
+	idleConnTimeout          = 90 * time.Second
+)
+
+// --- Error codes and types ---
+
+// SubmitErrorCode represents the structured error codes returned by the submitter service.
+// See the error_code table in the file-level doc for the full mapping.
+type SubmitErrorCode string
+
+const (
+	ErrorCodeBadRequest             SubmitErrorCode = "BAD_REQUEST"
+	ErrorCodeInvalidSparkSubmitArgs SubmitErrorCode = "INVALID_SPARK_SUBMIT_ARGS"
+	ErrorCodeMethodNotAllowed       SubmitErrorCode = "METHOD_NOT_ALLOWED"
+	ErrorCodeUnsupportedMediaType   SubmitErrorCode = "UNSUPPORTED_MEDIA_TYPE"
+	ErrorCodeDriverPodAlreadyExists SubmitErrorCode = "DRIVER_POD_ALREADY_EXISTS"
+	ErrorCodeInvalidPodTemplate     SubmitErrorCode = "INVALID_POD_TEMPLATE"
+	ErrorCodeInternalServerError    SubmitErrorCode = "INTERNAL_SERVER_ERROR"
+	ErrorCodeSubmitterOverloaded    SubmitErrorCode = "SUBMITTER_OVERLOADED"
+)
+
+// SubmitError wraps a submitter error response with the structured error code.
+type SubmitError struct {
+	SubmissionID string
+	Code         SubmitErrorCode
+	StatusCode   int
+	Message      string
+}
+
+func (e *SubmitError) Error() string {
+	return fmt.Sprintf("submitter service returned error: %s (HTTP %d, error code: %s)", e.Message, e.StatusCode, e.Code)
+}
+
+func (e *SubmitError) IsRetryable() bool {
+	return e.Code == ErrorCodeSubmitterOverloaded || e.Code == ErrorCodeInternalServerError
+}
+
+func (e *SubmitError) IsRetryOfCompletedSubmission(submissionID string) bool {
+	return e.Code == ErrorCodeDriverPodAlreadyExists && e.SubmissionID == submissionID
+}
+
+// --- Config and types ---
+
+var restLogger = ctrl.Log.WithName("rest-submitter")
+
+// TLSConfig holds TLS settings for the submitter REST client.
+type TLSConfig struct {
+	Enabled    bool
+	CertFile   string
+	KeyFile    string
+	CACertFile string
+}
+
+// RestSparkSubmitterConfig holds submitter connection settings.
+type RestSparkSubmitterConfig struct {
+	URL             string
+	RetryMaxRetries int
+	RequestTimeout  time.Duration
+	InitialBackoff  time.Duration
+	TLS             *TLSConfig
+}
+
+// RestSparkSubmitter submits a SparkApplication via the REST submitter service.
+type RestSparkSubmitter struct {
+	httpClient     *http.Client
+	submitURL      string
+	hostAddr       string
+	maxRetries     int
+	initialBackoff time.Duration
+}
+
+var _ SparkApplicationSubmitter = &RestSparkSubmitter{}
+
+// --- Request/Response payloads ---
+
+type submitRequest struct {
+	SubmissionID        string                  `json:"submission_id"`
+	SparkSubmitArgs     []string                `json:"spark_submit_args"`
+	DriverPodTemplate   *corev1.PodTemplateSpec `json:"driver_pod_template,omitempty"`
+	ExecutorPodTemplate *corev1.PodTemplateSpec `json:"executor_pod_template,omitempty"`
+}
+
+type submitResponse struct {
+	SubmissionID  string `json:"submission_id"`
+	AppName       string `json:"app_name"`
+	Message       string `json:"message"`
+	SubmittedAt   string `json:"submitted_at"`
+	SparkAppID    string `json:"spark_app_id"`
+	DriverPodName string `json:"driver_pod_name"`
+	DriverPodUID  string `json:"driver_pod_uid"`
+	Namespace     string `json:"namespace"`
+}
+
+type submitErrorResponse struct {
+	SubmissionID string          `json:"submission_id"`
+	Status       int             `json:"status"`
+	ErrorCode    SubmitErrorCode `json:"error_code"`
+	Message      string          `json:"message"`
+	Timestamp    string          `json:"timestamp"`
+}
+
+// --- Constructor ---
+
+// NewRestSparkSubmitter creates a REST client for the submitter service.
+func NewRestSparkSubmitter(cfg RestSparkSubmitterConfig) (*RestSparkSubmitter, error) {
+	submitURL := strings.TrimSpace(cfg.URL)
+	if submitURL == "" {
+		return nil, fmt.Errorf("submitter URL is required")
+	}
+
+	u, err := url.Parse(submitURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid submitter URL %q: %w", cfg.URL, err)
+	}
+	if u.Port() == "" {
+		return nil, fmt.Errorf("submitter URL %q must include an explicit port", cfg.URL)
+	}
+
+	transport, err := buildTransport(cfg.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transport: %w", err)
+	}
+
+	return &RestSparkSubmitter{
+		httpClient:     &http.Client{Timeout: cfg.RequestTimeout, Transport: transport},
+		submitURL:      submitURL,
+		hostAddr:       u.Host,
+		maxRetries:     cfg.RetryMaxRetries,
+		initialBackoff: cfg.InitialBackoff,
+	}, nil
+}
+
+// --- Public methods ---
+
+// WaitForConnection blocks until the submitter service responds to an HTTP request (verifying
+// both network connectivity and TLS handshake) or the context expires.
+func (c *RestSparkSubmitter) WaitForConnection(ctx context.Context) error {
+	restLogger.Info("Waiting for submitter service to be ready", "addr", c.hostAddr)
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.submitURL, nil)
+		resp, err := c.httpClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			restLogger.Info("Submitter service is ready", "addr", c.hostAddr)
+			return nil
+		}
+		restLogger.V(1).Info("Submitter service not yet ready, retrying", "addr", c.hostAddr, "error", err)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for submitter service at %s: %w", c.hostAddr, ctx.Err())
+		case <-time.After(startupPollInterval):
+		}
+	}
+}
+
+// Submit implements SparkApplicationSubmitter interface.
+func (c *RestSparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication) error {
+	args, err := buildSparkSubmitArgs(app, true)
+	if err != nil {
+		return fmt.Errorf("failed to build spark-submit arguments: %v", err)
+	}
+
+	request := newSubmitRequest(args, app)
+	restLogger.Info("Submitting spark application via RestSubmitter", "name", app.Name, "namespace", app.Namespace, "submissionId", request.SubmissionID)
+
+	response, err := c.doSubmitWithRetry(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to submit Spark application %s/%s: %w", app.Namespace, app.Name, err)
+	}
+
+	restLogger.Info("Submitted successfully",
+		"name", app.Name,
+		"submissionId", response.SubmissionID,
+		"driverPod", response.DriverPodName,
+		"sparkAppId", response.SparkAppID,
+	)
+	return nil
+}
+
+// --- Submission internals ---
+
+func newSubmitRequest(args []string, app *v1beta2.SparkApplication) *submitRequest {
+	return &submitRequest{
+		SubmissionID:        app.Status.SubmissionID,
+		SparkSubmitArgs:     args,
+		DriverPodTemplate:   app.Spec.Driver.Template,
+		ExecutorPodTemplate: app.Spec.Executor.Template,
+	}
+}
+
+// doSubmitWithRetry submits the request with exponential backoff.
+// If the submitter returns DRIVER_POD_ALREADY_EXISTS for the same submission_id,
+// it is treated as idempotent success (the prior attempt created the pod).
+func (c *RestSparkSubmitter) doSubmitWithRetry(ctx context.Context, request *submitRequest) (*submitResponse, error) {
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal submission request to JSON: %w", err)
+	}
+
+	var lastErr error
+	backoff := c.initialBackoff
+
+	for attempt := 0; attempt < c.maxRetries; attempt++ {
+		result, postErr := c.tryPost(ctx, jsonData)
+		if postErr == nil {
+			return result, nil
+		}
+		lastErr = postErr
+
+		var submitErr *SubmitError
+		if errors.As(lastErr, &submitErr) && submitErr.IsRetryOfCompletedSubmission(request.SubmissionID) {
+			restLogger.Info("Driver pod already exists for this submission, treating as success",
+				"submissionId", request.SubmissionID)
+			return &submitResponse{SubmissionID: request.SubmissionID}, nil
+		}
+
+		if !c.canRetry(attempt, lastErr) {
+			return nil, lastErr
+		}
+
+		backoff, err = c.waitForRetry(ctx, attempt, backoff, lastErr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, lastErr
+}
+
+func (c *RestSparkSubmitter) tryPost(ctx context.Context, jsonData []byte) (*submitResponse, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.submitURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request to %s: %w", c.submitURL, err)
+	}
+	httpReq.Header.Set("Content-Type", contentTypeJSON)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP request to %s: %w", c.submitURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return parseSubmitResponse(resp)
+}
+
+func (c *RestSparkSubmitter) canRetry(attempt int, err error) bool {
+	if attempt >= c.maxRetries-1 {
+		return false
+	}
+	var submitErr *SubmitError
+	if errors.As(err, &submitErr) {
+		return submitErr.IsRetryable()
+	}
+	// Network and TLS errors (connection refused, timeout, cert reload) are transient and retryable.
+	return true
+}
+
+func (c *RestSparkSubmitter) waitForRetry(ctx context.Context, attempt int, backoff time.Duration, lastErr error) (time.Duration, error) {
+	restLogger.V(1).Info("Retrying submission", "attempt", attempt+1, "maxRetries", c.maxRetries, "backoff", backoff, "error", lastErr)
+	select {
+	case <-ctx.Done():
+		return backoff, fmt.Errorf("retry cancelled: %w", ctx.Err())
+	case <-time.After(backoff):
+		return backoff * 2, nil
+	}
+}
+
+// --- Response parsing ---
+
+func parseSubmitResponse(resp *http.Response) (*submitResponse, error) {
+	statusCode := resp.StatusCode
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySizeBytes))
+
+	if readErr != nil {
+		return nil, fmt.Errorf("failed to read response body from submitter service (status %d): %w", statusCode, readErr)
+	}
+
+	if statusCode == http.StatusCreated {
+		var r submitResponse
+		if err := json.Unmarshal(body, &r); err != nil {
+			return nil, fmt.Errorf("failed to parse success response from submitter service (status %d): %w", statusCode, err)
+		}
+		return &r, nil
+	}
+
+	var errResp submitErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		return nil, &SubmitError{
+			SubmissionID: errResp.SubmissionID,
+			Code:         errResp.ErrorCode,
+			StatusCode:   statusCode,
+			Message:      errResp.Message,
+		}
+	}
+
+	bodyStr := string(body)
+	if len(bodyStr) > maxErrorBodyLength {
+		bodyStr = bodyStr[:maxErrorBodyLength] + "..."
+	}
+	return nil, fmt.Errorf("submitter service returned unexpected response (HTTP %d): %s", statusCode, bodyStr)
+}
+
+// --- TLS transport ---
+
+// buildTransport creates an HTTP transport, optionally with TLS configured.
+func buildTransport(tlsCfg *TLSConfig) (http.RoundTripper, error) {
+	transport := &http.Transport{
+		MaxIdleConns:        maxIdleConns,
+		MaxIdleConnsPerHost: maxIdleConnsPerHost,
+		IdleConnTimeout:     idleConnTimeout,
+	}
+
+	if tlsCfg == nil || !tlsCfg.Enabled {
+		return transport, nil
+	}
+
+	tlsConfig := &tls.Config{}
+
+	caCertFile := strings.TrimSpace(tlsCfg.CACertFile)
+	certFile := strings.TrimSpace(tlsCfg.CertFile)
+	keyFile := strings.TrimSpace(tlsCfg.KeyFile)
+
+	if caCertFile != "" {
+		caCert, err := os.ReadFile(caCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA cert file %q: %w", caCertFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA cert from %q", caCertFile)
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	if (certFile != "") != (keyFile != "") {
+		return nil, fmt.Errorf("both tls.crt and tls.key must be present in the TLS cert directory, got cert=%q key=%q", certFile, keyFile)
+	}
+
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate %q / %q: %w", certFile, keyFile, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+		restLogger.Info("TLS enabled with client certificate (mTLS)", "certFile", certFile, "keyFile", keyFile)
+	} else {
+		restLogger.Info("TLS enabled (server verification only)", "caCertFile", caCertFile)
+	}
+
+	transport.TLSClientConfig = tlsConfig
+	return transport, nil
+}

--- a/internal/controller/sparkapplication/rest_submission.go
+++ b/internal/controller/sparkapplication/rest_submission.go
@@ -269,7 +269,7 @@ func (c *RestSparkSubmitter) WaitForConnection(ctx context.Context) error {
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.submitURL, nil)
 		resp, err := c.httpClient.Do(req)
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			restLogger.Info("Submitter service is ready", "addr", c.hostAddr)
 			return nil
 		}

--- a/internal/controller/sparkapplication/rest_submission.go
+++ b/internal/controller/sparkapplication/rest_submission.go
@@ -25,20 +25,17 @@ limitations under the License.
 //     ownership remains with the operator via Kubernetes owner references.
 //  2. The request carries the same spark-submit argument vector the operator already produces
 //     via buildSparkSubmitArgs. There is no parallel spec schema.
-//  3. Every submission carries a client-supplied submission_id for correlation and operator-side
-//     idempotency. The client is responsible for providing a unique id; conflicts lead to failures.
+//  3. Every submission carries a client-supplied submission_id. Repeat submissions with the
+//     same submission_id are idempotent (returns 200 with duplicate_submission=true).
 //  4. Pod templates are sent inline as JSON. The operator omits podTemplateFile --conf entries
 //     from spark_submit_args; the submitter merges the inline template with the args exactly as
 //     Spark does when loading a podTemplateFile (template is base, --conf values layered on top).
 //
 // # Idempotency
 //
-// The submitter is stateless — it creates the driver pod via Spark libraries and returns
-// DRIVER_POD_ALREADY_EXISTS if the pod already exists. It does not track prior submissions.
-//
-// The operator achieves idempotency by comparing the returned submission_id with its own:
-//   - Match → retry of a completed submission, treat as success.
-//   - Mismatch → genuine conflict, treat as failure.
+// Duplicate submission (same submission_id) returns 200 with duplicate_submission=true
+// and existing pod details. The operator treats both 201 and 200 as success.
+// A genuine pod name conflict (different submission_id) returns DRIVER_POD_ALREADY_EXISTS error.
 //
 // # Request Payload
 //
@@ -59,7 +56,7 @@ limitations under the License.
 //	| driver_pod_template    | object (PodTemplateSpec)| no      | Inline driver template (omits podTemplateFile conf)    |
 //	| executor_pod_template  | object (PodTemplateSpec)| no      | Inline executor template                               |
 //
-// # Success Response (201 Created)
+// # Success Response (201 Created / 200 OK)
 //
 //	{
 //	  "submission_id": "550e8400-e29b-41d4-a716-446655440000",
@@ -68,18 +65,20 @@ limitations under the License.
 //	  "driver_pod_name": "spark-pi-abc123-driver",
 //	  "driver_pod_uid": "0c1f...",
 //	  "namespace": "spark-jobs",
-//	  "submitted_at": "2026-06-16T08:30:00Z"
+//	  "submitted_at": "2026-06-16T08:30:00Z",
+//	  "duplicate_submission": false
 //	}
 //
-//	| Field              | Type   | Notes                                                                |
-//	| ------------------ | ------ | -------------------------------------------------------------------- |
-//	| submission_id      | string | Echoes the request value                                             |
-//	| spark_app_id       | string | Spark application id assigned to the submission                      |
-//	| driver_pod_name    | string | Name of the created driver pod                                       |
-//	| driver_pod_uid     | string | UID of the driver pod; lets the operator bind to the exact object    |
+//	| Field                | Type   | Notes                                                                |
+//	| -------------------- | ------ | -------------------------------------------------------------------- |
+//	| submission_id        | string | Echoes the request value                                             |
+//	| spark_app_id         | string | Spark application id assigned to the submission                      |
+//	| driver_pod_name      | string | Name of the created driver pod                                       |
+//	| driver_pod_uid       | string | UID of the driver pod; lets the operator bind to the exact object    |
+//	| duplicate_submission | bool   | true when the pod already existed for this submission_id (200 OK)    |
 //
-//	Semantics of 201: the driver pod object was persisted to the API server. It does not assert
-//	the driver was scheduled, started, or succeeded.
+//	201: driver pod was created. 200: duplicate submission, existing pod returned.
+//	Neither asserts the driver was scheduled, started, or succeeded.
 //
 // # Error Response
 //
@@ -97,7 +96,7 @@ limitations under the License.
 //	| INVALID_SPARK_SUBMIT_ARGS  | 400  | No     | spark_submit_args failed Spark argument parsing     |
 //	| METHOD_NOT_ALLOWED         | 405  | No     | Non-POST request                                   |
 //	| UNSUPPORTED_MEDIA_TYPE     | 415  | No     | Content-Type is not application/json                |
-//	| DRIVER_POD_ALREADY_EXISTS  | 422  | No     | Pod name conflict (K8s 409)                        |
+//	| DRIVER_POD_ALREADY_EXISTS  | 409  | No     | Pod exists for a different submission_id (conflict) |
 //	| INVALID_POD_TEMPLATE       | 422  | No     | Template structurally invalid (K8s 422)            |
 //	| INTERNAL_SERVER_ERROR      | 500  | Yes    | Unexpected server failure                          |
 //	| SUBMITTER_OVERLOADED       | 503  | Yes    | Submitter at capacity; back off and retry          |
@@ -168,10 +167,6 @@ func (e *SubmitError) IsRetryable() bool {
 	return e.Code == ErrorCodeSubmitterOverloaded || e.Code == ErrorCodeInternalServerError
 }
 
-func (e *SubmitError) IsRetryOfCompletedSubmission(submissionID string) bool {
-	return e.Code == ErrorCodeDriverPodAlreadyExists && e.SubmissionID == submissionID
-}
-
 // --- Config and types ---
 
 var restLogger = ctrl.Log.WithName("rest-submitter")
@@ -214,14 +209,15 @@ type submitRequest struct {
 }
 
 type submitResponse struct {
-	SubmissionID  string `json:"submission_id"`
-	AppName       string `json:"app_name"`
-	Message       string `json:"message"`
-	SubmittedAt   string `json:"submitted_at"`
-	SparkAppID    string `json:"spark_app_id"`
-	DriverPodName string `json:"driver_pod_name"`
-	DriverPodUID  string `json:"driver_pod_uid"`
-	Namespace     string `json:"namespace"`
+	SubmissionID        string `json:"submission_id"`
+	AppName             string `json:"app_name"`
+	Message             string `json:"message"`
+	SubmittedAt         string `json:"submitted_at"`
+	SparkAppID          string `json:"spark_app_id"`
+	DriverPodName       string `json:"driver_pod_name"`
+	DriverPodUID        string `json:"driver_pod_uid"`
+	Namespace           string `json:"namespace"`
+	DuplicateSubmission bool   `json:"duplicate_submission"`
 }
 
 type submitErrorResponse struct {
@@ -302,7 +298,11 @@ func (c *RestSparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkAppli
 		return fmt.Errorf("failed to submit Spark application %s/%s: %w", app.Namespace, app.Name, err)
 	}
 
-	restLogger.Info("Submitted successfully",
+	msg := "Submitted successfully"
+	if response.DuplicateSubmission {
+		msg = "Duplicate submission detected, existing pod returned"
+	}
+	restLogger.Info(msg,
 		"name", app.Name,
 		"submissionId", response.SubmissionID,
 		"driverPod", response.DriverPodName,
@@ -323,8 +323,8 @@ func newSubmitRequest(args []string, app *v1beta2.SparkApplication) *submitReque
 }
 
 // doSubmitWithRetry submits the request with exponential backoff.
-// If the submitter returns DRIVER_POD_ALREADY_EXISTS for the same submission_id,
-// it is treated as idempotent success (the prior attempt created the pod).
+// The submitter handles duplicate submissions server-side: if the driver pod already exists
+// for the same submission_id, it returns 201 with duplicate_submission=true.
 func (c *RestSparkSubmitter) doSubmitWithRetry(ctx context.Context, request *submitRequest) (*submitResponse, error) {
 	jsonData, err := json.Marshal(request)
 	if err != nil {
@@ -340,13 +340,6 @@ func (c *RestSparkSubmitter) doSubmitWithRetry(ctx context.Context, request *sub
 			return result, nil
 		}
 		lastErr = postErr
-
-		var submitErr *SubmitError
-		if errors.As(lastErr, &submitErr) && submitErr.IsRetryOfCompletedSubmission(request.SubmissionID) {
-			restLogger.Info("Driver pod already exists for this submission, treating as success",
-				"submissionId", request.SubmissionID)
-			return &submitResponse{SubmissionID: request.SubmissionID}, nil
-		}
 
 		if !c.canRetry(attempt, lastErr) {
 			return nil, lastErr
@@ -409,7 +402,7 @@ func parseSubmitResponse(resp *http.Response) (*submitResponse, error) {
 		return nil, fmt.Errorf("failed to read response body from submitter service (status %d): %w", statusCode, readErr)
 	}
 
-	if statusCode == http.StatusCreated {
+	if statusCode == http.StatusCreated || statusCode == http.StatusOK {
 		var r submitResponse
 		if err := json.Unmarshal(body, &r); err != nil {
 			return nil, fmt.Errorf("failed to parse success response from submitter service (status %d): %w", statusCode, err)

--- a/internal/controller/sparkapplication/rest_submission_test.go
+++ b/internal/controller/sparkapplication/rest_submission_test.go
@@ -1,0 +1,521 @@
+package sparkapplication
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+func TestNewRestSparkSubmitter(t *testing.T) {
+	t.Run("rejects empty URL", func(t *testing.T) {
+		_, err := NewRestSparkSubmitter(RestSparkSubmitterConfig{})
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects URL without port", func(t *testing.T) {
+		_, err := NewRestSparkSubmitter(RestSparkSubmitterConfig{URL: "http://host"})
+		assert.Error(t, err)
+	})
+
+	t.Run("succeeds with valid URL", func(t *testing.T) {
+		s, err := NewRestSparkSubmitter(RestSparkSubmitterConfig{
+			URL: "http://host:8080", RetryMaxRetries: 3, RequestTimeout: 10 * time.Second, InitialBackoff: 1 * time.Second,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+}
+
+func TestWaitForConnection(t *testing.T) {
+	t.Run("succeeds when service is reachable", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}))
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		assert.NoError(t, s.WaitForConnection(ctx))
+	})
+
+	t.Run("fails when context expires", func(t *testing.T) {
+		s := newTestSubmitter(t, "http://127.0.0.1:19999")
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		assert.Error(t, s.WaitForConnection(ctx))
+	})
+}
+
+func TestSubmitRetry(t *testing.T) {
+	setK8sEnv(t)
+	t.Run("retries on SUBMITTER_OVERLOADED and succeeds", func(t *testing.T) {
+		attempt := 0
+		server := retryThenSuccessServer(3, http.StatusServiceUnavailable, ErrorCodeSubmitterOverloaded, &attempt)
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		assert.NoError(t, s.Submit(context.Background(), newTestApp()))
+		assert.Equal(t, 3, attempt)
+	})
+
+	t.Run("does not retry on BAD_REQUEST", func(t *testing.T) {
+		attempt := 0
+		server := retryAlwaysFailServer(http.StatusBadRequest, ErrorCodeBadRequest, &attempt)
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		assert.Error(t, s.Submit(context.Background(), newTestApp()))
+		assert.Equal(t, 1, attempt)
+	})
+
+	t.Run("gives up after max retries on INTERNAL_SERVER_ERROR", func(t *testing.T) {
+		attempt := 0
+		server := retryAlwaysFailServer(http.StatusInternalServerError, ErrorCodeInternalServerError, &attempt)
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		assert.Error(t, s.Submit(context.Background(), newTestApp()))
+		assert.Equal(t, 3, attempt)
+	})
+}
+
+func TestSubmitIdempotency(t *testing.T) {
+	setK8sEnv(t)
+
+	t.Run("treats DRIVER_POD_ALREADY_EXISTS as success when submission_id matches", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req submitRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(submitErrorResponse{
+				SubmissionID: req.SubmissionID,
+				Status:       422,
+				ErrorCode:    ErrorCodeDriverPodAlreadyExists,
+				Message:      "pod already exists",
+			})
+		}))
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		app := newTestApp()
+		app.Status.SubmissionID = "test-sub-123"
+		assert.NoError(t, s.Submit(context.Background(), app))
+	})
+
+	t.Run("does not treat DRIVER_POD_ALREADY_EXISTS as success when submission_id differs", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(submitErrorResponse{
+				SubmissionID: "different-sub-id",
+				Status:       422,
+				ErrorCode:    ErrorCodeDriverPodAlreadyExists,
+				Message:      "pod already exists",
+			})
+		}))
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		app := newTestApp()
+		app.Status.SubmissionID = "test-sub-123"
+		assert.Error(t, s.Submit(context.Background(), app))
+	})
+
+	t.Run("does not treat other 422 errors as success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(submitErrorResponse{
+				SubmissionID: "test-sub-123",
+				Status:       422,
+				ErrorCode:    ErrorCodeInvalidPodTemplate,
+				Message:      "invalid template",
+			})
+		}))
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		app := newTestApp()
+		app.Status.SubmissionID = "test-sub-123"
+		assert.Error(t, s.Submit(context.Background(), app))
+	})
+}
+
+func TestSubmitPodTemplates(t *testing.T) {
+	setK8sEnv(t)
+	t.Run("sends templates inline when present", func(t *testing.T) {
+		var capturedReq submitRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(submitResponse{DriverPodName: "drv", SparkAppID: "id"})
+		}))
+		defer server.Close()
+
+		app := newTestApp()
+		app.Spec.Driver.Template = &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "driver"}}}}
+		app.Spec.Executor.Template = &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "executor"}}}}
+
+		s := newTestSubmitter(t, server.URL)
+		require.NoError(t, s.Submit(context.Background(), app))
+		assert.NotNil(t, capturedReq.DriverPodTemplate)
+		assert.NotNil(t, capturedReq.ExecutorPodTemplate)
+	})
+
+	t.Run("omits templates when not specified", func(t *testing.T) {
+		var capturedReq submitRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(submitResponse{DriverPodName: "drv", SparkAppID: "id"})
+		}))
+		defer server.Close()
+
+		s := newTestSubmitter(t, server.URL)
+		require.NoError(t, s.Submit(context.Background(), newTestApp()))
+		assert.Nil(t, capturedReq.DriverPodTemplate)
+		assert.Nil(t, capturedReq.ExecutorPodTemplate)
+	})
+}
+
+func TestSubmitContextCancellation(t *testing.T) {
+	setK8sEnv(t)
+
+	t.Run("returns error when context cancelled during retry backoff", func(t *testing.T) {
+		attempt := 0
+		server := retryAlwaysFailServer(http.StatusInternalServerError, ErrorCodeInternalServerError, &attempt)
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		s, _ := NewRestSparkSubmitter(RestSparkSubmitterConfig{
+			URL:             server.URL,
+			RetryMaxRetries: 3,
+			RequestTimeout:  5 * time.Second,
+			InitialBackoff:  2 * time.Second,
+		})
+		err := s.Submit(ctx, newTestApp())
+		assert.Error(t, err)
+		assert.Equal(t, 1, attempt)
+	})
+
+	t.Run("returns error on network failure", func(t *testing.T) {
+		s := newTestSubmitter(t, "http://192.0.2.1:9999")
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		assert.Error(t, s.Submit(ctx, newTestApp()))
+	})
+}
+
+func TestParseSubmitResponse(t *testing.T) {
+	t.Run("parses success response", func(t *testing.T) {
+		body, _ := json.Marshal(submitResponse{
+			SubmissionID: "sub-123", AppName: "app", SparkAppID: "id",
+			DriverPodName: "app-driver", DriverPodUID: "uid", Namespace: "ns",
+		})
+		resp := &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(bytes.NewReader(body))}
+		result, err := parseSubmitResponse(resp)
+		assert.NoError(t, err)
+		assert.Equal(t, "sub-123", result.SubmissionID)
+		assert.Equal(t, "app-driver", result.DriverPodName)
+	})
+
+	t.Run("structured error", func(t *testing.T) {
+		body, _ := json.Marshal(submitErrorResponse{
+			SubmissionID: "sub-123",
+			Status:       422,
+			ErrorCode:    ErrorCodeDriverPodAlreadyExists,
+			Message:      "Failed to submit: pod already exists",
+			Timestamp:    "2026-06-17T23:30:00.123Z",
+		})
+		resp := &http.Response{StatusCode: 422, Body: io.NopCloser(bytes.NewReader(body))}
+		result, err := parseSubmitResponse(resp)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "Failed to submit")
+		assert.Contains(t, err.Error(), "DRIVER_POD_ALREADY_EXISTS")
+		var submitErr *SubmitError
+		assert.True(t, errors.As(err, &submitErr))
+		assert.Equal(t, ErrorCodeDriverPodAlreadyExists, submitErr.Code)
+		assert.Equal(t, "sub-123", submitErr.SubmissionID)
+	})
+
+	t.Run("structured error with different code", func(t *testing.T) {
+		body, _ := json.Marshal(submitErrorResponse{
+			SubmissionID: "sub-456",
+			Status:       400,
+			ErrorCode:    ErrorCodeBadRequest,
+			Message:      "Invalid job configuration",
+			Timestamp:    "2026-06-17T23:30:00.123Z",
+		})
+		resp := &http.Response{StatusCode: 400, Body: io.NopCloser(bytes.NewReader(body))}
+		result, err := parseSubmitResponse(resp)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "Invalid job configuration")
+		assert.Contains(t, err.Error(), "BAD_REQUEST")
+	})
+
+	t.Run("non-JSON response body", func(t *testing.T) {
+		resp := &http.Response{StatusCode: 502, Body: io.NopCloser(bytes.NewReader([]byte("Bad Gateway")))}
+		result, err := parseSubmitResponse(resp)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "unexpected response")
+		assert.Contains(t, err.Error(), "Bad Gateway")
+	})
+
+	t.Run("truncates long response body", func(t *testing.T) {
+		longBody := make([]byte, maxErrorBodyLength+100)
+		for i := range longBody {
+			longBody[i] = 'x'
+		}
+		resp := &http.Response{StatusCode: 500, Body: io.NopCloser(bytes.NewReader(longBody))}
+		_, err := parseSubmitResponse(resp)
+		assert.Contains(t, err.Error(), "...")
+		assert.LessOrEqual(t, len(err.Error()), maxErrorBodyLength+100)
+	})
+}
+
+func TestCanRetry(t *testing.T) {
+	s := &RestSparkSubmitter{maxRetries: 3}
+
+	networkErr := fmt.Errorf("connection refused")
+	overloaded := &SubmitError{Code: ErrorCodeSubmitterOverloaded, StatusCode: 503, Message: "overloaded"}
+	internalErr := &SubmitError{Code: ErrorCodeInternalServerError, StatusCode: 500, Message: "internal"}
+	badRequest := &SubmitError{Code: ErrorCodeBadRequest, StatusCode: 400, Message: "bad request"}
+	podExists := &SubmitError{Code: ErrorCodeDriverPodAlreadyExists, StatusCode: 422, Message: "exists"}
+	invalidTemplate := &SubmitError{Code: ErrorCodeInvalidPodTemplate, StatusCode: 422, Message: "invalid"}
+
+	assert.True(t, s.canRetry(0, networkErr), "network error should retry")
+	assert.True(t, s.canRetry(0, overloaded), "SUBMITTER_OVERLOADED should retry")
+	assert.True(t, s.canRetry(0, internalErr), "INTERNAL_SERVER_ERROR should retry")
+	assert.False(t, s.canRetry(0, badRequest), "BAD_REQUEST should not retry")
+	assert.False(t, s.canRetry(0, podExists), "DRIVER_POD_ALREADY_EXISTS should not retry")
+	assert.False(t, s.canRetry(0, invalidTemplate), "INVALID_POD_TEMPLATE should not retry")
+	assert.False(t, s.canRetry(2, overloaded), "last attempt should not retry")
+}
+
+// --- Test helpers ---
+
+func newTestSubmitter(t *testing.T, url string) *RestSparkSubmitter {
+	t.Helper()
+	s, err := NewRestSparkSubmitter(RestSparkSubmitterConfig{
+		URL:             url,
+		RetryMaxRetries: 3,
+		RequestTimeout:  5 * time.Second,
+		InitialBackoff:  10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	return s
+}
+
+func setK8sEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "6443")
+}
+
+func newTestApp() *v1beta2.SparkApplication {
+	return &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
+		Spec:       v1beta2.SparkApplicationSpec{},
+	}
+}
+
+func retryThenSuccessServer(succeedOnAttempt int, failStatus int, errorCode SubmitErrorCode, attempt *int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*attempt++
+		if *attempt < succeedOnAttempt {
+			w.WriteHeader(failStatus)
+			_ = json.NewEncoder(w).Encode(submitErrorResponse{ErrorCode: errorCode, Message: "transient"})
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(submitResponse{DriverPodName: "drv", SparkAppID: "id"})
+	}))
+}
+
+func retryAlwaysFailServer(failStatus int, errorCode SubmitErrorCode, attempt *int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*attempt++
+		w.WriteHeader(failStatus)
+		_ = json.NewEncoder(w).Encode(submitErrorResponse{ErrorCode: errorCode, Message: "error"})
+	}))
+}
+
+// --- TLS tests ---
+
+func TestBuildTransport_NilConfig(t *testing.T) {
+	transport, err := buildTransport(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestBuildTransport_Disabled(t *testing.T) {
+	transport, err := buildTransport(&TLSConfig{Enabled: false})
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestBuildTransport_InvalidCACert(t *testing.T) {
+	badCA := writeTempFile(t, "bad-ca.pem", "not a cert")
+	_, err := buildTransport(&TLSConfig{
+		Enabled:    true,
+		CACertFile: badCA,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse CA cert")
+}
+
+func TestBuildTransport_MissingCACertFile(t *testing.T) {
+	_, err := buildTransport(&TLSConfig{
+		Enabled:    true,
+		CACertFile: "/nonexistent/ca.crt",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read CA cert file")
+}
+
+func TestBuildTransport_PartialCertKeyErrors(t *testing.T) {
+	certFile := writeTempFile(t, "tls.crt", "cert")
+
+	t.Run("cert without key", func(t *testing.T) {
+		_, err := buildTransport(&TLSConfig{
+			Enabled:  true,
+			CertFile: certFile,
+			KeyFile:  "",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both tls.crt and tls.key must be present in the TLS cert directory")
+	})
+
+	t.Run("key without cert", func(t *testing.T) {
+		_, err := buildTransport(&TLSConfig{
+			Enabled:  true,
+			CertFile: "",
+			KeyFile:  "/some/key.pem",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both tls.crt and tls.key must be present in the TLS cert directory")
+	})
+}
+
+func TestBuildTransport_InvalidCertKeyPair(t *testing.T) {
+	certFile := writeTempFile(t, "tls.crt", "not a cert")
+	keyFile := writeTempFile(t, "tls.key", "not a key")
+
+	_, err := buildTransport(&TLSConfig{
+		Enabled:  true,
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load client certificate")
+}
+
+func TestBuildTransport_ValidTLS(t *testing.T) {
+	certFile, keyFile, caFile := generateTestCertFiles(t)
+
+	transport, err := buildTransport(&TLSConfig{
+		Enabled:    true,
+		CertFile:   certFile,
+		KeyFile:    keyFile,
+		CACertFile: caFile,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+func TestBuildTransport_WhitespacePathsIgnored(t *testing.T) {
+	transport, err := buildTransport(&TLSConfig{
+		Enabled:    true,
+		CertFile:   "  ",
+		KeyFile:    "  ",
+		CACertFile: "  ",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, transport)
+}
+
+// --- TLS test helpers ---
+
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/" + name
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+func generateTestCertFiles(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	certFile = dir + "/tls.crt"
+	keyFile = dir + "/tls.key"
+	caFile = dir + "/ca.crt"
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0600))
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-leaf"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caTemplate, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	require.NoError(t, os.WriteFile(certFile, leafPEM, 0600))
+
+	keyBytes, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+
+	return certFile, keyFile, caFile
+}

--- a/internal/controller/sparkapplication/rest_submission_test.go
+++ b/internal/controller/sparkapplication/rest_submission_test.go
@@ -105,16 +105,19 @@ func TestSubmitRetry(t *testing.T) {
 func TestSubmitIdempotency(t *testing.T) {
 	setK8sEnv(t)
 
-	t.Run("treats DRIVER_POD_ALREADY_EXISTS as success when submission_id matches", func(t *testing.T) {
+	t.Run("duplicate submission returns success with existing pod details", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var req submitRequest
 			_ = json.NewDecoder(r.Body).Decode(&req)
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			_ = json.NewEncoder(w).Encode(submitErrorResponse{
-				SubmissionID: req.SubmissionID,
-				Status:       422,
-				ErrorCode:    ErrorCodeDriverPodAlreadyExists,
-				Message:      "pod already exists",
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(submitResponse{
+				SubmissionID:        req.SubmissionID,
+				AppName:             "test-app",
+				SparkAppID:          "spark-existing-id",
+				DriverPodName:       "test-app-driver",
+				DriverPodUID:        "existing-uid",
+				Namespace:           "default",
+				DuplicateSubmission: true,
 			})
 		}))
 		defer server.Close()
@@ -125,14 +128,14 @@ func TestSubmitIdempotency(t *testing.T) {
 		assert.NoError(t, s.Submit(context.Background(), app))
 	})
 
-	t.Run("does not treat DRIVER_POD_ALREADY_EXISTS as success when submission_id differs", func(t *testing.T) {
+	t.Run("DRIVER_POD_ALREADY_EXISTS is a genuine conflict error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.WriteHeader(http.StatusConflict)
 			_ = json.NewEncoder(w).Encode(submitErrorResponse{
 				SubmissionID: "different-sub-id",
-				Status:       422,
+				Status:       409,
 				ErrorCode:    ErrorCodeDriverPodAlreadyExists,
-				Message:      "pod already exists",
+				Message:      "Driver pod already exists for a different submission",
 			})
 		}))
 		defer server.Close()
@@ -243,17 +246,32 @@ func TestParseSubmitResponse(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "sub-123", result.SubmissionID)
 		assert.Equal(t, "app-driver", result.DriverPodName)
+		assert.False(t, result.DuplicateSubmission)
+	})
+
+	t.Run("parses duplicate submission response (200)", func(t *testing.T) {
+		body, _ := json.Marshal(submitResponse{
+			SubmissionID: "sub-123", AppName: "app", SparkAppID: "spark-existing",
+			DriverPodName: "app-driver", DriverPodUID: "uid", Namespace: "ns",
+			DuplicateSubmission: true,
+		})
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(body))}
+		result, err := parseSubmitResponse(resp)
+		assert.NoError(t, err)
+		assert.Equal(t, "sub-123", result.SubmissionID)
+		assert.Equal(t, "spark-existing", result.SparkAppID)
+		assert.True(t, result.DuplicateSubmission)
 	})
 
 	t.Run("structured error", func(t *testing.T) {
 		body, _ := json.Marshal(submitErrorResponse{
 			SubmissionID: "sub-123",
-			Status:       422,
+			Status:       409,
 			ErrorCode:    ErrorCodeDriverPodAlreadyExists,
 			Message:      "Failed to submit: pod already exists",
 			Timestamp:    "2026-06-17T23:30:00.123Z",
 		})
-		resp := &http.Response{StatusCode: 422, Body: io.NopCloser(bytes.NewReader(body))}
+		resp := &http.Response{StatusCode: http.StatusConflict, Body: io.NopCloser(bytes.NewReader(body))}
 		result, err := parseSubmitResponse(resp)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "Failed to submit")
@@ -306,7 +324,7 @@ func TestCanRetry(t *testing.T) {
 	overloaded := &SubmitError{Code: ErrorCodeSubmitterOverloaded, StatusCode: 503, Message: "overloaded"}
 	internalErr := &SubmitError{Code: ErrorCodeInternalServerError, StatusCode: 500, Message: "internal"}
 	badRequest := &SubmitError{Code: ErrorCodeBadRequest, StatusCode: 400, Message: "bad request"}
-	podExists := &SubmitError{Code: ErrorCodeDriverPodAlreadyExists, StatusCode: 422, Message: "exists"}
+	podExists := &SubmitError{Code: ErrorCodeDriverPodAlreadyExists, StatusCode: 409, Message: "exists"}
 	invalidTemplate := &SubmitError{Code: ErrorCodeInvalidPodTemplate, StatusCode: 422, Message: "invalid"}
 
 	assert.True(t, s.canRetry(0, networkErr), "network error should retry")

--- a/internal/controller/sparkapplication/rest_submission_test.go
+++ b/internal/controller/sparkapplication/rest_submission_test.go
@@ -186,7 +186,7 @@ func TestSubmitPodTemplates(t *testing.T) {
 		assert.NotNil(t, capturedReq.ExecutorPodTemplate)
 	})
 
-	t.Run("omits templates when not specified", func(t *testing.T) {
+	t.Run("sends default templates with owner ref when not specified", func(t *testing.T) {
 		var capturedReq submitRequest
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
@@ -197,8 +197,10 @@ func TestSubmitPodTemplates(t *testing.T) {
 
 		s := newTestSubmitter(t, server.URL)
 		require.NoError(t, s.Submit(context.Background(), newTestApp()))
-		assert.Nil(t, capturedReq.DriverPodTemplate)
-		assert.Nil(t, capturedReq.ExecutorPodTemplate)
+		assert.NotNil(t, capturedReq.DriverPodTemplate)
+		assert.NotNil(t, capturedReq.ExecutorPodTemplate)
+		assert.Len(t, capturedReq.DriverPodTemplate.OwnerReferences, 1)
+		assert.Len(t, capturedReq.ExecutorPodTemplate.OwnerReferences, 1)
 	})
 }
 

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -54,7 +54,7 @@ var _ SparkApplicationSubmitter = &SparkSubmitter{}
 func (*SparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication) error {
 	logger := log.FromContext(ctx)
 
-	args, err := buildSparkSubmitArgs(app)
+	args, err := buildSparkSubmitArgs(app, false)
 	if err != nil {
 		return fmt.Errorf("failed to build spark-submit arguments: %v", err)
 	}
@@ -94,7 +94,9 @@ func runSparkSubmit(args []string) error {
 }
 
 // buildSparkSubmitArgs builds the arguments for spark-submit.
-func buildSparkSubmitArgs(app *v1beta2.SparkApplication) ([]string, error) {
+// When skipPodTemplates is true, pod template file options are skipped
+// as the submission strategy handles pod templates separately.
+func buildSparkSubmitArgs(app *v1beta2.SparkApplication, skipPodTemplates bool) ([]string, error) {
 	optionFuncs := []sparkSubmitOptionFunc{
 		masterOption,
 		deployModeOption,
@@ -109,23 +111,28 @@ func buildSparkSubmitArgs(app *v1beta2.SparkApplication) ([]string, error) {
 		submissionWaitAppCompletionOption,
 		sparkConfOption,
 		hadoopConfOption,
-		driverPodTemplateOption,
 		driverPodNameOption,
 		driverConfOption,
 		driverEnvOption,
 		driverSecretOption,
 		driverVolumeMountsOption,
-		executorPodTemplateOption,
 		executorConfOption,
 		executorEnvOption,
 		executorSecretOption,
 		executorVolumeMountsOption,
 		nodeSelectorOption,
 		dynamicAllocationOption,
-		proxyUserOption,
-		mainApplicationFileOption,
-		applicationOption,
 	}
+
+	// Pod template options write files and add --conf args; skipped when the submission
+	// strategy sends templates inline (e.g., REST submitter).
+	if !skipPodTemplates {
+		optionFuncs = append(optionFuncs, driverPodTemplateOption, executorPodTemplateOption)
+	}
+
+	// These must come last: proxyUser is a spark-submit flag, mainApplicationFile is the
+	// positional JAR/py path, and applicationOption produces application arguments.
+	optionFuncs = append(optionFuncs, proxyUserOption, mainApplicationFileOption, applicationOption)
 
 	var args []string
 	for _, optionFunc := range optionFuncs {

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -1121,24 +1121,7 @@ func applicationOption(app *v1beta2.SparkApplication) ([]string, error) {
 
 // driverPodTemplateOption returns the driver pod template arguments.
 func driverPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) {
-	template := app.Spec.Driver.Template
-	// Spark expects the template to have a driver container
-	// if user specifies a driver pod template, it is responsible
-	// for user to ensure the template has a driver container
-	if template == nil {
-		template = &corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: common.SparkDriverContainerName}},
-			},
-		}
-	}
-
-	ownerReference := util.GetOwnerReference(app)
-	if !slices.ContainsFunc(template.OwnerReferences, func(r metav1.OwnerReference) bool {
-		return reflect.DeepEqual(r, ownerReference)
-	}) {
-		template.OwnerReferences = append(template.OwnerReferences, ownerReference)
-	}
+	template := buildDriverPodTemplate(app)
 
 	podTemplateFile := fmt.Sprintf("/tmp/spark/%s/driver-pod-template.yaml", app.Status.SubmissionID)
 	if err := util.WriteObjectToFile(template, podTemplateFile); err != nil {
@@ -1156,30 +1139,7 @@ func driverPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) {
 
 // executorPodTemplateOption returns the executor pod template arguments.
 func executorPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) {
-	template := app.Spec.Executor.Template
-
-	// Spark expects the template to have a driver container
-	// if user specifies a driver pod template, it is responsible
-	// for user to ensure the template has a driver container
-	if template == nil {
-		template = &corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: common.Spark3DefaultExecutorContainerName}},
-			},
-		}
-	}
-
-	// we put non-controller owner reference so that
-	// other controller (e.g. Kueue) can recognize the executor pods
-	// are the children of the SparkApplication
-	ownerReference := util.GetOwnerReference(app)
-	ownerReference.Controller = nil
-	ownerReference.BlockOwnerDeletion = nil
-	if !slices.ContainsFunc(template.OwnerReferences, func(r metav1.OwnerReference) bool {
-		return reflect.DeepEqual(r, ownerReference)
-	}) {
-		template.OwnerReferences = append(template.OwnerReferences, ownerReference)
-	}
+	template := buildExecutorPodTemplate(app)
 
 	podTemplateFile := fmt.Sprintf("/tmp/spark/%s/executor-pod-template.yaml", app.Status.SubmissionID)
 	if err := util.WriteObjectToFile(template, podTemplateFile); err != nil {
@@ -1193,6 +1153,61 @@ func executorPodTemplateOption(app *v1beta2.SparkApplication) ([]string, error) 
 		fmt.Sprintf("%s=%s", common.SparkKubernetesExecutorPodTemplateContainerName, common.Spark3DefaultExecutorContainerName),
 	}
 	return args, nil
+}
+
+// buildDriverPodTemplate returns a driver pod template ready for submission.
+func buildDriverPodTemplate(app *v1beta2.SparkApplication) *corev1.PodTemplateSpec {
+	template := app.Spec.Driver.Template
+	// Spark expects the template to have a driver container
+	// if user specifies a driver pod template, it is responsible
+	// for user to ensure the template has a driver container
+	if template == nil {
+		template = &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: common.SparkDriverContainerName}},
+			},
+		}
+	} else {
+		template = template.DeepCopy()
+	}
+
+	ownerReference := util.GetOwnerReference(app)
+	if !slices.ContainsFunc(template.OwnerReferences, func(r metav1.OwnerReference) bool {
+		return reflect.DeepEqual(r, ownerReference)
+	}) {
+		template.OwnerReferences = append(template.OwnerReferences, ownerReference)
+	}
+	return template
+}
+
+// buildExecutorPodTemplate returns an executor pod template ready for submission.
+func buildExecutorPodTemplate(app *v1beta2.SparkApplication) *corev1.PodTemplateSpec {
+	template := app.Spec.Executor.Template
+	// Spark expects the template to have a driver container
+	// if user specifies a driver pod template, it is responsible
+	// for user to ensure the template has a driver container
+	if template == nil {
+		template = &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: common.Spark3DefaultExecutorContainerName}},
+			},
+		}
+	} else {
+		template = template.DeepCopy()
+	}
+
+	// we put non-controller owner reference so that
+	// other controller (e.g. Kueue) can recognize the executor pods
+	// are the children of the SparkApplication
+	ownerReference := util.GetOwnerReference(app)
+	ownerReference.Controller = nil
+	ownerReference.BlockOwnerDeletion = nil
+	if !slices.ContainsFunc(template.OwnerReferences, func(r metav1.OwnerReference) bool {
+		return reflect.DeepEqual(r, ownerReference)
+	}) {
+		template.OwnerReferences = append(template.OwnerReferences, ownerReference)
+	}
+	return template
 }
 
 // loadSparkDefaultsOption adds `--load-spark-defaults` flag to the command when feature gate `LoadSparkDefaults` is enabled.

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -651,6 +651,57 @@ func TestExecutorPodTemplateContents(t *testing.T) {
 	}
 }
 
+func TestBuildSparkSubmitArgsSkipPodTemplates(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "6443")
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+			UID:       "uid-123",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Type:                v1beta2.SparkApplicationTypeScala,
+			Mode:                v1beta2.DeployModeCluster,
+			MainApplicationFile: ptr.To("local:///app.jar"),
+			MainClass:           ptr.To("org.example.Main"),
+			SparkVersion:        "4.0.1",
+		},
+		Status: v1beta2.SparkApplicationStatus{
+			SubmissionID: "sub-123",
+		},
+	}
+
+	t.Run("includes pod template args when skipPodTemplates is false", func(t *testing.T) {
+		args, err := buildSparkSubmitArgs(app, false)
+		assert.NoError(t, err)
+
+		hasDriverTemplate := slices.ContainsFunc(args, func(s string) bool {
+			return strings.Contains(s, common.SparkKubernetesDriverPodTemplateFile)
+		})
+		hasExecutorTemplate := slices.ContainsFunc(args, func(s string) bool {
+			return strings.Contains(s, common.SparkKubernetesExecutorPodTemplateFile)
+		})
+		assert.True(t, hasDriverTemplate, "should include driver pod template conf")
+		assert.True(t, hasExecutorTemplate, "should include executor pod template conf")
+	})
+
+	t.Run("skips pod template args when skipPodTemplates is true", func(t *testing.T) {
+		args, err := buildSparkSubmitArgs(app, true)
+		assert.NoError(t, err)
+
+		hasDriverTemplate := slices.ContainsFunc(args, func(s string) bool {
+			return strings.Contains(s, common.SparkKubernetesDriverPodTemplateFile)
+		})
+		hasExecutorTemplate := slices.ContainsFunc(args, func(s string) bool {
+			return strings.Contains(s, common.SparkKubernetesExecutorPodTemplateFile)
+		})
+		assert.False(t, hasDriverTemplate, "should not include driver pod template conf")
+		assert.False(t, hasExecutorTemplate, "should not include executor pod template conf")
+	})
+}
+
 // import (
 // 	"fmt"
 // 	"os"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -43,6 +43,12 @@ const (
 	// owner: @ChenYi015
 	// alpha: v2.5.0
 	LoadSparkDefaults featuregate.Feature = "LoadSparkDefaults"
+
+	// RestSubmitter enables the REST-based submission strategy instead of spark-submit.
+	//
+	// owner: @venkomirisetti
+	// alpha: v2.6.0
+	RestSubmitter featuregate.Feature = "RestSubmitter"
 )
 
 // To add a new feature gate, follow these steps:
@@ -83,6 +89,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	PartialRestart: {Default: false, PreRelease: featuregate.Alpha},
 
 	LoadSparkDefaults: {Default: false, PreRelease: featuregate.Alpha},
+
+	RestSubmitter: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest sets the specified feature gate to the specified value during a test.


### PR DESCRIPTION
## Summary

Adds a REST submitter client to the operator as an alternative to the default `spark-submit` CLI. When the `RestSubmitter` feature gate is enabled, the operator submits SparkApplications via an external REST service instead of spawning a JVM per submission.

This PR contains only the **operator-side client** — the Helm chart, CI, Dockerfile, and submitter deployment will follow in a separate PR.

### Problem
- Each `spark-submit` spawns a full JVM (~2-8s startup, ~200-400MB memory)
- Degrades under high submission rates (1000s+ SparkApplications)
- Related: #2337

### Solution
- REST client that submits to a long-running service: ~200ms latency vs 2-8s
- Fire-and-forget: returns immediately after driver pod creation
- mTLS support for secure communication with the submitter service

## Changes

| File | Description |
|------|-------------|
| `rest_submission.go` | REST client with structured error codes, retry/backoff, TLS transport, idempotent submission handling |
| `rest_submission_test.go` | Unit tests for retry, idempotency, response parsing, TLS, and connection verification |
| `start.go` | `newSparkSubmitter()` helper with feature gate switch |
| `submission.go` | `skipPodTemplates` param to omit podTemplateFile confs when using REST path |
| `submission_test.go` | Tests for skipPodTemplates |
| `features.go` | `RestSubmitter` feature gate (alpha, default off) |

## Key Design Decisions

- **Feature gate**: `RestSubmitter` (alpha, default off) — zero impact on existing users
- **Error-code-based retry**: retries on `SUBMITTER_OVERLOADED` and `INTERNAL_SERVER_ERROR` only; network/TLS errors always retried (covers cert reload)
- **Operator-side idempotency**: on `DRIVER_POD_ALREADY_EXISTS`, compares `submission_id` — match = success (retry of completed submission), mismatch = genuine conflict
- **Startup verification**: `WaitForConnection` does full HTTP+TLS request, not just TCP dial
- **No factory abstraction**: feature gate check and wiring live in `start.go`

## Test plan

- [x] Unit tests for all retry scenarios (overloaded, internal error, bad request, max retries)
- [x] Unit tests for idempotent submission (matching ID, differing ID, other 422)
- [x] Unit tests for response parsing (success, structured error, non-JSON, truncation)
- [x] Unit tests for TLS transport (valid certs, invalid certs, partial config, whitespace paths)
- [x] Unit tests for connection wait (reachable, timeout)
- [x] Unit tests for context cancellation
- [x] `go build ./cmd/operator/...` passes
- [x] Feature gate defaults to off — no behavior change without explicit opt-in