### PR TITLE
feat(helm): add RestSubmitter feature gate with controller integration

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -93,7 +93,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | hook.labels | object | `{}` | Extra labels for the Helm hook Job pod. |
 | hook.annotations | object | `{}` | Extra annotations for the Helm hook Job pod. |
 | controller.replicas | int | `1` | Number of replicas of controller. |
-| controller.featureGates | list | `[{"enabled":false,"name":"PartialRestart"},{"enabled":false,"name":"LoadSparkDefaults"}]` | Feature gates to enable or disable specific features. |
+| controller.featureGates | list | `[{"enabled":false,"name":"PartialRestart"},{"enabled":false,"name":"LoadSparkDefaults"},{"enabled":false,"name":"RestSubmitter"}]` | Feature gates to enable or disable specific features. |
 | controller.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | controller.leaderElection.enable | bool | `true` | Specifies whether to enable leader election for controller. |
 | controller.leaderElection.leaseDuration | string | `"15s"` | Leader election lease duration. |
@@ -147,6 +147,13 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.workqueueRateLimiter.bucketSize | int | `500` | Specifies the maximum number of items that can be in the workqueue at any given time. |
 | controller.workqueueRateLimiter.maxDelay.enable | bool | `true` | Specifies whether to enable max delay for the workqueue rate limiter. This is useful to avoid losing events when the workqueue is full. |
 | controller.workqueueRateLimiter.maxDelay.duration | string | `"6h"` | Specifies the maximum delay duration for the workqueue rate limiter. |
+| submitter.serviceUrl | string | `"http://spark-operator-submitter-svc:8080/api/v1/spark-submit"` | URL of the REST submitter service endpoint. |
+| submitter.requestTimeout | string | `"2m"` | HTTP request timeout per spark submission attempt. |
+| submitter.startupTimeout | string | `"5m"` | How long the controller waits for the submitter service to become reachable at startup. |
+| submitter.maxRetries | int | `3` | Max retry attempts for transient submission failures. |
+| submitter.initialBackoff | string | `"2s"` | Initial backoff duration before the first retry. Doubles on each subsequent attempt. |
+| submitter.startupProbe.periodSeconds | int | `5` | Seconds between probe attempts. |
+| submitter.startupProbe.failureThreshold | int | `60` | Number of failures before restart. (failureThreshold × periodSeconds) should >= startupTimeout. |
 | webhook.enable | bool | `true` | Specifies whether to enable webhook. |
 | webhook.replicas | int | `1` | Number of replicas of webhook server. |
 | webhook.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |

--- a/charts/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/_helpers.tpl
@@ -76,3 +76,12 @@ Spark Operator image
 {{- define "spark-operator.image" -}}
 {{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion | toString) }}
 {{- end -}}
+
+{{/*
+Whether the RestSubmitter feature gate is enabled.
+*/}}
+{{- define "spark-operator.submitter.enabled" -}}
+{{- range .Values.controller.featureGates -}}
+{{- if and (eq .name "RestSubmitter") .enabled -}}true{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -140,6 +140,13 @@ spec:
         {{- if .Values.controller.featureGates }}
         - --feature-gates={{ range $index, $gate := .Values.controller.featureGates }}{{ if $index }},{{ end }}{{ $gate.name }}={{ $gate.enabled }}{{ end }}
         {{- end }}
+        {{- if include "spark-operator.submitter.enabled" . }}
+        - --submitter-service-url={{ .Values.submitter.serviceUrl }}
+        - --submitter-request-timeout={{ .Values.submitter.requestTimeout }}
+        - --submitter-startup-timeout={{ .Values.submitter.startupTimeout }}
+        - --submitter-max-retries={{ .Values.submitter.maxRetries }}
+        - --submitter-initial-backoff={{ .Values.submitter.initialBackoff }}
+        {{- end }}
         {{- if or .Values.prometheus.metrics.enable .Values.controller.pprof.enable }}
         ports:
         {{- if .Values.controller.pprof.enable }}
@@ -166,6 +173,15 @@ spec:
         {{- with .Values.controller.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if include "spark-operator.submitter.enabled" . }}
+        startupProbe:
+          httpGet:
+            port: 8081
+            scheme: HTTP
+            path: /healthz
+          failureThreshold: {{ .Values.submitter.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.submitter.startupProbe.periodSeconds }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -894,3 +894,74 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --feature-gates=PartialRestart=true,AnotherFeature=false
 
+  - it: Should render submitter args when RestSubmitter feature gate is enabled
+    set:
+      controller:
+        featureGates:
+        - name: RestSubmitter
+          enabled: true
+      submitter:
+        serviceUrl: http://my-submitter:8080/api/v1/spark-submit
+        requestTimeout: 3m
+        startupTimeout: 10m
+        maxRetries: 5
+        initialBackoff: 5s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --submitter-service-url=http://my-submitter:8080/api/v1/spark-submit
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --submitter-request-timeout=3m
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --submitter-startup-timeout=10m
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --submitter-max-retries=5
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --submitter-initial-backoff=5s
+
+  - it: Should not render submitter args when RestSubmitter feature gate is disabled
+    set:
+      controller:
+        featureGates:
+        - name: RestSubmitter
+          enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --submitter-service-url=http://spark-operator-submitter-svc:8080/api/v1/spark-submit
+
+  - it: Should render startup probe when RestSubmitter feature gate is enabled
+    set:
+      controller:
+        featureGates:
+        - name: RestSubmitter
+          enabled: true
+      submitter:
+        startupProbe:
+          periodSeconds: 10
+          failureThreshold: 30
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].startupProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].startupProbe.failureThreshold
+          value: 30
+
+  - it: Should not render startup probe when RestSubmitter feature gate is disabled
+    set:
+      controller:
+        featureGates:
+        - name: RestSubmitter
+          enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].startupProbe
+

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -84,6 +84,8 @@ controller:
     enabled: false
   - name: LoadSparkDefaults
     enabled: false
