### PR TITLE
Preserve user-supplied service port

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -177,8 +177,8 @@ func driverConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 
 	driverHost := "$(host=${POD_IP}; if [[ $host == *:* ]] && [[ $host != \\[* ]]; then echo \"[$host]\"; else echo \"$host\"; fi)"
 	args = append(args, "--conf", fmt.Sprintf("spark.driver.host=%s", driverHost))
-	args = append(args, "--conf", "spark.driver.port=7078")
-	args = append(args, "--conf", "spark.driver.blockManager.port=7079")
+	args = append(args, "--conf", fmt.Sprintf("spark.driver.port=%d", common.SparkConnectDriverRPCPort))
+	args = append(args, "--conf", fmt.Sprintf("spark.driver.blockManager.port=%d", common.SparkConnectBlockManagerPort))
 
 	// Driver pod name
 	args = append(args, "--conf", fmt.Sprintf("%s=%s", common.SparkKubernetesDriverPodName, fmt.Sprintf("%s-server", conn.Name)))

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -538,40 +537,11 @@ func (r *Reconciler) createOrUpdateServerService(ctx context.Context, conn *v1al
 }
 
 // mutateServerService mutates the server service for the SparkConnect resource.
+// On creation, it preserves any user-supplied ports and appends the required
+// ports (by name) that are missing. Existing services are left untouched.
 func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.SparkConnect, svc *corev1.Service) error {
 	if svc.CreationTimestamp.IsZero() {
-		svc.Spec.Ports = []corev1.ServicePort{
-			{
-				Name:        "driver-rpc",
-				Port:        7078,
-				TargetPort:  intstr.FromInt(7078),
-				Protocol:    corev1.ProtocolTCP,
-				AppProtocol: ptr.To("tcp"),
-			},
-			{
-				Name:        "blockmanager",
-				Port:        7079,
-				TargetPort:  intstr.FromInt(7079),
-				Protocol:    corev1.ProtocolTCP,
-				AppProtocol: ptr.To("tcp"),
-			},
-			{
-				Name:        "web-ui",
-				Port:        4040,
-				TargetPort:  intstr.FromInt(4040),
-				Protocol:    corev1.ProtocolTCP,
-				AppProtocol: ptr.To("http"),
-			},
-			{
-				Name:        "spark-connect-server",
-				Port:        sparkConnectServerPort,
-				TargetPort:  intstr.FromInt(sparkConnectServerPort),
-				Protocol:    corev1.ProtocolTCP,
-				AppProtocol: ptr.To("grpc"),
-			},
-		}
-
-		// Set pod label selector on server service.
+		svc.Spec.Ports = mergeServerServicePorts(svc.Spec.Ports)
 		if svc.Spec.Selector == nil {
 			svc.Spec.Selector = map[string]string{}
 		}
@@ -594,6 +564,40 @@ func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.Spark
 	}
 
 	return nil
+}
+
+func mergeServerServicePorts(userPorts []corev1.ServicePort) []corev1.ServicePort {
+	required := util.GetRequiredServerServicePorts()
+	requiredByName := make(map[string]corev1.ServicePort, len(required))
+	for _, p := range required {
+		requiredByName[p.Name] = p
+	}
+
+	merged := make([]corev1.ServicePort, 0, len(userPorts)+len(required))
+	seen := make(map[string]struct{}, len(userPorts))
+	for _, up := range userPorts {
+		if req, ok := requiredByName[up.Name]; ok {
+			// Enforce the wiring invariants while preserving the user's
+			// service-facing port and nodePort.
+			if up.TargetPort == (intstr.IntOrString{}) {
+				up.TargetPort = req.TargetPort
+			}
+			if up.Protocol == "" {
+				up.Protocol = req.Protocol
+			}
+			if up.AppProtocol == nil {
+				up.AppProtocol = req.AppProtocol
+			}
+		}
+		merged = append(merged, up)
+		seen[up.Name] = struct{}{}
+	}
+	for _, req := range required {
+		if _, ok := seen[req.Name]; !ok {
+			merged = append(merged, req)
+		}
+	}
+	return merged
 }
 
 // updateSparkConnectStatus updates the status of the SparkConnect resource.

--- a/internal/controller/sparkconnect/reconciler_test.go
+++ b/internal/controller/sparkconnect/reconciler_test.go
@@ -150,6 +150,73 @@ var _ = Describe("mutateServerService", func() {
 			Expect(svc.Spec.Ports[0].Name).To(Equal("spark-connect-server"))
 		})
 	})
