### PR TITLE
fix(chart): grant webhook leader election event permissions

### DIFF
--- a/charts/spark-operator-chart/templates/webhook/rbac.yaml
+++ b/charts/spark-operator-chart/templates/webhook/rbac.yaml
@@ -84,6 +84,16 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
+{{- if .Values.webhook.leaderElection.enable }}
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/spark-operator-chart/tests/webhook/rbac_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/rbac_test.yaml
@@ -85,6 +85,17 @@ tests:
           kind: Role
           name: spark-operator-webhook
           namespace: spark-operator
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - events
+            verbs:
+              - create
+              - update
+              - patch
 
   - it: Should create role and rolebinding for webhook in release namespace
     documentIndex: 3
@@ -107,6 +118,57 @@ tests:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
             name: spark-operator-webhook
+
+  - it: Should not grant events permissions if `webhook.leaderElection.enable` is set to `false`
+    set:
+      webhook:
+        leaderElection:
+          enable: false
+    documentIndex: 2
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - events
+            verbs:
+              - create
+              - update
+              - patch
+
+  - it: Should grant events permissions and include webhook policyRules when release namespace is in `spark.jobNamespaces`
+    set:
+      spark:
+        jobNamespaces:
+          - spark-operator
+      webhook:
+        leaderElection:
+          enable: true
+    documentIndex: 2
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - events
+            verbs:
+              - create
+              - update
+              - patch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - list
+              - watch
 
   - it: Should create roles and rolebindings for webhook in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
     set:

--- a/config/webhook/role.yaml
+++ b/config/webhook/role.yaml
@@ -11,6 +11,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - create

--- a/test/kustomize/kustomize_build_test.go
+++ b/test/kustomize/kustomize_build_test.go
@@ -235,8 +235,8 @@ func TestKustomizeBuild(t *testing.T) {
 
 		assert.True(t, rulesHaveResource(role.Rules, "secrets"),
 			"webhook Role should have 'secrets'")
-		assert.False(t, rulesHaveResource(role.Rules, "events"),
-			"webhook Role should NOT have 'events' (events are in ClusterRole for Helm parity)")
+		assert.True(t, rulesHaveResource(role.Rules, "events"),
+			"webhook Role should have 'events' for leader election event recording")
 		assert.True(t, rulesHaveResourceName(role.Rules, "spark-operator-webhook-certs"),
 			"webhook Role should scope secret to 'spark-operator-webhook-certs'")
 		assert.True(t, rulesHaveResourceName(role.Rules, "spark-operator-webhook-lock"),


### PR DESCRIPTION
## Purpose of this PR

Fixes #3024.

Add `events` create/update/patch to the webhook Role when leader election is enabled.
Keep the kustomize webhook Role in sync with the default deployment.
Add Helm tests for enabled and disabled leader election.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The chart enables webhook leader election by default. `client-go` records `LeaderElection` events when a pod acquires or releases the lease, so the missing `events` verbs cause RBAC errors in the normal startup path. This is easy to hit, even with 1 replica, since the first lease acquire records an event too. No weird quota edge here, just a plain default path bug, pretty noisy in logs.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

Repro:
1. Install the chart with `webhook.leaderElection.enable=true`.
2. Keep the release namespace out of `spark.jobNamespaces`.
3. Start the webhook and check logs.
4. Before this fix you get `events is forbidden ... cannot create resource "events"`.
