### PR TITLE
feat: Add preinstalled mode to e2e test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,19 @@ unit-test: setup-envtest ## Run unit tests.
 
 .PHONY: e2e-test
 e2e-test: IMAGE_TAG=local
-e2e-test: envtest kind-load-image kind-load-spark-image ## Run the e2e tests against a Kind k8s instance that is spun up.
+e2e-test: envtest kind-load-image kind-load-spark-image ## Run the e2e tests against a Kind k8s instance. DEPLOY_METHOD: helm (default) or kustomize.
 	@echo "Running e2e tests (deploy_method=$(DEPLOY_METHOD))..."
-	DEPLOY_METHOD=$(DEPLOY_METHOD) IMAGE_TAG=$(IMAGE_TAG) KUBECONFIG=$(KIND_KUBE_CONFIG) go test ./test/e2e/ -v -ginkgo.v -timeout 30m
+	export DEPLOY_METHOD="$(DEPLOY_METHOD)" && \
+	export IMAGE_TAG="$(IMAGE_TAG)" && \
+	export KUBECONFIG="$(KIND_KUBE_CONFIG)" && \
+	go test ./test/e2e/ -v -ginkgo.v -timeout 30m
+
+.PHONY: e2e-test-preinstalled
+e2e-test-preinstalled: envtest ## Run the e2e tests against a preinstalled operator. DEPLOY_METHOD: helm (default) or kustomize.
+	@echo "Running e2e tests against preinstalled operator (deploy_method=$(DEPLOY_METHOD))..."
+	export DEPLOY_METHOD="$(DEPLOY_METHOD)" && \
+	export PREINSTALLED="true" && \
+	go test ./test/e2e/ -v -ginkgo.v -timeout 30m
 
 ##@ Kustomize
 

