### PR TITLE
Scope codegen paths to workload-operator packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,15 @@ print-%: ; @echo $*=$($*)
 
 ##@ Development
 
+CONTROLLER_GEN_PATHS := ./api/...;./internal/...
+
 .PHONY: manifests
 manifests: controller-gen ## Generate CustomResourceDefinition, RBAC and WebhookConfiguration manifests.
-	$(CONTROLLER_GEN) crd:generateEmbeddedObjectMeta=true rbac:roleName=spark-operator-controller webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:generateEmbeddedObjectMeta=true rbac:roleName=spark-operator-controller webhook paths="$(CONTROLLER_GEN_PATHS)" output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen manifests ## Generate Go code and Python APIs.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="$(CONTROLLER_GEN_PATHS)"
 	$(MAKE) python-api
 
 .PHONY: update-crd

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -35,6 +35,7 @@ kube::codegen::gen_register \
 # Generate client code: client, lister, informer in client-go directory
 kube::codegen::gen_client \
   --with-watch \
+  --one-input-api api \
   --output-dir "${SCRIPT_ROOT}/pkg/client" \
   --output-pkg "${SPARK_OPERATOR_PKG}/pkg/client" \
   --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -30,7 +30,7 @@ source "${CODEGEN_PKG}/kube_codegen.sh"
 # Generate register code
 kube::codegen::gen_register \
   --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
-  "${SCRIPT_ROOT}"
+  "${SCRIPT_ROOT}/api"
 
 # Generate client code: client, lister, informer in client-go directory
 kube::codegen::gen_client \

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,15 +20,13 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-_tmp="${SCRIPT_ROOT}/_tmp"
+_tmp="$(mktemp -d)"
 DIFF_ROOTS=("${SCRIPT_ROOT}/api" "${SCRIPT_ROOT}/pkg")
 
 cleanup() {
   rm -rf "${_tmp}"
 }
 trap "cleanup" EXIT SIGINT
-
-cleanup
 
 for root in "${DIFF_ROOTS[@]}"; do
   rel="${root#"${SCRIPT_ROOT}/"}"

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,9 +20,8 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-DIFFROOT="${SCRIPT_ROOT}/pkg"
-TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
 _tmp="${SCRIPT_ROOT}/_tmp"
+DIFF_ROOTS=("${SCRIPT_ROOT}/api" "${SCRIPT_ROOT}/pkg")
 
 cleanup() {
   rm -rf "${_tmp}"
@@ -31,17 +30,25 @@ trap "cleanup" EXIT SIGINT
 
 cleanup
 
-mkdir -p "${TMP_DIFFROOT}"
-cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
+for root in "${DIFF_ROOTS[@]}"; do
+  rel="${root#"${SCRIPT_ROOT}/"}"
+  mkdir -p "${_tmp}/${rel}"
+  cp -a "${root}"/* "${_tmp}/${rel}"
+done
 
 "${SCRIPT_ROOT}/hack/update-codegen.sh"
-echo "diffing ${DIFFROOT} against freshly generated codegen"
+
 ret=0
-diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
-cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
+for root in "${DIFF_ROOTS[@]}"; do
+  rel="${root#"${SCRIPT_ROOT}/"}"
+  echo "diffing ${root} against freshly generated codegen"
+  diff -Naupr "${root}" "${_tmp}/${rel}" || ret=$?
+  cp -a "${_tmp}/${rel}"/* "${root}"
+done
+
 if [[ $ret -eq 0 ]]; then
-  echo "${DIFFROOT} up to date."
+  echo "codegen up to date."
 else
-  echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"
+  echo "codegen is out of date. Please run hack/update-codegen.sh"
   exit 1
 fi


### PR DESCRIPTION
## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

Fixes #3022  `controller-gen paths="./..."` and `gen_register "${SCRIPT_ROOT}"` scan the entire repository tree. When nested Go modules are added under the repo root, codegen picks up their types, produces stray CRD/RBAC artifacts under `config/`, and breaks `make verify-codegen`.

**Proposed changes:**

- Add `WORKLOAD_OPERATOR_CODEGEN_PATHS` variable to scope `manifests` and `generate` targets to the four workload-operator package trees (`api`, `cmd`, `internal`, `pkg`)
- Scope `gen_register` in `hack/update-codegen.sh` to `api/` instead of the entire repo root

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

No functional change for the current repo layout. This is a forward-compatibility guard for monorepo-style module additions — it ensures `controller-gen` and `gen_register` only process the workload operator's own packages and don't accidentally scan into sibling Go modules that may be added at the repo root.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.