### PR TITLE
feat: Add Spark Connect server probes

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -209,8 +209,6 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
-    env:
-      GOPROXY: "https://proxy.golang.org|direct"
     strategy:
       matrix:
         k8s_version:
@@ -232,19 +230,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
-
-      - name: Download Go modules
-        run: |
-          for attempt in 1 2 3; do
-            if go mod download; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            echo "go mod download failed (attempt $attempt/3), retrying..."
-            sleep $((attempt * 10))
-          done
 
       - name: Create a Kind cluster
         run: make kind-create-cluster KIND_K8S_VERSION=${{ matrix.k8s_version }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -209,6 +209,8 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
+    env:
+      GOPROXY: "https://proxy.golang.org|direct"
     strategy:
       matrix:
         k8s_version:
@@ -230,6 +232,19 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
+
+      - name: Download Go modules
+        run: |
+          for attempt in 1 2 3; do
+            if go mod download; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            echo "go mod download failed (attempt $attempt/3), retrying..."
+            sleep $((attempt * 10))
+          done
 
       - name: Create a Kind cluster
         run: make kind-create-cluster KIND_K8S_VERSION=${{ matrix.k8s_version }}

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -50,6 +50,8 @@ import (
 
 const (
 	ExecutorPodTemplateFileName = "executor-pod-template.yaml"
+
+	sparkConnectServerPort = 15002
 )
 
 // Options defines the options of SparkConnect reconciler.
@@ -383,6 +385,8 @@ func (r *Reconciler) mutateServerPod(_ context.Context, conn *v1alpha1.SparkConn
 		}
 		container.Args = []string{strings.Join(args, " ")}
 
+		setDefaultSparkConnectServerProbes(container)
+
 		// Setup environment variables.
 		container.Env = append(
 			container.Env,
@@ -461,6 +465,42 @@ func (r *Reconciler) mutateServerPod(_ context.Context, conn *v1alpha1.SparkConn
 	return nil
 }
 
+func setDefaultSparkConnectServerProbes(container *corev1.Container) {
+	if container.StartupProbe == nil {
+		container.StartupProbe = newSparkConnectServerStartupProbe()
+	}
+	if container.ReadinessProbe == nil {
+		container.ReadinessProbe = newSparkConnectServerReadinessProbe()
+	}
+}
+
+func newSparkConnectServerStartupProbe() *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(sparkConnectServerPort),
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      1,
+		FailureThreshold:    30,
+	}
+}
+
+func newSparkConnectServerReadinessProbe() *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(sparkConnectServerPort),
+			},
+		},
+		PeriodSeconds:    10,
+		TimeoutSeconds:   1,
+		FailureThreshold: 3,
+	}
+}
+
 // createOrUpdateServerService creates or updates the server service for the SparkConnect resource.
 func (r *Reconciler) createOrUpdateServerService(ctx context.Context, conn *v1alpha1.SparkConnect) error {
 	logger := ctrl.LoggerFrom(ctx)
@@ -524,8 +564,8 @@ func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.Spark
 			},
 			{
 				Name:        "spark-connect-server",
-				Port:        15002,
-				TargetPort:  intstr.FromInt(15002),
+				Port:        sparkConnectServerPort,
+				TargetPort:  intstr.FromInt(sparkConnectServerPort),
 				Protocol:    corev1.ProtocolTCP,
 				AppProtocol: ptr.To("grpc"),
 			},

