### PR TITLE
test(e2e): add ScheduledSparkApplication workload e2e test

### DIFF
--- a/test/e2e/scheduledsparkapplication_test.go
+++ b/test/e2e/scheduledsparkapplication_test.go
@@ -1,0 +1,152 @@
+package e2e_test
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+)
+
+var _ = Describe("Example ScheduledSparkApplication", func() {
+	Context("spark-pi-scheduled", func() {
+		ctx := context.Background()
+		path := os.Getenv("SCHEDULED_APP_YAML")
+		if path == "" {
+			path = filepath.Join("..", "..", "examples", "spark-pi-scheduled.yaml")
+		}
+		var scheduledApp *v1beta2.ScheduledSparkApplication
+
+		BeforeEach(func() {
+			By("Parsing ScheduledSparkApplication from file")
+			scheduledApp = &v1beta2.ScheduledSparkApplication{}
+			file, err := os.Open(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).NotTo(BeNil())
+			defer func() { Expect(file.Close()).To(Succeed()) }()
+
+			decoder := yaml.NewYAMLOrJSONDecoder(file, 100)
+			Expect(decoder).NotTo(BeNil())
+			Expect(decoder.Decode(scheduledApp)).NotTo(HaveOccurred())
+
+			// Use GenerateName so each spec gets a unique CR name,
+			// avoiding AlreadyExists when CLEANUP=false skips deletion.
+			scheduledApp.GenerateName = scheduledApp.Name + "-"
+			scheduledApp.Name = ""
+
+			// Override schedule to fire quickly for testing.
+			scheduledApp.Spec.Schedule = "@every 1m"
+
+			By("Creating ScheduledSparkApplication")
+			Expect(k8sClient.Create(ctx, scheduledApp)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if strings.EqualFold(os.Getenv("CLEANUP"), "false") && CurrentSpecReport().Failed() {
+				return
+			}
+
+			key := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: scheduledApp.Name}
+			if err := k8sClient.Get(ctx, key, scheduledApp); err == nil {
+				By("Deleting ScheduledSparkApplication")
+				Expect(k8sClient.Delete(ctx, scheduledApp)).To(Succeed())
+			}
+
+			By("Verifying child SparkApplications are cascade-deleted via owner references")
+			Eventually(func(g Gomega) {
+				appList := &v1beta2.SparkApplicationList{}
+				g.Expect(k8sClient.List(ctx, appList,
+					client.InNamespace(scheduledApp.Namespace),
+					client.MatchingLabels{common.LabelScheduledSparkAppName: scheduledApp.Name},
+				)).To(Succeed())
+				g.Expect(appList.Items).To(BeEmpty())
+			}).WithTimeout(WaitTimeout).WithPolling(PollInterval).Should(Succeed())
+		})
+
+		It("Should reach Scheduled state and populate NextRun", func() {
+			key := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: scheduledApp.Name}
+
+			By("Waiting for ScheduledSparkApplication to reach Scheduled state")
+			Eventually(func(g Gomega) {
+				app := &v1beta2.ScheduledSparkApplication{}
+				g.Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+				g.Expect(app.Status.ScheduleState).To(Equal(v1beta2.ScheduleStateScheduled))
+				g.Expect(app.Status.NextRun.IsZero()).To(BeFalse())
+			}).WithTimeout(WaitTimeout).WithPolling(PollInterval).Should(Succeed())
+		})
+
+		It("Should spawn a child SparkApplication that completes successfully", func() {
+			key := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: scheduledApp.Name}
+
+			By("Waiting for a child SparkApplication to be created")
+			var childName string
+			Eventually(func(g Gomega) {
+				app := &v1beta2.ScheduledSparkApplication{}
+				g.Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+				g.Expect(app.Status.LastRunName).NotTo(BeEmpty())
+				childName = app.Status.LastRunName
+			}).WithTimeout(2 * time.Minute).WithPolling(PollInterval).Should(Succeed())
+
+			By("Verifying the child SparkApplication resource exists")
+			childKey := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: childName}
+			childApp := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, childKey, childApp)).To(Succeed())
+
+			By("Verifying the child has the scheduled app label")
+			Expect(childApp.Labels).To(HaveKeyWithValue(common.LabelScheduledSparkAppName, scheduledApp.Name))
+
+			By("Verifying the child has an owner reference to the scheduled app")
+			Expect(childApp.OwnerReferences).NotTo(BeEmpty())
+			found := false
+			for _, ref := range childApp.OwnerReferences {
+				if ref.Name == scheduledApp.Name && ref.Kind == "ScheduledSparkApplication" {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue())
+
+			By("Waiting for the child SparkApplication to complete")
+			Expect(waitForSparkApplicationCompleted(ctx, childKey)).NotTo(HaveOccurred())
+
+			By("Verifying LastRun is set")
+			app := &v1beta2.ScheduledSparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(app.Status.LastRun.IsZero()).To(BeFalse())
+
+			By("Checking driver logs of the child SparkApplication")
+			driverPodName := util.GetDriverPodName(childApp)
+			logStream, err := clientset.CoreV1().Pods(scheduledApp.Namespace).GetLogs(driverPodName, &corev1.PodLogOptions{
+				LimitBytes: ptr.To(int64(1 << 20)),
+			}).Stream(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { Expect(logStream.Close()).To(Succeed()) }()
+			scanner := bufio.NewScanner(io.LimitReader(logStream, 1<<20))
+			foundPi := false
+			for scanner.Scan() {
+				if strings.Contains(scanner.Text(), "Pi is roughly 3") {
+					foundPi = true
+					break
+				}
+			}
+			Expect(scanner.Err()).NotTo(HaveOccurred())
+			Expect(foundPi).To(BeTrue(), "expected driver logs to contain 'Pi is roughly 3'")
+		})
+	})
+
+})

