### PR TITLE
fix: use API reader for namespace label checks in event filters

### DIFF
--- a/internal/controller/scheduledsparkapplication/controller.go
+++ b/internal/controller/scheduledsparkapplication/controller.go
@@ -237,7 +237,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 
 	// Create event filter with error handling
 	eventFilter, err := NewEventFilter(
-		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		r.options.Namespaces,
 		r.options.NamespaceSelector,
 	)

--- a/internal/controller/scheduledsparkapplication/event_filter.go
+++ b/internal/controller/scheduledsparkapplication/event_filter.go
@@ -31,7 +31,7 @@ import (
 
 // EventFilter filters out ScheduledSparkApplication events.
 type EventFilter struct {
-	client           client.Client
+	namespaceReader  client.Reader
 	namespaceMatcher *util.NamespaceMatcher
 	logger           logr.Logger
 }
@@ -40,14 +40,14 @@ type EventFilter struct {
 var _ predicate.Predicate = &EventFilter{}
 
 // NewEventFilter creates a new EventFilter instance.
-func NewEventFilter(client client.Client, namespaces []string, namespaceSelector string) (*EventFilter, error) {
+func NewEventFilter(namespaceReader client.Reader, namespaces []string, namespaceSelector string) (*EventFilter, error) {
 	matcher, err := util.NewNamespaceMatcher(namespaces, namespaceSelector)
 	if err != nil {
 		return nil, err
 	}
 
 	return &EventFilter{
-		client:           client,
+		namespaceReader:  namespaceReader,
 		namespaceMatcher: matcher,
 		logger:           log.Log.WithName("scheduled-spark-application-event-filter"),
 	}, nil
@@ -88,7 +88,7 @@ func (f *EventFilter) Generic(e event.GenericEvent) bool {
 
 func (f *EventFilter) filter(app *v1beta2.ScheduledSparkApplication) bool {
 	// Check if namespace matches using the matcher
-	matched, err := f.namespaceMatcher.MatchesWithClient(context.TODO(), f.client, app.Namespace)
+	matched, err := f.namespaceMatcher.MatchesWithClient(context.TODO(), f.namespaceReader, app.Namespace)
 	if err != nil {
 		f.logger.Error(err, "failed to check namespace match", "namespace", app.Namespace, "app", app.Name)
 		return false

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -248,7 +248,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 
 	// Create event filters with error handling
 	podEventFilter, err := newSparkPodEventFilter(
-		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		r.options.Namespaces,
 		r.options.NamespaceSelector,
 	)
@@ -258,6 +258,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 
 	appEventFilter, err := NewSparkApplicationEventFilter(
 		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		mgr.GetEventRecorder("spark-application-event-handler"),
 		r.options.Namespaces,
 		r.options.NamespaceSelector,

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -36,7 +36,7 @@ import (
 
 // sparkPodEventFilter filters Spark pod events.
 type sparkPodEventFilter struct {
-	client           client.Client
+	namespaceReader  client.Reader
 	namespaceMatcher *util.NamespaceMatcher
 	logger           logr.Logger
 }
@@ -45,14 +45,14 @@ type sparkPodEventFilter struct {
 var _ predicate.Predicate = &sparkPodEventFilter{}
 
 // newSparkPodEventFilter creates a new SparkPodEventFilter instance.
-func newSparkPodEventFilter(client client.Client, namespaces []string, namespaceSelector string) (*sparkPodEventFilter, error) {
+func newSparkPodEventFilter(namespaceReader client.Reader, namespaces []string, namespaceSelector string) (*sparkPodEventFilter, error) {
 	matcher, err := util.NewNamespaceMatcher(namespaces, namespaceSelector)
 	if err != nil {
 		return nil, err
 	}
 
 	return &sparkPodEventFilter{
-		client:           client,
+		namespaceReader:  namespaceReader,
 		namespaceMatcher: matcher,
 		logger:           log.Log.WithName("spark-pod-event-filter"),
 	}, nil
@@ -113,7 +113,7 @@ func (f *sparkPodEventFilter) filter(pod *corev1.Pod) bool {
 	}
 
 	// Check if namespace matches using the matcher
-	matched, err := f.namespaceMatcher.MatchesWithClient(context.TODO(), f.client, pod.Namespace)
+	matched, err := f.namespaceMatcher.MatchesWithClient(context.TODO(), f.namespaceReader, pod.Namespace)
 	if err != nil {
 		f.logger.Error(err, "failed to check namespace match", "namespace", pod.Namespace, "pod", pod.Name)
 		return false
@@ -124,6 +124,7 @@ func (f *sparkPodEventFilter) filter(pod *corev1.Pod) bool {
 
 type EventFilter struct {
 	client           client.Client
+	namespaceReader  client.Reader
 	recorder         events.EventRecorder
 	namespaceMatcher *util.NamespaceMatcher
 	logger           logr.Logger
@@ -131,7 +132,7 @@ type EventFilter struct {
 
 var _ predicate.Predicate = &EventFilter{}
 
-func NewSparkApplicationEventFilter(client client.Client, recorder events.EventRecorder, namespaces []string, namespaceSelector string) (*EventFilter, error) {
+func NewSparkApplicationEventFilter(client client.Client, namespaceReader client.Reader, recorder events.EventRecorder, namespaces []string, namespaceSelector string) (*EventFilter, error) {
 	matcher, err := util.NewNamespaceMatcher(namespaces, namespaceSelector)
 	if err != nil {
 		return nil, err
@@ -139,6 +140,7 @@ func NewSparkApplicationEventFilter(client client.Client, recorder events.EventR
 
 	return &EventFilter{
 		client:           client,
+		namespaceReader:  namespaceReader,
 		recorder:         recorder,
 		namespaceMatcher: matcher,
 		logger:           log.Log.WithName("spark-application-event-filter"),
@@ -249,7 +251,7 @@ func (f *EventFilter) Generic(e event.GenericEvent) bool {
 
 func (f *EventFilter) filter(app *v1beta2.SparkApplication) bool {
 	// Check if namespace matches using the matcher
-	matched, err := f.namespaceMatcher.MatchesWithClient(context.TODO(), f.client, app.Namespace)
+	matched, err := f.namespaceMatcher.MatchesWithClient(context.TODO(), f.namespaceReader, app.Namespace)
 	if err != nil {
 		f.logger.Error(err, "failed to check namespace match", "namespace", app.Namespace, "app", app.Name)
 		return false

--- a/internal/controller/sparkapplication/event_filter_test.go
+++ b/internal/controller/sparkapplication/event_filter_test.go
@@ -939,7 +939,7 @@ func TestNewSparkApplicationEventFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, tt.namespaces, tt.namespaceSelector)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("NewSparkApplicationEventFilter() expected error, got nil")
@@ -1046,7 +1046,7 @@ func TestSparkApplicationEventFilter_Create(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, tt.namespaces, tt.namespaceSelector)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1073,7 +1073,7 @@ func TestSparkApplicationEventFilter_Create_NonSparkApplication(t *testing.T) {
 	_ = v1beta2.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	filter, _ := NewSparkApplicationEventFilter(fakeClient, nil, []string{"default"}, "")
+	filter, _ := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, []string{"default"}, "")
 
 	// Test with a Pod instead of SparkApplication
 	pod := &corev1.Pod{
@@ -1120,7 +1120,7 @@ func TestSparkApplicationEventFilter_Update_TimeToLiveSecondsDoesNotInvalidate(t
 		WithStatusSubresource(&v1beta2.SparkApplication{}).
 		WithObjects(newApp.DeepCopy()).
 		Build()
-	filter, err := NewSparkApplicationEventFilter(fakeClient, events.NewFakeRecorder(10), []string{"default"}, "")
+	filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, events.NewFakeRecorder(10), []string{"default"}, "")
 	if err != nil {
 		t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 	}
@@ -1185,7 +1185,7 @@ func TestSparkApplicationEventFilter_Delete(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, tt.namespaces, tt.namespaceSelector)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1256,7 +1256,7 @@ func TestSparkApplicationEventFilter_Generic(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, tt.namespaces, tt.namespaceSelector)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1339,7 +1339,7 @@ func TestSparkApplicationEventFilter_MultipleLabelsSelector(t *testing.T) {
 				WithObjects(ns).
 				Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, []string{}, tt.selector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, []string{}, tt.selector)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1367,7 +1367,7 @@ func TestSparkApplicationEventFilter_NamespaceAll(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	// Empty namespaces list means watch all namespaces
-	filter, err := NewSparkApplicationEventFilter(fakeClient, nil, []string{}, "")
+	filter, err := NewSparkApplicationEventFilter(fakeClient, fakeClient, nil, []string{}, "")
 	if err != nil {
 		t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 	}

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -97,7 +97,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 
 	// Create predicate before the builder chain.
 	namespacePredicate, err := util.NewNamespacePredicate(
-		r.client,
+		mgr.GetAPIReader(),
 		r.options.Namespaces,
 		r.options.NamespaceSelector,
 	)

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -97,9 +97,9 @@ func (m *NamespaceMatcher) MatchesNamespace(ns *corev1.Namespace) bool {
 	return m.Matches(ns.Name, ns.Labels)
 }
 
-// MatchesWithClient retrieves the namespace from the cache and checks if it matches.
-// This is useful in EventFilters where you only have the namespace name.
-func (m *NamespaceMatcher) MatchesWithClient(ctx context.Context, c client.Client, namespaceName string) (bool, error) {
+// MatchesWithClient retrieves the namespace and checks if it matches.
+// The reader should be an uncached API reader in predicates to avoid informer cache lag.
+func (m *NamespaceMatcher) MatchesWithClient(ctx context.Context, r client.Reader, namespaceName string) (bool, error) {
 	// Fast-path: if watching all namespaces, always match
 	if m.explicitNamespaces[metav1.NamespaceAll] {
 		return true, nil
@@ -115,9 +115,8 @@ func (m *NamespaceMatcher) MatchesWithClient(ctx context.Context, c client.Clien
 		return false, nil
 	}
 
-	// Need to retrieve namespace from cache to check labels
 	ns := &corev1.Namespace{}
-	if err := c.Get(ctx, client.ObjectKey{Name: namespaceName}, ns); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: namespaceName}, ns); err != nil {
 		return false, fmt.Errorf("failed to get namespace %s: %v", namespaceName, err)
 	}
 

--- a/pkg/util/predicates.go
+++ b/pkg/util/predicates.go
@@ -11,7 +11,7 @@ import (
 // namespacePredicate is a predicate.Predicate
 // that filters events based on namespace list and/or label selector.
 type namespacePredicate struct {
-	client           client.Client
+	namespaceReader  client.Reader
 	namespaceMatcher *NamespaceMatcher
 }
 
@@ -20,21 +20,21 @@ type namespacePredicate struct {
 //
 // If namespaceSelector is empty, only explicit namespaces are matched.
 // If namespaces is empty, all namespaces are matched.
-func NewNamespacePredicate(c client.Client, namespaces []string, namespaceSelector string) (predicate.Predicate, error) {
+func NewNamespacePredicate(namespaceReader client.Reader, namespaces []string, namespaceSelector string) (predicate.Predicate, error) {
 	matcher, err := NewNamespaceMatcher(namespaces, namespaceSelector)
 	if err != nil {
 		return nil, err
 	}
 
 	return &namespacePredicate{
-		client:           c,
+		namespaceReader:  namespaceReader,
 		namespaceMatcher: matcher,
 	}, nil
 }
 
 // Create implements the predicate.Predicate interface.
 func (p *namespacePredicate) Create(e event.CreateEvent) bool {
-	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.client, e.Object.GetNamespace())
+	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.namespaceReader, e.Object.GetNamespace())
 	if err != nil {
 		return false
 	}
@@ -43,7 +43,7 @@ func (p *namespacePredicate) Create(e event.CreateEvent) bool {
 
 // Update implements the predicate.Predicate interface.
 func (p *namespacePredicate) Update(e event.UpdateEvent) bool {
-	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.client, e.ObjectNew.GetNamespace())
+	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.namespaceReader, e.ObjectNew.GetNamespace())
 	if err != nil {
 		return false
 	}
@@ -52,7 +52,7 @@ func (p *namespacePredicate) Update(e event.UpdateEvent) bool {
 
 // Delete implements the predicate.Predicate interface.
 func (p *namespacePredicate) Delete(e event.DeleteEvent) bool {
-	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.client, e.Object.GetNamespace())
+	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.namespaceReader, e.Object.GetNamespace())
 	if err != nil {
 		return false
 	}
@@ -61,7 +61,7 @@ func (p *namespacePredicate) Delete(e event.DeleteEvent) bool {
 
 // Generic implements the predicate.Predicate interface.
 func (p *namespacePredicate) Generic(e event.GenericEvent) bool {
-	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.client, e.Object.GetNamespace())
+	matched, err := p.namespaceMatcher.MatchesWithClient(context.TODO(), p.namespaceReader, e.Object.GetNamespace())
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Purpose of this PR

Fixes a race condition in namespace selector filtering that causes flaky e2e failures (`Namespace Filtering > With namespace selector > should process SparkApp in labeled namespace`).

When `jobNamespaceSelector` is configured, event filters evaluate namespace labels via the controller's **cached client**. If a SparkApplication create event arrives before the namespace informer has indexed the new namespace, the lookup fails, the predicate returns `false`, and the event is **silently dropped** with no retry. The SparkApplication stays in `New` state until the test times out.

### Observed CI failures

This race has been seen across multiple PRs and Kubernetes versions:

| CI run | K8s version | Symptom |
|---|---|---|
| [job/79602618303](https://github.com/kubeflow/spark-operator/actions/runs/26975877379/job/79602618303?pr=2975) | v1.32.11 | Namespace filtering flake — SparkApp stuck in `New`, 5min timeout |
| [job/79746346579](https://github.com/kubeflow/spark-operator/actions/runs/26976934082/job/79746346579?pr=2975) | v1.33.7 | BeforeSuite timeout (likely separate Helm readiness issue) |
| [job/79606205486](https://github.com/kubeflow/spark-operator/actions/runs/26976934082/job/79606205486?pr=2975) | v1.34.3 | BeforeSuite timeout (likely separate Helm readiness issue) |

Also reproduced on PR #2990 and other unrelated PRs (e.g. REST submitter).

**Proposed changes:**

- Use `mgr.GetAPIReader()` for live namespace label lookups in SparkApplication, ScheduledSparkApplication, and SparkConnect event filters/predicates
- Update `MatchesWithClient` to accept `client.Reader` instead of `client.Client`
- Keep the cached `client.Client` on SparkApplication event filters only where writes are needed (e.g. `Status().Update()` in the Update predicate)

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The operator maintains two independent informer caches (namespaces and SparkApplications). A test (or user) can create a labeled namespace and immediately submit a SparkApplication — the test client sees the namespace, but the controller cache may not yet.

Using the uncached API reader for label checks eliminates this lag while preserving correct fail-closed behavior: unlabeled namespaces still return `false`, and non-existent namespaces still return a real `NotFound`.

This is preferred over returning `true` on lookup error, which would fix the flake but incorrectly allow events through for unlabeled namespaces during the same race window.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.