--- a/internal/controller/sparkconnect/reconciler_test.go
+++ b/internal/controller/sparkconnect/reconciler_test.go
@@ -18,16 +18,19 @@ package sparkconnect
 
 import (
 	"context"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
 
 var _ = Describe("mutateServerService", func() {
@@ -145,6 +148,109 @@ var _ = Describe("mutateServerService", func() {
 			// Ports should remain unchanged for existing services.
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Name).To(Equal("spark-connect-server"))
+		})
+	})
+})
+
+var _ = Describe("mutateServerPod", func() {
+	var (
+		reconciler *Reconciler
+		conn       *v1alpha1.SparkConnect
+		image      string
+	)
+
+	BeforeEach(func() {
+		reconciler = &Reconciler{
+			scheme: scheme.Scheme,
+		}
+		image = "apache/spark:4.0.0"
+		Expect(os.Setenv(common.EnvKubernetesServiceHost, "127.0.0.1")).NotTo(HaveOccurred())
+		Expect(os.Setenv(common.EnvKubernetesServicePort, "443")).NotTo(HaveOccurred())
+		conn = &v1alpha1.SparkConnect{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-spark-connect",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+			},
+			Spec: v1alpha1.SparkConnectSpec{
+				Image:        &image,
+				SparkVersion: "4.0.0",
+				Server: v1alpha1.ServerSpec{
+					SparkPodSpec: v1alpha1.SparkPodSpec{},
+				},
+				Executor: v1alpha1.ExecutorSpec{
+					SparkPodSpec: v1alpha1.SparkPodSpec{},
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(os.Unsetenv(common.EnvKubernetesServiceHost)).NotTo(HaveOccurred())
+		Expect(os.Unsetenv(common.EnvKubernetesServicePort)).NotTo(HaveOccurred())
+	})
+
+	Context("when creating a new server pod", func() {
+		It("should set default TCP startup and readiness probes", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conn.Namespace,
+				},
+			}
+			err := reconciler.mutateServerPod(context.TODO(), conn, pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pod.Spec.Containers).NotTo(BeEmpty())
+
+			container := pod.Spec.Containers[0]
+			Expect(container.Name).To(Equal(common.SparkDriverContainerName))
+			Expect(container.StartupProbe).NotTo(BeNil())
+			Expect(container.StartupProbe.TCPSocket).NotTo(BeNil())
+			Expect(container.StartupProbe.TCPSocket.Port).To(Equal(intstr.FromInt(sparkConnectServerPort)))
+			Expect(container.ReadinessProbe).NotTo(BeNil())
+			Expect(container.ReadinessProbe.TCPSocket).NotTo(BeNil())
+			Expect(container.ReadinessProbe.TCPSocket.Port).To(Equal(intstr.FromInt(sparkConnectServerPort)))
+		})
+
+		It("should preserve user-provided startup and readiness probes", func() {
+			startupProbe := &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/startup",
+						Port: intstr.FromInt(4040),
+					},
+				},
+			}
+			readinessProbe := &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/ready",
+						Port: intstr.FromInt(4040),
+					},
+				},
+			}
+			conn.Spec.Server.Template = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:           common.SparkDriverContainerName,
+							Image:          image,
+							StartupProbe:   startupProbe,
+							ReadinessProbe: readinessProbe,
+						},
+					},
+				},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conn.Namespace,
+				},
+			}
+			err := reconciler.mutateServerPod(context.TODO(), conn, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := pod.Spec.Containers[0]
+			Expect(container.StartupProbe).To(Equal(startupProbe))
+			Expect(container.ReadinessProbe).To(Equal(readinessProbe))
 		})
 	})
 })


### PR DESCRIPTION


## Purpose of this PR
Ref https://github.com/kubeflow/spark-operator/issues/2994

Adds default TCP startup and readiness probes to the Spark Connect server container.

This does not add a full Spark Connect application-level health check. The default TCP probes provide a conservative readiness signal: the Spark Connect server pod is not marked Ready
  until port 15002 is accepting connections.

  This improves the current behavior where the pod can become Ready once the container is running, even if Spark Connect is not yet reachable. A deeper semantic health check would require
  Spark Connect to expose a supported health endpoint, such as the standard gRPC health checking service or another lightweight readiness API. Ref https://issues.apache.org/jira/browse/SPARK-57584


**Proposed changes:**
  - Added shared Spark Connect server port constant for 15002.
  - Added default startupProbe and readinessProbe for the Spark Connect server container.
  - Reused the same port constant in the Spark Connect service.
  - Added tests for default probe injection and preserving user-provided probes.



## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Spark Connect server pods could be marked ready by Kubernetes before the Spark Connect port was actually accepting traffic. SDK/client flows that wait for pod readiness could then attempt  to connect too early.

After: 
  New Spark Connect server pods get default TCP probes against port 15002. Kubernetes readiness now waits until the Spark Connect port is reachable. User-defined probes in  spec.server.template are preserved and not overwritten.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