--- a/test/e2e/scheduledsparkapplication_test.go
+++ b/test/e2e/scheduledsparkapplication_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -160,7 +161,7 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 			secondChildApp := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, secondChildKey, secondChildApp)).To(Succeed())
 			actualInterval := secondChildApp.CreationTimestamp.Sub(childApp.CreationTimestamp.Time)
-			Expect(actualInterval).To(BeNumerically(">=", expectedInterval - 2*time.Second)),
+			Expect(actualInterval).To(BeNumerically(">=", expectedInterval-2*time.Second),
 				"second run started before the schedule interval elapsed")
 
 			By("Waiting for the second child SparkApplication to complete")

--- a/test/e2e/scheduledsparkapplication_test.go
+++ b/test/e2e/scheduledsparkapplication_test.go
@@ -1,13 +1,26 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e_test
 
 import (
-	"bufio"
 	"context"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
@@ -26,10 +38,7 @@ import (
 var _ = Describe("Example ScheduledSparkApplication", func() {
 	Context("spark-pi-scheduled", func() {
 		ctx := context.Background()
-		path := os.Getenv("SCHEDULED_APP_YAML")
-		if path == "" {
-			path = filepath.Join("..", "..", "examples", "spark-pi-scheduled.yaml")
-		}
+		path := filepath.Join("..", "..", "examples", "spark-pi-scheduled.yaml")
 		var scheduledApp *v1beta2.ScheduledSparkApplication
 
 		BeforeEach(func() {
@@ -45,7 +54,7 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 			Expect(decoder.Decode(scheduledApp)).NotTo(HaveOccurred())
 
 			// Use GenerateName so each spec gets a unique CR name,
-			// avoiding AlreadyExists when CLEANUP=false skips deletion.
+			// preventing collisions if a prior AfterEach fails to delete.
 			scheduledApp.GenerateName = scheduledApp.Name + "-"
 			scheduledApp.Name = ""
 
@@ -57,10 +66,6 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 		})
 
 		AfterEach(func() {
-			if strings.EqualFold(os.Getenv("CLEANUP"), "false") && CurrentSpecReport().Failed() {
-				return
-			}
-
 			key := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: scheduledApp.Name}
 			if err := k8sClient.Get(ctx, key, scheduledApp); err == nil {
 				By("Deleting ScheduledSparkApplication")
@@ -100,7 +105,7 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 				g.Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
 				g.Expect(app.Status.LastRunName).NotTo(BeEmpty())
 				childName = app.Status.LastRunName
-			}).WithTimeout(2 * time.Minute).WithPolling(PollInterval).Should(Succeed())
+			}).WithTimeout(WaitTimeout).WithPolling(PollInterval).Should(Succeed())
 
 			By("Verifying the child SparkApplication resource exists")
 			childKey := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: childName}
@@ -131,21 +136,10 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 
 			By("Checking driver logs of the child SparkApplication")
 			driverPodName := util.GetDriverPodName(childApp)
-			logStream, err := clientset.CoreV1().Pods(scheduledApp.Namespace).GetLogs(driverPodName, &corev1.PodLogOptions{
-				LimitBytes: ptr.To(int64(1 << 20)),
-			}).Stream(ctx)
+			bytes, err := clientset.CoreV1().Pods(scheduledApp.Namespace).GetLogs(driverPodName, &corev1.PodLogOptions{}).Do(ctx).Raw()
 			Expect(err).NotTo(HaveOccurred())
-			defer func() { Expect(logStream.Close()).To(Succeed()) }()
-			scanner := bufio.NewScanner(io.LimitReader(logStream, 1<<20))
-			foundPi := false
-			for scanner.Scan() {
-				if strings.Contains(scanner.Text(), "Pi is roughly 3") {
-					foundPi = true
-					break
-				}
-			}
-			Expect(scanner.Err()).NotTo(HaveOccurred())
-			Expect(foundPi).To(BeTrue(), "expected driver logs to contain 'Pi is roughly 3'")
+			Expect(bytes).NotTo(BeEmpty())
+			Expect(strings.Contains(string(bytes), "Pi is roughly 3")).To(BeTrue())
 		})
 	})
 

