### PR TITLE
ci: add shfmt and shellcheck checks for shell scripts

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
         with:
           go-version-file: go.mod
 
@@ -87,7 +87,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
         with:
           go-version-file: go.mod
 
@@ -110,7 +110,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
         with:
           go-version-file: go.mod
 
@@ -234,7 +234,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/kustomize-drift-check.yaml
+++ b/.github/workflows/kustomize-drift-check.yaml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/kustomize-lint.yaml
+++ b/.github/workflows/kustomize-lint.yaml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] caching is intentional for CI jobs
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/shell-lint.yaml
+++ b/.github/workflows/shell-lint.yaml
@@ -8,7 +8,6 @@ on:
       - release-*
     paths:
       - '**.sh'
-      - '.shellcheckrc'
       - 'Makefile'
       - '.github/workflows/shell-lint.yaml'
 
@@ -18,7 +17,6 @@ on:
       - release-*
     paths:
       - '**.sh'
-      - '.shellcheckrc'
       - 'Makefile'
       - '.github/workflows/shell-lint.yaml'
 

--- a/.github/workflows/shell-lint.yaml
+++ b/.github/workflows/shell-lint.yaml
@@ -1,0 +1,56 @@
+# Static formatting and lint checks for shell scripts (no cluster required).
+name: Shell Lint
+
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+    paths:
+      - '**.sh'
+      - '.shellcheckrc'
+      - 'Makefile'
+      - '.github/workflows/shell-lint.yaml'
+
+  push:
+    branches:
+      - master
+      - release-*
+    paths:
+      - '**.sh'
+      - '.shellcheckrc'
+      - 'Makefile'
+      - '.github/workflows/shell-lint.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.actor }}
+  cancel-in-progress: true
+
+jobs:
+  shell-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check shell script formatting
+        run: |
+          make shell-fmt
+          if ! git diff --quiet; then
+            echo "Shell scripts are not formatted. Run 'make shell-fmt' and commit the changes."
+            git diff
+            false
+          fi
+
+      - name: Run shellcheck
+        run: make shell-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,21 @@ repos:
           - --chart-search-root=charts
           - --template-files=README.md.gotmpl
           - --sort-values-order=file
+  - repo: local
+    hooks:
+      - id: shfmt
+        name: shfmt
+        description: Format shell scripts with shfmt
+        entry: make shell-fmt
+        language: system
+        types: [shell]
+        pass_filenames: false
+        require_serial: true
+      - id: shellcheck
+        name: shellcheck
+        description: Lint shell scripts with shellcheck
+        entry: make shell-lint
+        language: system
+        types: [shell]
+        pass_filenames: false
+        require_serial: true

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,0 @@
-# ShellCheck configuration for the Spark operator repository.
-
-# Code-generator scripts source helper files that only exist at runtime
-# (e.g. ${CODEGEN_PKG}/kube_codegen.sh), which ShellCheck cannot follow.
-disable=SC1091

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,5 @@
+# ShellCheck configuration for the Spark operator repository.
+
+# Code-generator scripts source helper files that only exist at runtime
+# (e.g. ${CODEGEN_PKG}/kube_codegen.sh), which ShellCheck cannot follow.
+disable=SC1091

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ HELM_VERSION ?= $(shell grep -e '^	helm.sh/helm/v3 v' go.mod | cut -d ' ' -f 2)
 HELM_UNITTEST_VERSION ?= 0.8.2
 HELM_DOCS_VERSION ?= v1.14.2
 CODE_GENERATOR_VERSION ?= v0.35.4
+SHFMT_VERSION ?= v3.13.1
+SHELLCHECK_VERSION ?= v0.11.0
 
 ## Binaries
 SPARK_OPERATOR ?= $(LOCALBIN)/spark-operator
@@ -75,6 +77,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 GEN_CRD_API_REFERENCE_DOCS ?= $(LOCALBIN)/gen-crd-api-reference-docs-$(GEN_CRD_API_REFERENCE_DOCS_VERSION)
 HELM ?= $(LOCALBIN)/helm-$(HELM_VERSION)
 HELM_DOCS ?= $(LOCALBIN)/helm-docs-$(HELM_DOCS_VERSION)
+SHFMT ?= $(LOCALBIN)/shfmt-$(SHFMT_VERSION)
+SHELLCHECK ?= $(LOCALBIN)/shellcheck-$(SHELLCHECK_VERSION)
 
 ##@ General
 
@@ -161,6 +165,25 @@ go-lint: golangci-lint ## Run golangci-lint linter.
 go-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 	@echo "Running golangci-lint run --fix..."
 	$(GOLANGCI_LINT) run --fix
