### PR TITLE
Bump Go to 1.25.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=docker.io/library/spark:4.0.1
+ARG SPARK_IMAGE=docker.io/library/spark:4.0.1@sha256:a552a335e0aedb44fa28b20ed7e9dc52c2e856faf87fb0409fb57dbf37b45bf7
 
-FROM golang:1.25.9 AS builder
+FROM docker.io/library/golang:1.25.11@sha256:00feed335fe561979f2cdcc30a5191231977c5631fe79c40f7d3ab63b4fa222f AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kubeflow/spark-operator/v2
 
 go 1.25.0
 
+toolchain go1.25.11
+
 tool k8s.io/code-generator
 
 require (


### PR DESCRIPTION


## Purpose of this PR

This PR bumps Go to 1.25.11 from 1.25.0

**Proposed changes:**

- Bump Go to 1.25.11
- Pin Go and Spark images to hashes


## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

We need to keep Go version updated

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