+
+	Context("when the user supplies ports via Server.Service", func() {
+		portNames := func(svc *corev1.Service) []string {
+			names := make([]string, 0, len(svc.Spec.Ports))
+			for _, p := range svc.Spec.Ports {
+				names = append(names, p.Name)
+			}
+			return names
+		}
+
+		It("should preserve a custom port and append all required ports", func() {
+			conn.Spec.Server.Service = &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "custom", Port: 9999},
+					},
+				},
+			}
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: conn.Namespace},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "custom", Port: 9999},
+					},
+				},
+			}
+			err := reconciler.mutateServerService(context.TODO(), conn, svc)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Custom port preserved, all four required ports appended.
+			Expect(svc.Spec.Ports).To(HaveLen(5))
+			Expect(portNames(svc)).To(ContainElements(
+				"custom", "driver-rpc", "blockmanager", "web-ui", "spark-connect-server",
+			))
+		})
+
+		It("should not overwrite a user-defined required port", func() {
+			conn.Spec.Server.Service = &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "web-ui", Port: 8080},
+					},
+				},
+			}
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: conn.Namespace},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "web-ui", Port: 8080},
+					},
+				},
+			}
+			err := reconciler.mutateServerService(context.TODO(), conn, svc)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The user's web-ui port wins; the other three required ports are appended.
+			Expect(svc.Spec.Ports).To(HaveLen(4))
+			Expect(portNames(svc)).To(ContainElements(
+				"driver-rpc", "blockmanager", "web-ui", "spark-connect-server",
+			))
+			for _, p := range svc.Spec.Ports {
+				if p.Name == "web-ui" {
+					Expect(p.Port).To(Equal(int32(8080)))
+				}
+			}
+		})
+	})
 })
 
 var _ = Describe("mutateServerPod", func() {

--- a/internal/webhook/sparkconnect_validator.go
+++ b/internal/webhook/sparkconnect_validator.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -262,7 +264,49 @@ func (v *SparkConnectValidator) validateServerSpec(sc *v1alpha1.SparkConnect) er
 		}
 	}
 
+	if server.Service != nil {
+		if err := validateServerServicePorts(server.Service.Spec.Ports); err != nil {
+			return fmt.Errorf("invalid server.service: %v", err)
+		}
+	}
+
 	return nil
+}
+
+func validateServerServicePorts(ports []corev1.ServicePort) error {
+	requiredByName := make(map[string]corev1.ServicePort)
+	for _, p := range util.GetRequiredServerServicePorts() {
+		requiredByName[p.Name] = p
+	}
+	for _, up := range ports {
+		req, ok := requiredByName[up.Name]
+		if !ok {
+			continue
+		}
+		if !IsCompatibleServerServicePort(up, req) {
+			return fmt.Errorf(
+				"service port %q conflicts with the required Spark Connect server port (required targetPort %q, protocol %q)",
+				up.Name, req.TargetPort.String(), req.Protocol,
+			)
+		}
+	}
+	return nil
+}
+
+// IsCompatibleServerServicePort reports whether a user-supplied service port is
+// compatible with a required Spark Connect server port of the same name. A user
+// port is compatible when it leaves the wiring fields (protocol and targetPort)
+// unset, or sets them to the required values. The service-facing port, nodePort
+// and appProtocol may be customized freely; the reconciler fills in any unset
+// wiring fields.
+func IsCompatibleServerServicePort(userPort, requiredPort corev1.ServicePort) bool {
+	if userPort.Protocol != "" && userPort.Protocol != requiredPort.Protocol {
+		return false
+	}
+	if userPort.TargetPort != (intstr.IntOrString{}) && userPort.TargetPort != requiredPort.TargetPort {
+		return false
+	}
+	return true
 }
 
 // validateExecutorSpec validates the Executor specification.

