### PR TITLE
fix: harden controller-runtime cache against OOMKill vulnerabilities

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -40,6 +40,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -305,6 +306,14 @@ func start() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: operatorscheme.ControllerScheme,
 		Cache:  newCacheOptions(),
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&networkingv1.Ingress{},
+					&extensionsv1beta1.Ingress{},
+				},
+			},
+		},
 		Metrics: metricsserver.Options{
 			BindAddress:   metricsBindAddress,
 			SecureServing: secureMetrics,
@@ -467,6 +476,7 @@ func newCacheOptions() cache.Options {
 	options := cache.Options{
 		Scheme:            operatorscheme.ControllerScheme,
 		DefaultNamespaces: defaultNamespaces,
+		DefaultTransform:  cache.TransformStripManagedFields(),
 		ByObject: map[client.Object]cache.ByObject{
 			&corev1.Namespace{}: {},
 			&corev1.Pod{}: {
@@ -479,8 +489,11 @@ func newCacheOptions() cache.Options {
 					common.LabelCreatedBySparkOperator: "true",
 				}),
 			},
-			&corev1.PersistentVolumeClaim{}:      {},
-			&corev1.Service{}:                    {},
+			&corev1.Service{}: {
+				Label: labels.SelectorFromSet(labels.Set{
+					common.LabelCreatedBySparkOperator: "true",
+				}),
+			},
 			&v1beta2.SparkApplication{}:          {},
 			&v1beta2.ScheduledSparkApplication{}: {},
 			&v1alpha1.SparkConnect{}:             {},

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -308,6 +308,8 @@ func start() {
 		Cache:  newCacheOptions(),
 		Client: client.Options{
 			Cache: &client.CacheOptions{
+				// TODO: If Ingress reconciliation is added, move these to ByObject with a label selector.
+				// Currently write-only (created with OwnerReferences, no Watches/Owns registered).
 				DisableFor: []client.Object{
 					&networkingv1.Ingress{},
 					&extensionsv1beta1.Ingress{},

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -210,13 +210,7 @@ func start() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: operatorscheme.WebhookScheme,
 		Cache:  newCacheOptions(),
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					&corev1.ResourceQuota{},
-				},
-			},
-		},
+		Client: client.Options{},
 		Metrics: metricsserver.Options{
 			BindAddress:   metricsBindAddress,
 			SecureServing: secureMetrics,
@@ -395,6 +389,7 @@ func newCacheOptions() cache.Options {
 				common.LabelLaunchedBySparkOperator: "true",
 			}),
 		},
+		&corev1.ResourceQuota{}:              {},
 		&v1beta2.SparkApplication{}:          {},
 		&v1beta2.ScheduledSparkApplication{}: {},
 		&admissionregistrationv1.MutatingWebhookConfiguration{}: {

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -210,6 +210,13 @@ func start() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: operatorscheme.WebhookScheme,
 		Cache:  newCacheOptions(),
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.ResourceQuota{},
+				},
+			},
+		},
 		Metrics: metricsserver.Options{
 			BindAddress:   metricsBindAddress,
 			SecureServing: secureMetrics,
@@ -402,13 +409,10 @@ func newCacheOptions() cache.Options {
 		},
 	}
 
-	if enableResourceQuotaEnforcement {
-		byObject[&corev1.ResourceQuota{}] = cache.ByObject{}
-	}
-
 	options := cache.Options{
 		Scheme:            operatorscheme.WebhookScheme,
 		DefaultNamespaces: defaultNamespaces,
+		DefaultTransform:  cache.TransformStripManagedFields(),
 		ByObject:          byObject,
 	}
 

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -332,11 +332,14 @@ func (r *Reconciler) createDriverIngressService(
 	serviceLabels map[string]string,
 ) (*SparkService, error) {
 	logger := log.FromContext(ctx)
+	resourceLabels := util.GetResourceLabels(app)
+	resourceLabels[common.LabelCreatedBySparkOperator] = "true"
+
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            serviceName,
 			Namespace:       app.Namespace,
-			Labels:          util.GetResourceLabels(app),
+			Labels:          resourceLabels,
 			OwnerReferences: []metav1.OwnerReference{util.GetOwnerReference(app)},
 		},
 		Spec: corev1.ServiceSpec{
@@ -361,6 +364,7 @@ func (r *Reconciler) createDriverIngressService(
 	if len(serviceLabels) != 0 {
 		service.Labels = serviceLabels
 	}
+	service.Labels[common.LabelCreatedBySparkOperator] = "true"
 
 	if len(serviceAnnotations) != 0 {
 		service.Annotations = serviceAnnotations

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -332,14 +332,11 @@ func (r *Reconciler) createDriverIngressService(
 	serviceLabels map[string]string,
 ) (*SparkService, error) {
 	logger := log.FromContext(ctx)
-	resourceLabels := util.GetResourceLabels(app)
-	resourceLabels[common.LabelCreatedBySparkOperator] = "true"
-
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            serviceName,
 			Namespace:       app.Namespace,
-			Labels:          resourceLabels,
+			Labels:          util.GetResourceLabels(app),
 			OwnerReferences: []metav1.OwnerReference{util.GetOwnerReference(app)},
 		},
 		Spec: corev1.ServiceSpec{
@@ -381,11 +378,26 @@ func (r *Reconciler) createDriverIngressService(
 			if !errors.IsAlreadyExists(err) {
 				return nil, err
 			}
-			// Lost a race — another reconciliation created it; fetch it.
-			if err := r.client.Get(ctx, client.ObjectKeyFromObject(service), existing); err != nil {
+			// Handle upgrade scenario: Service exists in the cluster but is not
+			// visible in the filtered cache because it was created before the
+			// LabelCreatedBySparkOperator label selector was added to the informer.
+			// Use Patch (merge patch) instead of Update because we cannot Get the
+			// object from the filtered cache to obtain its resourceVersion.
+			base := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      service.Name,
+					Namespace: service.Namespace,
+				},
+			}
+			desired := base.DeepCopy()
+			desired.Labels = service.Labels
+			desired.Annotations = service.Annotations
+			desired.OwnerReferences = service.OwnerReferences
+			desired.Spec = service.Spec
+			if err := r.client.Patch(ctx, desired, client.MergeFrom(base)); err != nil {
 				return nil, err
 			}
-			service = existing
+			service = desired
 		}
 		logger.Info("Created service for SparkApplication", "name", service.Name)
 	} else {

--- a/internal/controller/sparkapplication/web_ui_test.go
+++ b/internal/controller/sparkapplication/web_ui_test.go
@@ -296,7 +296,8 @@ func TestCreateWebUIService(t *testing.T) {
 			wantPortName: common.DefaultSparkWebUIPortName,
 			wantType:     corev1.ServiceTypeClusterIP,
 			wantLabels: map[string]string{
-				common.LabelSparkAppName: "ui-default",
+				common.LabelSparkAppName:           "ui-default",
+				common.LabelCreatedBySparkOperator: "true",
 			},
 			wantAnnots: nil,
 		},
@@ -329,7 +330,8 @@ func TestCreateWebUIService(t *testing.T) {
 			wantPortName: "http-spark",
 			wantType:     corev1.ServiceTypeClusterIP,
 			wantLabels: map[string]string{
-				"custom": "label",
+				"custom":                           "label",
+				common.LabelCreatedBySparkOperator: "true",
 			},
 			wantAnnots: map[string]string{"key": "value"},
 		},
@@ -355,7 +357,7 @@ func TestCreateWebUIService(t *testing.T) {
 			if tc.wantLabels != nil {
 				assert.Equal(t, tc.wantLabels, created.Labels)
 			} else {
-				assert.Equal(t, map[string]string{common.LabelSparkAppName: tc.app.Name}, created.Labels)
+				assert.Equal(t, map[string]string{common.LabelSparkAppName: tc.app.Name, common.LabelCreatedBySparkOperator: "true"}, created.Labels)
 			}
 
 			if tc.wantAnnots != nil {

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -587,6 +587,7 @@ func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.Spark
 	for key, val := range GetCommonLabels(conn) {
 		svc.Labels[key] = val
 	}
+	svc.Labels[common.LabelCreatedBySparkOperator] = "true"
 
 	// Set controller owner reference on server service.
 	if err := ctrl.SetControllerReference(conn, svc, r.scheme); err != nil {

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -587,7 +587,6 @@ func (r *Reconciler) mutateServerService(_ context.Context, conn *v1alpha1.Spark
 	for key, val := range GetCommonLabels(conn) {
 		svc.Labels[key] = val
 	}
-	svc.Labels[common.LabelCreatedBySparkOperator] = "true"
 
 	// Set controller owner reference on server service.
 	if err := ctrl.SetControllerReference(conn, svc, r.scheme); err != nil {


### PR DESCRIPTION
## Purpose of this PR

Harden controller-runtime cache against OOMKill by eliminating unfiltered informers that allow standard `edit` users to flood the operator's memory.

Fixes: https://github.com/kubeflow/spark-operator/issues/3028

**Changes:**

- Remove unused `PersistentVolumeClaim` from `ByObject` (no `client.Get/List` or `Watches` for PVCs exist anywhere in the codebase)
- Add label selector to `Service` `ByObject` entry, matching the existing `Pod`/`ConfigMap` pattern, and stamp `LabelCreatedBySparkOperator` on all operator-created Services
- Add `DisableFor` for Ingress types to prevent invisible cluster-wide informers from `client.Get()` calls
- Add `DisableFor` for `ResourceQuota` in webhook — quota validation needs all ResourceQuotas, so cache bypass is correct over label filtering
- Add `DefaultTransform: cache.TransformStripManagedFields()` to both caches

**References:**
- [Protect your Kubernetes Operator from OOMKill](https://developers.redhat.com/articles/2025/06/11/protect-your-kubernetes-operator-oomkill)
- [5 anti-patterns that cause Kubernetes operator vulnerabilities](https://developers.redhat.com/articles/2025/07/03/5-anti-patterns-cause-kubernetes-operator-vulnerabilities)
- Scanner: [eformat/operator-anti-patterns](https://github.com/eformat/operator-anti-patterns)

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.