### PR TITLE
fix: always set NextProtos regardless of enableHTTP2 flag

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -127,7 +127,6 @@ var (
 	healthProbeBindAddress                      string
 	pprofBindAddress                            string
 	secureMetrics                               bool
-	enableHTTP2                                 bool
 	tlsMinVersion                               string
 	tlsCipherSuites                             []string
 	scheduledSparkApplicationTimestampPrecision string
@@ -212,7 +211,6 @@ func NewStartCommand() *cobra.Command {
 
 	command.Flags().StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	command.Flags().BoolVar(&secureMetrics, "secure-metrics", false, "If set the metrics endpoint is served securely")
-	command.Flags().BoolVar(&enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	command.Flags().StringVar(&tlsMinVersion, "metric-tls-min-version", "VersionTLS12",
 		"Minimum TLS version for the metrics server. "+
 			"Possible values: VersionTLS12, VersionTLS13")
@@ -251,7 +249,7 @@ func start() {
 	cfg.Burst = kubeAPIBurst
 
 	// Create the manager.
-	tlsOptions, err := operatortls.SetupTLS(tlsMinVersion, tlsCipherSuites, enableHTTP2)
+	tlsOptions, err := operatortls.SetupTLS(tlsMinVersion, tlsCipherSuites)
 	if err != nil {
 		logger.Error(err, "Failed to set up TLS")
 		os.Exit(1)

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -108,7 +108,6 @@ var (
 
 	healthProbeBindAddress string
 	secureMetrics          bool
-	enableHTTP2            bool
 	tlsMinVersion          string
 	tlsCipherSuites        []string
 	development            bool
@@ -173,7 +172,6 @@ func NewStartCommand() *cobra.Command {
 
 	command.Flags().StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	command.Flags().BoolVar(&secureMetrics, "secure-metrics", false, "If set the metrics endpoint is served securely")
-	command.Flags().BoolVar(&enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	command.Flags().StringVar(&tlsMinVersion, "webhook-tls-min-version", "VersionTLS12",
 		"Minimum TLS version for the webhook and metrics servers. "+
 			"Possible values: VersionTLS12, VersionTLS13")
@@ -204,7 +202,7 @@ func start() {
 	cfg.Burst = kubeAPIBurst
 
 	// Create the manager.
-	tlsOptions, err := operatortls.SetupTLS(tlsMinVersion, tlsCipherSuites, enableHTTP2)
+	tlsOptions, err := operatortls.SetupTLS(tlsMinVersion, tlsCipherSuites)
 	if err != nil {
 		logger.Error(err, "Failed to set up TLS")
 		os.Exit(1)

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -23,7 +23,7 @@ import (
 )
 
 // SetupTLS parses the TLS flags and returns TLS option functions for webhook and metrics servers.
-func SetupTLS(minVersion string, cipherSuites []string, enableHTTP2 bool) ([]func(*cryptotls.Config), error) {
+func SetupTLS(minVersion string, cipherSuites []string) ([]func(*cryptotls.Config), error) {
 	var tlsOpts []func(*cryptotls.Config)
 
 	ver, err := ParseTLSVersion(minVersion)
@@ -44,15 +44,9 @@ func SetupTLS(minVersion string, cipherSuites []string, enableHTTP2 bool) ([]fun
 		})
 	}
 
-	if enableHTTP2 {
-		tlsOpts = append(tlsOpts, func(c *cryptotls.Config) {
-			c.NextProtos = []string{"h2", "http/1.1"}
-		})
-	} else {
-		tlsOpts = append(tlsOpts, func(c *cryptotls.Config) {
-			c.NextProtos = []string{"h2", "http/1.1"}
-		})
-	}
+	tlsOpts = append(tlsOpts, func(c *cryptotls.Config) {
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
 
 	return tlsOpts, nil
 }


### PR DESCRIPTION
## Summary
Both branches of the `enableHTTP2` conditional in `SetupTLS()` were setting the same `NextProtos` value `["h2", "http/1.1"]`, making the conditional dead code. This removes it and always sets NextProtos for proper ALPN negotiation.

Follow-up to #2986.

## Test plan
- [ ] Build passes
- [ ] Existing tests pass