### PR TITLE
Add deploymentAnnotations to controller and webhook deployments

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -124,6 +124,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.rbac.annotations | object | `{}` | Extra annotations for the controller RBAC resources. |
 | controller.labels | object | `{}` | Extra labels for controller pods. |
 | controller.annotations | object | `{}` | Extra annotations for controller pods. |
+| controller.deploymentAnnotations | object | `{}` | Annotations for the controller Deployment resource (metadata.annotations). |
 | controller.volumes | list | `[{"emptyDir":{"sizeLimit":"1Gi"},"name":"tmp"}]` | Volumes for controller pods. |
 | controller.nodeSelector | object | `{}` | Node selector for controller pods. |
 | controller.affinity | object | `{}` | Affinity for controller pods. |
@@ -168,6 +169,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.rbac.annotations | object | `{}` | Extra annotations for the webhook RBAC resources. |
 | webhook.labels | object | `{}` | Extra labels for webhook pods. |
 | webhook.annotations | object | `{}` | Extra annotations for webhook pods. |
+| webhook.deploymentAnnotations | object | `{}` | Annotations for the webhook Deployment resource (metadata.annotations). |
 | webhook.sidecars | list | `[]` | Sidecar containers for webhook pods. |
 | webhook.volumes | list | `[{"emptyDir":{"sizeLimit":"500Mi"},"name":"serving-certs"}]` | Volumes for webhook pods. |
 | webhook.nodeSelector | object | `{}` | Node selector for webhook pods. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -20,6 +20,10 @@ metadata:
   name: {{ include "spark-operator.controller.deploymentName" . }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
+  {{- with .Values.controller.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.controller.replicas }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -21,6 +21,10 @@ metadata:
   name: {{ include "spark-operator.webhook.deploymentName" . }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
+  {{- with .Values.webhook.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.webhook.replicas }}
   revisionHistoryLimit: {{ .Values.webhook.revisionHistoryLimit }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -123,6 +123,20 @@ tests:
           path: spec.template.metadata.annotations.key2
           value: value2
 
+  - it: Should add deployment annotations if `controller.deploymentAnnotations` is set
+    set:
+      controller:
+        deploymentAnnotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: metadata.annotations.key1
+          value: value1
+      - equal:
+          path: metadata.annotations.key2
+          value: value2
+
   - it: Should contain `--zap-log-level` arg if `controller.logLevel` is set
     set:
       controller:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -100,6 +100,20 @@ tests:
           path: spec.template.metadata.annotations.key2
           value: value2
 
+  - it: Should add deployment annotations if `webhook.deploymentAnnotations` is set
+    set:
+      webhook:
+        deploymentAnnotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: metadata.annotations.key1
+          value: value1
+      - equal:
+          path: metadata.annotations.key2
+          value: value2
+
   - it: Should use the specified image repository if `image.registry`, `image.repository` and `image.tag` are set
     set:
       image:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -189,6 +189,11 @@ controller:
     # key1: value1
     # key2: value2
 
+  # -- Annotations for the controller deployment
+  deploymentAnnotations: {}
+    # key1: value1
+    # key2: value2
+
   # -- Volumes for controller pods.
   volumes:
   # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
@@ -363,6 +368,11 @@ webhook:
 
   # -- Extra annotations for webhook pods.
   annotations: {}
+    # key1: value1
+    # key2: value2
+
+  # -- Annotations for the webhook deployment
+  deploymentAnnotations: {}
     # key1: value1
     # key2: value2
 

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -189,7 +189,7 @@ controller:
     # key1: value1
     # key2: value2
 
-  # -- Annotations for the controller deployment
+  # -- Annotations for the controller Deployment resource (metadata.annotations).
   deploymentAnnotations: {}
     # key1: value1
     # key2: value2
@@ -371,7 +371,7 @@ webhook:
     # key1: value1
     # key2: value2
 
-  # -- Annotations for the webhook deployment
+  # -- Annotations for the webhook Deployment resource (metadata.annotations).
   deploymentAnnotations: {}
     # key1: value1
     # key2: value2


### PR DESCRIPTION
## Purpose of this PR

The chart supports `controller.annotations` and `webhook.annotations`, but these target the pod template (`spec.template.metadata.annotations`), not the Deployment resource itself (`metadata.annotations`).

Tools like [Reloader](https://github.com/stakater/Reloader) watch for annotations on the Deployment object to trigger rolling restarts when ConfigMaps or Secrets change. There is currently no way to set Deployment-level annotations without forking the chart templates.

**Proposed changes:**

- Add controller.deploymentAnnotations value applied to metadata.annotations of the controller Deployment
- Add webhook.deploymentAnnotations value applied to metadata.annotations of the webhook Deployment
- Add helm unit tests for both new values


## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The existing `annotations` keys are already documented as pod annotations. Adding a separate `deploymentAnnotations` key mirrors that pattern and keeps the distinction explicit, consistent with how other charts (e.g. ingress-nginx, cert-manager) handle this separation.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

No breaking changes — `deploymentAnnotation`s defaults to `{}` in both cases, so existing deployments are unaffected.