--- a/test/e2e/scheduledsparkapplication_test.go
+++ b/test/e2e/scheduledsparkapplication_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/robfig/cron/v3"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -140,6 +141,30 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bytes).NotTo(BeEmpty())
 			Expect(strings.Contains(string(bytes), "Pi is roughly 3")).To(BeTrue())
+
+			By("Waiting for a second scheduled run to fire at the expected interval")
+			schedule, err := cron.ParseStandard(scheduledApp.Spec.Schedule)
+			Expect(err).NotTo(HaveOccurred())
+			expectedInterval := schedule.Next(childApp.CreationTimestamp.Time).Sub(childApp.CreationTimestamp.Time)
+
+			var secondChildName string
+			Eventually(func(g Gomega) {
+				app := &v1beta2.ScheduledSparkApplication{}
+				g.Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+				g.Expect(app.Status.LastRunName).NotTo(Equal(childName))
+				secondChildName = app.Status.LastRunName
+			}).WithTimeout(WaitTimeout).WithPolling(PollInterval).Should(Succeed())
+
+			By("Verifying the second run starts at correct interval after the first run")
+			secondChildKey := types.NamespacedName{Namespace: scheduledApp.Namespace, Name: secondChildName}
+			secondChildApp := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, secondChildKey, secondChildApp)).To(Succeed())
+			actualInterval := secondChildApp.CreationTimestamp.Sub(childApp.CreationTimestamp.Time)
+			Expect(actualInterval).To(BeNumerically(">=", expectedInterval),
+				"second run started before the schedule interval elapsed")
+
+			By("Waiting for the second child SparkApplication to complete")
+			Expect(waitForSparkApplicationCompleted(ctx, secondChildKey)).NotTo(HaveOccurred())
 		})
 	})
 

--- a/test/e2e/scheduledsparkapplication_test.go
+++ b/test/e2e/scheduledsparkapplication_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Example ScheduledSparkApplication", func() {
 			secondChildApp := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, secondChildKey, secondChildApp)).To(Succeed())
 			actualInterval := secondChildApp.CreationTimestamp.Sub(childApp.CreationTimestamp.Time)
-			Expect(actualInterval).To(BeNumerically(">=", expectedInterval),
+			Expect(actualInterval).To(BeNumerically(">=", expectedInterval - 2*time.Second)),
 				"second run started before the schedule interval elapsed")
 
 			By("Waiting for the second child SparkApplication to complete")


### PR DESCRIPTION
This test adds e2e functionality confirming that a ScheduledSparkApplication actually completes a real run on its configured schedule. It runs a workload for the ScheduledSparkApplication CRD instead of just creating the CRD. It waits for the cron schedule to fire, verifies the spawned child SparkApplication completes, and then checks the driver logs for the expected output.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://spark.kubeflow.org/en/latest/contributor-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Add `test/e2e/scheduledsparkapplication_test.go`, a new e2e test that exercises the full ScheduledSparkApplication scheduling lifecycle

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->
This test adds missing coverage to confirm that a ScheduledSparkApplication produces a completed, correct Spark run on its configured schedule, adding to the existing unit-level coverage of controller logic.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly (N/A)
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
Verified locally: `make e2e-test` passing 19/19, including both specs in this new file.