--- a/internal/webhook/sparkconnect_validator_test.go
+++ b/internal/webhook/sparkconnect_validator_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
@@ -67,6 +68,69 @@ func TestSparkConnectValidatorValidateCreate_ImageRequired(t *testing.T) {
 
 	if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "image must be specified") {
 		t.Fatalf("expected image validation error, got %v", err)
+	}
+}
+
+func TestSparkConnectValidatorValidateCreate_ServerServicePorts(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	tests := []struct {
+		name      string
+		ports     []corev1.ServicePort
+		wantError bool
+	}{
+		{
+			name:      "no service ports",
+			ports:     nil,
+			wantError: false,
+		},
+		{
+			name:      "custom non-required port",
+			ports:     []corev1.ServicePort{{Name: "custom", Port: 9999}},
+			wantError: false,
+		},
+		{
+			name:      "required port with only a custom service-facing port",
+			ports:     []corev1.ServicePort{{Name: "web-ui", Port: 8080}},
+			wantError: false,
+		},
+		{
+			name:      "required port with matching targetPort",
+			ports:     []corev1.ServicePort{{Name: "web-ui", Port: 8080, TargetPort: intstr.FromInt32(4040)}},
+			wantError: false,
+		},
+		{
+			name:      "required port with conflicting targetPort",
+			ports:     []corev1.ServicePort{{Name: "web-ui", Port: 8080, TargetPort: intstr.FromInt32(9090)}},
+			wantError: true,
+		},
+		{
+			name:      "required port with conflicting protocol",
+			ports:     []corev1.ServicePort{{Name: "spark-connect-server", Protocol: corev1.ProtocolUDP}},
+			wantError: true,
+		},
+		{
+			name:      "driver-rpc with conflicting targetPort",
+			ports:     []corev1.ServicePort{{Name: "driver-rpc", TargetPort: intstr.FromInt32(1234)}},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newSparkConnect()
+			sc.Spec.Server.Service = &corev1.Service{
+				Spec: corev1.ServiceSpec{Ports: tt.ports},
+			}
+			_, err := validator.ValidateCreate(context.Background(), sc)
+			if tt.wantError {
+				if err == nil || !strings.Contains(err.Error(), "invalid server.service") {
+					t.Fatalf("expected server.service conflict error, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected success, got %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/common/spark.go
+++ b/pkg/common/spark.go
@@ -395,3 +395,27 @@ const (
 	// form the path to the file referred to by HADOOP_TOKEN_FILE_LOCATION.
 	HadoopDelegationTokenFileName = "hadoop.token"
 )
+
+// Spark Connect server service ports. These are the single source of truth for the
+// ports the Spark Connect server binds to and that its Service must expose.
+const (
+	// SparkConnectServerPortName is the name of the Spark Connect gRPC server port.
+	SparkConnectServerPortName = "spark-connect-server"
+	// SparkConnectServerPort is the default port the Spark Connect gRPC server binds to.
+	SparkConnectServerPort int32 = 15002
+
+	// SparkConnectDriverRPCPortName is the name of the driver RPC port.
+	SparkConnectDriverRPCPortName = "driver-rpc"
+	// SparkConnectDriverRPCPort is the port the driver RPC endpoint binds to (spark.driver.port).
+	SparkConnectDriverRPCPort int32 = 7078
+
+	// SparkConnectBlockManagerPortName is the name of the block manager port.
+	SparkConnectBlockManagerPortName = "blockmanager"
+	// SparkConnectBlockManagerPort is the port the block manager binds to (spark.driver.blockManager.port).
+	SparkConnectBlockManagerPort int32 = 7079
+
+	// SparkConnectWebUIPortName is the name of the Spark web UI port.
+	SparkConnectWebUIPortName = "web-ui"
+	// SparkConnectWebUIPort is the default Spark web UI port.
+	SparkConnectWebUIPort int32 = 4040
+)

--- a/pkg/util/sparkconnect.go
+++ b/pkg/util/sparkconnect.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+// GetRequiredServerServicePorts returns the service ports that the Spark Connect
+// server must expose in order to function.
+func GetRequiredServerServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Name:        common.SparkConnectBlockManagerPortName,
+			Port:        common.SparkConnectBlockManagerPort,
+			TargetPort:  intstr.FromInt32(common.SparkConnectBlockManagerPort),
+			Protocol:    corev1.ProtocolTCP,
+			AppProtocol: ptr.To("tcp"),
+		},
+		{
+			Name:        common.SparkConnectDriverRPCPortName,
+			Port:        common.SparkConnectDriverRPCPort,
+			TargetPort:  intstr.FromInt32(common.SparkConnectDriverRPCPort),
+			Protocol:    corev1.ProtocolTCP,
+			AppProtocol: ptr.To("tcp"),
+		},
+		{
+			Name:        common.SparkConnectServerPortName,
+			Port:        common.SparkConnectServerPort,
+			TargetPort:  intstr.FromInt32(common.SparkConnectServerPort),
+			Protocol:    corev1.ProtocolTCP,
+			AppProtocol: ptr.To("grpc"),
+		},
+		{
+			Name:        common.SparkConnectWebUIPortName,
+			Port:        common.SparkConnectWebUIPort,
+			TargetPort:  intstr.FromInt32(common.SparkConnectWebUIPort),
+			Protocol:    corev1.ProtocolTCP,
+			AppProtocol: ptr.To("http"),
+		},
+	}
+}


### PR DESCRIPTION
`mutateServerService` overwrote the entire `Spec.Ports` slice on creation,
  discarding ports supplied via the `Server.Service` override.

It now merges instead: user-supplied ports are kept, and any missing required
  ports are appended by name. Existing Services are left untouched.
## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