+  - name: RestSubmitter
+    enabled: false
 
   # -- The number of old history to retain to allow rollback.
   revisionHistoryLimit: 10
@@ -297,6 +299,34 @@ controller:
       enable: true
       # -- Specifies the maximum delay duration for the workqueue rate limiter.
       duration: 6h
+
+# REST Submitter Service configuration.
+# The submitter service itself is deployed separately (see submitter service repository).
+# These values configure the controller's connection to the submitter.
+# Enable via controller.featureGates RestSubmitter=true.
+submitter:
+  # -- URL of the REST submitter service endpoint.
+  serviceUrl: http://spark-operator-submitter-svc:8080/api/v1/spark-submit
+
+  # -- HTTP request timeout per spark submission attempt.
+  requestTimeout: 2m
+
+  # -- How long the controller waits for the submitter service to become reachable at startup.
+  startupTimeout: 5m
+
+  # -- Max retry attempts for transient submission failures.
+  maxRetries: 3
+
+  # -- Initial backoff duration before the first retry. Doubles on each subsequent attempt.
+  initialBackoff: 2s
+
+  # Controller startup probe settings. Allows the controller to block during startup
+  # without being killed by liveness probe. Should cover startupTimeout.
+  startupProbe:
+    # -- Seconds between probe attempts.
+    periodSeconds: 5
+    # -- Number of failures before restart. (failureThreshold × periodSeconds) should >= startupTimeout.
+    failureThreshold: 60
 
 webhook:
   # -- Specifies whether to enable webhook.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,7 +87,7 @@ spec:
             - --max-tracked-executor-per-app=1000
             - --kube-api-qps=20
             - --kube-api-burst=30
-            - --feature-gates=PartialRestart=false,LoadSparkDefaults=false
+            - --feature-gates=PartialRestart=false,LoadSparkDefaults=false,RestSubmitter=false
             - --scheduled-spark-application-timestamp-precision=nanos
           env:
             - name: OPERATOR_VERSION


### PR DESCRIPTION
## Summary
- Add `RestSubmitter` feature gate to the helm chart (disabled by default)
- Configure the controller to connect to an external REST submitter service when the gate is enabled
- Add submitter connection config in `values.yaml` (serviceUrl, timeouts, retries)
- Add startup probe to controller when submitter is enabled
- Add unit tests for enabled/disabled states

## Scope
- Controller deployment template changes only (submitter args, startup probe)
- `values.yaml` feature gate + submitter connection config
- Drift-check alignment (`config/manager/manager.yaml`)

## Out of scope
- Submitter service helm templates (deployed separately from the [submitter repo](https://github.com/venkomirisetti/k8s-spark-submitter))
- TLS/mTLS configuration (will be documented separately)
- E2E tests or CI workflow changes
- Documentation (to be added under `doc/website` as a follow-up)

## Test plan
- [x] Helm unit tests pass (216 tests)
- [x] Drift-check passes
- [x] `helm template` validated with feature gate enabled/disabled