+
+# Shell scripts to format and lint (all tracked *.sh files).
+SHELL_SCRIPTS = $(shell git ls-files '*.sh')
+
+# shfmt options: 2-space indent, indent switch cases, space after redirect operators.
+SHFMT_OPTIONS ?= --indent 2 --case-indent --space-redirects
+
+# Extra shellcheck options, e.g. set SHELLCHECK_OPTIONS=--severity=warning to only fail on warnings.
+SHELLCHECK_OPTIONS ?=
+
+.PHONY: shell-fmt
+shell-fmt: shfmt ## Format shell scripts with shfmt.
+	@echo "Running shfmt..."
+	$(SHFMT) --write --list $(SHFMT_OPTIONS) $(SHELL_SCRIPTS)
+
+.PHONY: shell-lint
+shell-lint: shellcheck ## Lint shell scripts with shellcheck.
+	@echo "Running shellcheck..."
+	$(SHELLCHECK) $(SHELLCHECK_OPTIONS) $(SHELL_SCRIPTS)
 
 .PHONY: unit-test
 unit-test: setup-envtest ## Run unit tests.
@@ -384,6 +407,16 @@ helm-docs-plugin: $(HELM_DOCS) ## Download helm-docs plugin locally if necessary
 $(HELM_DOCS): $(LOCALBIN)
 	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs,$(HELM_DOCS_VERSION))
 
+.PHONY: shfmt
+shfmt: $(SHFMT) ## Download shfmt locally if necessary.
+$(SHFMT): $(LOCALBIN)
+	$(call go-install-tool,$(SHFMT),mvdan.cc/sh/v3/cmd/shfmt,$(SHFMT_VERSION))
+
+.PHONY: shellcheck
+shellcheck: $(SHELLCHECK) ## Download shellcheck locally if necessary.
+$(SHELLCHECK): $(LOCALBIN)
+	$(call download-shellcheck,$(SHELLCHECK),$(SHELLCHECK_VERSION))
+
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)
 # $2 - package url which can be installed
@@ -395,5 +428,29 @@ package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 GOBIN=$(LOCALBIN) go install $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef
+
+# download-shellcheck will download a pinned shellcheck release binary if it doesn't exist.
+# $1 - target path with name of binary (ideally with version)
+# $2 - shellcheck version (e.g. v0.11.0)
+define download-shellcheck
+@[ -f "$(1)" ] || { \
+set -e; \
+os=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+arch=$$(uname -m); \
+case "$$arch" in \
+  x86_64|amd64) arch=x86_64 ;; \
+  arm64|aarch64) arch=aarch64 ;; \
+  *) echo "Unsupported architecture: $$arch" >&2; exit 1 ;; \
+esac; \
+archive="shellcheck-$(2).$${os}.$${arch}.tar.gz"; \
+url="https://github.com/koalaman/shellcheck/releases/download/$(2)/$${archive}"; \
+echo "Downloading $${url}"; \
+tmp=$$(mktemp -d); \
+curl -fsSL "$${url}" | tar -xz -C "$${tmp}"; \
+mv "$${tmp}/shellcheck-$(2)/shellcheck" "$(1)"; \
+chmod +x "$(1)"; \
+rm -rf "$${tmp}"; \
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,8 @@ mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 endef
 
 # download-shellcheck will download a pinned shellcheck release binary if it doesn't exist.
+# shellcheck publishes .tar.gz assets from v0.11.0 onward, which avoids an
+# xz/liblzma dependency. Pinning an older SHELLCHECK_VERSION would need .tar.xz.
 # $1 - target path with name of binary (ideally with version)
 # $2 - shellcheck version (e.g. v0.11.0)
 define download-shellcheck

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,19 +10,22 @@ myuid="$(id -u)"
 # It's to resolve OpenShift random UID case.
 # See also: https://github.com/docker-library/postgres/pull/448
 if ! getent passwd "$myuid" &> /dev/null; then