--- a/test/e2e/namespace_filtering_test.go
+++ b/test/e2e/namespace_filtering_test.go
@@ -144,8 +144,8 @@ var _ = Describe("Namespace Filtering", func() {
 		var testID string
 
 		BeforeEach(func() {
-			if deployMethod == "kustomize" {
-				Skip("Namespace filtering requires Helm deploy with jobNamespaceSelector configuration")
+			if !jobNamespaceSelectorConfigured {
+				Skip("Namespace filtering test requires operator configured with --job-namespace-selector flag")
 			}
 
 			// Generate TRULY unique suffix using current time

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -64,12 +64,18 @@ var _ = Describe("Driver PodDisruptionBudget", func() {
 		var app *v1beta2.SparkApplication
 
 		BeforeEach(func() {
+			if !driverPDBEnabled {
+				Skip("Driver PDB feature not enabled in operator (--enable-driver-pdb=true required)")
+			}
 			app = loadSparkPi("e2e-pdb-on")
 			app.Spec.DriverPodDisruptionBudget = ptr.To(true)
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
 		})
 
 		AfterEach(func() {
+			if app == nil {
+				return
+			}
 			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
 			if err := k8sClient.Get(ctx, key, app); err == nil {
 				_ = k8sClient.Delete(ctx, app)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -36,9 +36,11 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -73,10 +75,26 @@ var (
 	k8sClient client.Client
 	clientset *kubernetes.Clientset
 
-	// deployMethod is read from DEPLOY_METHOD env var; defaults to "helm".
-	deployMethod          string
+	// deployMethod determines webhook names; read from DEPLOY_METHOD env var.
+	// Supported values: "helm" (default), "kustomize"
+	deployMethod string
+	// preinstalled skips operator install/uninstall; read from PREINSTALLED env var.
+	// Set to "true" to skip operator lifecycle management.
+	preinstalled          bool
 	mutatingWebhookName   string
 	validatingWebhookName string
+
+	// driverPDBEnabled tracks whether the operator has driver PDB feature enabled
+	driverPDBEnabled bool
+	// jobNamespaceSelectorConfigured tracks whether the operator has jobNamespaceSelector configured
+	jobNamespaceSelectorConfigured bool
+
+	// operatorNamespace is the namespace where the operator is deployed
+	// Can be overridden via OPERATOR_NAMESPACE env var for preinstalled mode
+	operatorNamespace string
+	// operatorDeploymentName is the name of the controller deployment
+	// Can be overridden via OPERATOR_DEPLOYMENT_NAME env var for preinstalled mode
+	operatorDeploymentName string
 )
 
 func TestSparkOperator(t *testing.T) {
@@ -92,7 +110,30 @@ var _ = BeforeSuite(func() {
 	if deployMethod == "" {
 		deployMethod = "helm"
 	}
-	GinkgoWriter.Printf("Deploy method: %s\n", deployMethod)
+
+	preinstalledStr := strings.ToLower(strings.TrimSpace(os.Getenv("PREINSTALLED")))
+	switch preinstalledStr {
+	case "", "false":
+		preinstalled = false
+	case "true":
+		preinstalled = true
+	default:
+		Fail(fmt.Sprintf("invalid PREINSTALLED value: %q (must be '', 'true', or 'false')", preinstalledStr))
+	}
+
+	// Allow overriding operator namespace and deployment name for preinstalled mode
+	operatorNamespace = os.Getenv("OPERATOR_NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = ReleaseNamespace
+	}
+
+	operatorDeploymentName = os.Getenv("OPERATOR_DEPLOYMENT_NAME")
+	if operatorDeploymentName == "" {
+		operatorDeploymentName = "spark-operator-controller"
+	}
+
+	GinkgoWriter.Printf("Deploy method: %s, Preinstalled: %v, Operator namespace: %s, Deployment name: %s\n",
+		deployMethod, preinstalled, operatorNamespace, operatorDeploymentName)
 
 	switch deployMethod {
 	case "helm":
@@ -139,12 +180,84 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(clientset).NotTo(BeNil())
 
-	switch deployMethod {
-	case "helm":
-		installViaHelm()
-	case "kustomize":
-		installViaKustomize()
+	if !preinstalled {
+		switch deployMethod {
+		case "helm":
+			installViaHelm()
+		case "kustomize":
+			installViaKustomize()
+		}
+	} else {
+		logf.Log.Info("Operator is preinstalled, skipping installation")
+
+		// Check if Spark RBAC already exists based on deployment method
+		// Helm: SA/Role/RoleBinding all named "spark-operator-spark"
+		// Kustomize: SA="spark-operator-spark", Role="spark-role", RoleBinding="spark-role-binding"
+		By("Checking if Spark RBAC already exists")
+
+		var roleName, roleBindingName string
+		if deployMethod == "helm" {
+			roleName = "spark-operator-spark"
+			roleBindingName = "spark-operator-spark"
+		} else {
+			roleName = "spark-role"
+			roleBindingName = "spark-role-binding"
+		}
+
+		// Check each resource and track if ALL are missing
+		allMissing := true
+		sa := &corev1.ServiceAccount{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: "spark-operator-spark", Namespace: "default"}, sa); err == nil {
+			allMissing = false // SA exists
+		}
+
+		role := &rbacv1.Role{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: roleName, Namespace: "default"}, role); err == nil {
+			allMissing = false // Role exists
+		}
+
+		roleBinding := &rbacv1.RoleBinding{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: roleBindingName, Namespace: "default"}, roleBinding); err == nil {
+			allMissing = false // RoleBinding exists
+		}
+
+		if allMissing {
+			Fail(fmt.Sprintf("Spark job RBAC is missing in preinstalled mode.\n"+
+				"The e2e suite requires ServiceAccount, Role, and RoleBinding for Spark applications in the 'default' namespace.\n"+
+				"Please apply RBAC before running tests:\n"+
+				"  kubectl apply -k config/spark-rbac -n default\n"+
+				"Or if using Helm, ensure spark.rbac.create=true (default)"))
+		} else {
+			By(fmt.Sprintf("Spark RBAC exists for %s deployment", deployMethod))
+		}
 	}
+
+	// Detect if driver PDB feature is enabled in the operator
+	By("Detecting operator feature flags")
+	deployment := &appsv1.Deployment{}
+	err = k8sClient.Get(context.TODO(),
+		types.NamespacedName{Name: operatorDeploymentName, Namespace: operatorNamespace},
+		deployment)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to get controller deployment %s/%s: %v\nIn preinstalled mode, set OPERATOR_NAMESPACE and OPERATOR_DEPLOYMENT_NAME to match your deployment",
+			operatorNamespace, operatorDeploymentName, err))
+	}
+
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, arg := range container.Args {
+			if arg == "--enable-driver-pdb=true" || arg == "--enable-driver-pdb" {
+				driverPDBEnabled = true
+			}
+			if strings.HasPrefix(arg, "--namespace-selector=") {
+				jobNamespaceSelectorConfigured = true
+			}
+		}
+	}
+	GinkgoWriter.Printf("Driver PDB feature enabled: %v\n", driverPDBEnabled)
+	GinkgoWriter.Printf("jobNamespaceSelector configured: %v\n", jobNamespaceSelectorConfigured)
 
 	By("Waiting for the webhooks to be ready")
 	mutatingWebhookKey := types.NamespacedName{Name: mutatingWebhookName}
@@ -156,11 +269,15 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	switch deployMethod {
-	case "helm":
-		uninstallViaHelm()
-	case "kustomize":
-		uninstallViaKustomize()
+	if !preinstalled {
+		switch deployMethod {
+		case "helm":
+			uninstallViaHelm()
+		case "kustomize":
+			uninstallViaKustomize()
+		}
+	} else {
+		logf.Log.Info("Operator was preinstalled, skipping uninstallation")
 	}
 
 	By("Tearing down the test environment")


### PR DESCRIPTION
## Summary

Enable e2e tests to run against clusters where the Spark operator is already deployed, without requiring tests to manage operator installation and teardown.

This supports testing workflows on managed Kubernetes clusters (EKS, GKE, RHOAI) where operators are pre-deployed and long-lived.

## Changes

### Core Features

- **PREINSTALLED mode**: Set `PREINSTALLED=true` to skip operator install/uninstall
- **Runtime feature detection**: Test suite detects enabled features by inspecting deployment args
  - Driver PodDisruptionBudget support (`--enable-driver-pdb`)
  - Namespace selector configuration (`--namespace-selector=`)
- **RBAC validation**: Verify Spark job RBAC exists before running tests
- **Configurable deployment location**: Override namespace and deployment name for non-standard installations

### Environment Variables

| Variable | Values | Default | Description |
|----------|--------|---------|-------------|
| `PREINSTALLED` | `true`, `false` | `false` | Skip operator install/uninstall when true |
| `DEPLOY_METHOD` | `helm`, `kustomize` | `helm` | Determines webhook names and RBAC scheme |
| `OPERATOR_NAMESPACE` | any namespace | `spark-operator` | Where to find the operator deployment |
| `OPERATOR_DEPLOYMENT_NAME` | deployment name | `spark-operator-controller` | Controller deployment name |

### Test Behavior

**Feature detection:**
- Tests requiring driver PDB skip when `--enable-driver-pdb` not detected
- Tests requiring namespace filtering skip when `--namespace-selector` not configured
- Suite fails early with clear instructions if Spark job RBAC is missing

**RBAC requirements:**
Preinstalled mode requires complete Spark job RBAC in the `default` namespace:
- ServiceAccount: `spark-operator-spark`
- Role: `spark-operator-spark` (Helm) or `spark-role` (Kustomize)
- RoleBinding: `spark-operator-spark` (Helm) or `spark-role-binding` (Kustomize)

## Usage

### Preinstalled Mode (Managed Clusters)

```bash
# Operator installed via Helm
DEPLOY_METHOD=helm PREINSTALLED=true make e2e-test-preinstalled

# Operator installed via Kustomize
DEPLOY_METHOD=kustomize PREINSTALLED=true make e2e-test-preinstalled

# Custom deployment location
OPERATOR_NAMESPACE=my-namespace \
OPERATOR_DEPLOYMENT_NAME=my-spark-controller \
DEPLOY_METHOD=helm \
PREINSTALLED=true \
make e2e-test-preinstalled
```

### Standard Mode (Unchanged)

```bash
# Default: Helm deployment, manages full lifecycle
make e2e-test

# Kustomize deployment
DEPLOY_METHOD=kustomize make e2e-test
```

## Prerequisites for Preinstalled Mode

1. **Operator deployed and running** in target cluster
2. **Spark job RBAC** exists in `default` namespace:
   ```bash
   # Apply if missing
   kubectl apply -k config/spark-rbac -n default
   
   # Or ensure Helm chart has spark.rbac.create=true (default)
   ```
3. **KUBECONFIG** points to target cluster
4. **DEPLOY_METHOD** matches how operator was deployed

## Benefits

- **Faster iteration**: Deploy operator once, iterate on tests without reinstalling
- **CI/CD flexibility**: Separate operator deployment from test execution
- **Pre-production testing**: Validate against long-running operator instances
- **Managed cluster support**: Test on EKS, GKE, AKS, RHOAI where operators are pre-deployed

## Backward Compatibility

All existing workflows continue to work unchanged:
- `make e2e-test` still manages full operator lifecycle
- `DEPLOY_METHOD=kustomize make e2e-test` still works
- Default behavior is non-preinstalled mode

## Change Category

- [x] Feature (non-breaking change which adds functionality)

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.