### PR TITLE
fix(webhook): enforce ResourceQuota using Status.Hard instead of Spec…

### DIFF
--- a/internal/webhook/resourcequota.go
+++ b/internal/webhook/resourcequota.go
@@ -251,7 +251,7 @@ func validateResourceQuota(resourceList corev1.ResourceList, resourceQuota corev
 			continue
 		}
 		quantity.Add(resourceQuota.Status.Used[key])
-		if quantity.Cmp(resourceQuota.Spec.Hard[key]) > 0 {
+		if quantity.Cmp(resourceQuota.Status.Hard[key]) > 0 {
 			return false
 		}
 	}

--- a/internal/webhook/resourcequota_test.go
+++ b/internal/webhook/resourcequota_test.go
@@ -18,6 +18,10 @@ package webhook
 
 import (
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func assertMemory(memoryString string, expectedBytes int64, t *testing.T) {
@@ -39,3 +43,70 @@ func TestJavaMemoryString(t *testing.T) {
 	assertMemory("10TB", 10*1024*1024*1024*1024, t)
 	assertMemory("10PB", 10*1024*1024*1024*1024*1024, t)
 }
+
+// TestValidateResourceQuota_SpecHardDivergence is a regression test that
+// verifies validateResourceQuota enforces the limit from Status.Hard (the
+// authoritative, controller-reconciled value) rather than Spec.Hard (the
+// desired limit written by the administrator).
+//
+// Kubernetes' own ResourceQuota admission controller always checks
+// Status.Used + request ≤ Status.Hard. The spark-operator webhook must mirror
+// that behaviour, because Status.Hard is what the quota controller actually
+// enforces and tracks Status.Used against.
+//
+// In steady state Status.Hard == Spec.Hard, so the bug is normally invisible.
+// It surfaces when the two fields diverge, for example immediately after a
+// quota spec update before the quota controller has reconciled the status.
+func TestValidateResourceQuota_SpecHardDivergence(t *testing.T) {
+	// Construct a ResourceQuota where Spec.Hard ≠ Status.Hard.
+	//
+	// Scenario: an administrator recently raised the CPU limit in Spec to 100,
+	// but the quota controller has not yet reconciled Status.Hard, which still
+	// reflects the old enforced limit of 4.
+	//
+	//   Status.Hard[cpu] = 4   ← what Kubernetes actually enforces
+	//   Status.Used[cpu] = 0
+	//   Spec.Hard[cpu]   = 100 ← desired new limit, not yet enforced
+	//
+	// A request for 5 CPU cores must be REJECTED, because 0 + 5 > Status.Hard(4).
+	// The buggy implementation compares against Spec.Hard(100) and would ALLOW it.
+	quota := corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "diverged-quota",
+			Namespace: "default",
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				// Spec says 100 CPUs — not yet enforced.
+				corev1.ResourceCPU: resource.MustParse("100"),
+			},
+		},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{
+				// Status says 4 CPUs — what the quota controller actually enforces.
+				corev1.ResourceCPU: resource.MustParse("4"),
+			},
+			Used: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("0"),
+			},
+		},
+	}
+
+	// Request 5 CPUs: exceeds Status.Hard(4) but within Spec.Hard(100).
+	request := corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("5"),
+	}
+
+	// validateResourceQuota must return false (reject), because the request
+	// exceeds the enforced Status.Hard limit.
+	//
+	// On the BUGGY upstream code this returns true (allow), because the
+	// comparison is done against Spec.Hard(100) instead of Status.Hard(4).
+	if got := validateResourceQuota(request, quota); got != false {
+		t.Errorf(
+			"validateResourceQuota incorrectly returned %v (allow) for a request that exceeds the status hard limit",
+			got,
+		)
+	}
+}
+


### PR DESCRIPTION
While reviewing the quota validation logic, I noticed that `validateResourceQuota` checks whether a resource exists in `Status.Hard` but performs the final comparison against `Spec.Hard`.

This change makes the validation consistent by using `Status.Hard` for both the lookup and the comparison. A regression test has also been added to cover the case where `Spec.Hard` and `Status.Hard` contain different values.

**Proposed changes:**

* Update `validateResourceQuota` to compare resource usage against `resourceQuota.Status.Hard`.
* Add a regression test (`TestValidateResourceQuota_SpecHardDivergence`) covering divergent `Spec.Hard` and `Status.Hard` values.

## Change Category

Bug fix (non-breaking change)
This change updates the resource quota validation logic to consistently use Status.Hard when checking resource limits and adds a regression test to verify the behavior when Spec.Hard and Status.Hard differ.

### Rationale

The function already uses `Status.Hard` to determine whether a resource is tracked. Using the same field for the limit comparison keeps the validation logic consistent and avoids mixing two different quota fields during the same validation.

## Checklist

[ ] I have conducted a self-review of my own code.
[ ] I have updated documentation accordingly.
[ ] I have added tests that prove my changes are effective.
 [ ] Existing unit tests pass locally with my changes.

### Additional Notes

The regression test covers the scenario where `Spec.Hard` and `Status.Hard` differ. Running the full webhook test suite locally requires the Kubernetes envtest binaries, which are not available in my current environment.