-    for wrapper in {/usr,}/lib{/*,}/libnss_wrapper.so; do
-      if [ -s "$wrapper" ]; then
-        NSS_WRAPPER_PASSWD="$(mktemp)"
-        NSS_WRAPPER_GROUP="$(mktemp)"
-        export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-        mygid="$(id -g)"
-        printf 'spark:x:%s:%s:%s:%s:/bin/false\n' "$myuid" "$mygid" "${SPARK_USER_NAME:-anonymous uid}" "$SPARK_HOME" > "$NSS_WRAPPER_PASSWD"
-        printf 'spark:x:%s:\n' "$mygid" > "$NSS_WRAPPER_GROUP"
-        break
-      fi
-    done
+  for wrapper in {/usr,}/lib{/*,}/libnss_wrapper.so; do
+    if [ -s "$wrapper" ]; then
+      NSS_WRAPPER_PASSWD="$(mktemp)"
+      NSS_WRAPPER_GROUP="$(mktemp)"
+      export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+      mygid="$(id -g)"
+      printf 'spark:x:%s:%s:%s:%s:/bin/false\n' "$myuid" "$mygid" "${SPARK_USER_NAME:-anonymous uid}" "$SPARK_HOME" > "$NSS_WRAPPER_PASSWD"
+      printf 'spark:x:%s:\n' "$mygid" > "$NSS_WRAPPER_GROUP"
+      break
+    fi
+  done
 fi
 
 # Path for catatonit may differ depending on base container OS
-CATATONIT=$(command -v catatonit) || { echo "error: catatonit not found in PATH" >&2; exit 1; }
+CATATONIT=$(command -v catatonit) || {
+  echo "error: catatonit not found in PATH" >&2
+  exit 1
+}
 exec "$CATATONIT" -- /usr/bin/spark-operator "$@"

--- a/hack/install_packages.sh
+++ b/hack/install_packages.sh
@@ -18,8 +18,8 @@ arg1=$(head -2 /opt/spark/credentials | tail -1)
 arg2=$(head -3 /opt/spark/credentials | tail -1)
 arg3=$(head -1 /opt/spark/credentials | tail -1)
 
-subscription-manager register --username=$arg1 --password=$arg2  --name=docker
-subscription-manager attach --pool=$arg3 && yum install -y openssl
+subscription-manager register --username="$arg1" --password="$arg2" --name=docker
+subscription-manager attach --pool="$arg3" && yum install -y openssl
 subscription-manager remove --all
 subscription-manager unregister
 subscription-manager clean

--- a/hack/openapi/gen-openapi.sh
+++ b/hack/openapi/gen-openapi.sh
@@ -24,7 +24,6 @@ SPARK_OPERATOR_PKG="github.com/kubeflow/spark-operator/v2"
 
 cd "$CURRENT_DIR/../.."
 
-
 # Get the kube-openapi binary to generate OpenAPI spec.
 OPENAPI_PKG=$(go list -m -mod=readonly -f "{{.Dir}}" k8s.io/kube-openapi)
 echo ">> Using ${OPENAPI_PKG}"
@@ -51,7 +50,7 @@ EXTRA_PACKAGES=(
 for VERSION in v1alpha1 v1beta2; do
   echo "Generating OpenAPI for ${VERSION}"
 
-  go run ${OPENAPI_PKG}/cmd/openapi-gen \
+  go run "${OPENAPI_PKG}"/cmd/openapi-gen \
     --go-header-file "${SPARK_OPERATOR_ROOT}/hack/boilerplate.go.txt" \
     --output-pkg "${SPARK_OPERATOR_PKG}/api/${VERSION}" \
     --output-dir "${SPARK_OPERATOR_ROOT}/api/${VERSION}" \
@@ -63,4 +62,4 @@ done
 
 # Generating OpenAPI Swagger for Kubeflow Spark Operator.
 echo "Generate OpenAPI Swagger for Kubeflow Spark Operator"
-go run hack/swagger/main.go >api/openapi-spec/swagger.json
+go run hack/swagger/main.go > api/openapi-spec/swagger.json

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -28,13 +28,13 @@ source "${CODEGEN_PKG}/kube_codegen.sh"
 
 # Generate register code
 kube::codegen::gen_register \
-    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
-    "${SCRIPT_ROOT}"
+  --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
+  "${SCRIPT_ROOT}"
 
 # Generate client code: client, lister, informer in client-go directory
 kube::codegen::gen_client \
-    --with-watch \
-    --output-dir "${SCRIPT_ROOT}/pkg/client" \
-    --output-pkg "${SPARK_OPERATOR_PKG}/pkg/client" \
-    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
-    "${SCRIPT_ROOT}"
+  --with-watch \
+  --output-dir "${SCRIPT_ROOT}/pkg/client" \
+  --output-pkg "${SPARK_OPERATOR_PKG}/pkg/client" \
+  --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
+  "${SCRIPT_ROOT}"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -24,6 +24,7 @@ SCRIPT_ROOT="${SCRIPT_DIR}/.."
 CODEGEN_PKG="$($GO_CMD list -m -mod=readonly -f "{{.Dir}}" k8s.io/code-generator)"
 SPARK_OPERATOR_PKG="github.com/kubeflow/spark-operator/v2"
 
+# shellcheck source=/dev/null # provided by the code-generator module at runtime
 source "${CODEGEN_PKG}/kube_codegen.sh"
 
 # Generate register code

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 DIFFROOT="${SCRIPT_ROOT}/pkg"
 TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
@@ -39,8 +39,7 @@ echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
 cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
-if [[ $ret -eq 0 ]]
-then
+if [[ $ret -eq 0 ]]; then
   echo "${DIFFROOT} up to date."
 else
   echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"


### PR DESCRIPTION
## Purpose of this PR

The shell scripts in this repo (`entrypoint.sh` and the `hack/` codegen scripts) have no formatting or static-analysis checks today, so style drifts between scripts and common shell pitfalls can land unnoticed.

This PR adds `shfmt` formatting and `shellcheck` linting, enforced locally (Makefile + pre-commit) and in CI.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

Reference: https://github.com/kubeflow/spark-operator/pull/2975#discussion_r3361587538
