### PR TITLE
feat(chart): make Helm hook Job resources configurable

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -87,6 +87,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | hook.image.registry | string | `"ghcr.io"` | Image registry. |
 | hook.image.repository | string | `"kubeflow/spark-operator/kubectl"` | Image repository. |
 | hook.image.tag | string | If not set, the chart appVersion will be used. | Image tag. |
+| hook.resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Pod resource requests and limits for the Helm hook Job container. |
 | hook.nodeSelector | object | `{}` | Node selector for the Helm hook Job. |
 | hook.affinity | object | `{}` | Affinity for the Helm hook Job. |
 | hook.tolerations | list | `[]` | List of node taints to tolerate for the Helm hook Job. |

--- a/charts/spark-operator-chart/templates/hook/job.yaml
+++ b/charts/spark-operator-chart/templates/hook/job.yaml
@@ -51,13 +51,10 @@ spec:
         - --force-conflicts
         - -f
         - /etc/spark-operator/crds
+        {{- with .Values.hook.resources }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 100m
-            memory: 64Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
           privileged: false

--- a/charts/spark-operator-chart/tests/hook/job_test.yaml
+++ b/charts/spark-operator-chart/tests/hook/job_test.yaml
@@ -66,6 +66,43 @@ tests:
       path: spec.template.spec.containers[*].imagePullPolicy
       value: Always
 
+- it: Should use the default resources
+  set:
+    hook:
+      upgradeCrd: true
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[?(@.name=="spark-operator-hook")].resources
+        value:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+
+- it: Should add resources if `hook.resources` is set
+  set:
+    hook:
+      upgradeCrd: true
+      resources:
+        requests:
+          cpu: 200m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[?(@.name=="spark-operator-hook")].resources
+        value:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
 - it: Should add nodeSelector if `hook.nodeSelector` is set
   set:
     hook:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -55,6 +55,15 @@ hook:
     # -- Image tag.
     # @default -- If not set, the chart appVersion will be used.
     tag: ""
+  # -- Pod resource requests and limits for the Helm hook Job container.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
   # -- Node selector for the Helm hook Job.
   nodeSelector: {}
 


### PR DESCRIPTION
## What this does

Makes the resource requests/limits of the CRD-upgrade hook Job configurable through a new `hook.resources` value.

## Why

We run the operator on OpenShift and, for compliance reasons, have to build our own hook image with the OpenShift client baked in. That `oc`-client simply doesn't fit into the 64Mi memory limit the chart currently hardcodes in `templates/hook/job.yaml`, so the hook pod gets OOM-killed and the install/upgrade fails. There's currently no way to bump that limit from values.

I went with the same approach already used for `controller.resources` and `webhook.resources` so it feels consistent with the rest of the chart. The default for `hook.resources` keeps the existing 100m/64Mi requests and limits, so nothing changes for anyone who doesn't touch it.

## Changes

- `templates/hook/job.yaml` – render the hook container resources from `.Values.hook.resources`
- `values.yaml` – add `hook.resources`, defaulting to the previous hardcoded values
- `README.md` – regenerated with `helm-docs`
- `tests/hook/job_test.yaml` – tests for the default and an overridden value

`make helm-unittest` is green.