### PR TITLE
[release-2.5.2] fix(webhook): add sparkConf key validation (#3043)

### DIFF
--- a/internal/webhook/scheduledsparkapplication_validator.go
+++ b/internal/webhook/scheduledsparkapplication_validator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,12 +67,22 @@ func (v *ScheduledSparkApplicationValidator) ValidateUpdate(ctx context.Context,
 	if !ok {
 		return nil, nil
 	}
+	oldApp, ok := oldObj.(*v1beta2.ScheduledSparkApplication)
+	if !ok {
+		return nil, nil
+	}
 	logger := log.FromContext(ctx)
 	logger.Info("Validating ScheduledSparkApplication update")
 	// Name is immutable in Kubernetes, but validate anyway for safety in case of admission reconcilers
 	if err := v.validateName(newApp.Name); err != nil {
 		return nil, err
 	}
+
+	// Skip validating when spec does not change.
+	if equality.Semantic.DeepEqual(oldApp.Spec, newApp.Spec) {
+		return nil, nil
+	}
+
 	if err := v.validate(newApp); err != nil {
 		return nil, err
 	}
@@ -88,9 +99,8 @@ func (v *ScheduledSparkApplicationValidator) ValidateDelete(ctx context.Context,
 	return nil, nil
 }
 
-func (v *ScheduledSparkApplicationValidator) validate(_ *v1beta2.ScheduledSparkApplication) error {
-	// TODO: implement validate logic
-	return nil
+func (v *ScheduledSparkApplicationValidator) validate(app *v1beta2.ScheduledSparkApplication) error {
+	return validateSparkConf(app.Spec.Template.SparkConf, app.Namespace)
 }
 
 // validateName ensures the ScheduledSparkApplication metadata.name, when combined with suffixes,

--- a/internal/webhook/scheduledsparkapplication_validator_test.go
+++ b/internal/webhook/scheduledsparkapplication_validator_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
 
 func TestScheduledSparkApplicationValidatorValidateCreate(t *testing.T) {
@@ -118,6 +119,46 @@ func TestScheduledSparkApplicationValidatorValidateDelete(t *testing.T) {
 			t.Fatalf("expected no warnings, got %v", warnings)
 		}
 	})
+}
+
+func newScheduledSparkApplication() *v1beta2.ScheduledSparkApplication {
+	return &v1beta2.ScheduledSparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scheduled-app",
+			Namespace: "default",
+		},
+		Spec: v1beta2.ScheduledSparkApplicationSpec{
+			Schedule: "@every 1h",
+			Template: newSparkApplication().Spec,
+		},
+	}
+}
+
+func TestScheduledSparkApplicationValidatorSparkConf_SecurityVectorsRejected(t *testing.T) {
+	validator := NewScheduledSparkApplicationValidator()
+
+	for _, tt := range sparkConfSecurityVectors {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newScheduledSparkApplication()
+			app.Spec.Template.SparkConf = tt.sparkConf
+
+			if _, err := validator.ValidateCreate(context.Background(), app); err == nil {
+				t.Fatalf("expected sparkConf to be rejected, but it was allowed")
+			}
+		})
+	}
+}
+
+func TestScheduledSparkApplicationValidatorSparkConf_UpdateRejected(t *testing.T) {
+	validator := NewScheduledSparkApplicationValidator()
+
+	oldApp := newScheduledSparkApplication()
+	newApp := newScheduledSparkApplication()
+	newApp.Spec.Template.SparkConf = map[string]string{common.SparkMaster: "k8s://https://attacker-cluster:443"}
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err == nil {
+		t.Fatalf("expected sparkConf to be rejected on update, but it was allowed")
+	}
 }
 
 func TestScheduledSparkApplicationValidatorValidateName(t *testing.T) {

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -159,6 +159,10 @@ func (v *SparkApplicationValidator) validateSpec(ctx context.Context, app *v1bet
 		ingressURLFormats[item.IngressURLFormat] = true
 	}
 
+	if err := validateSparkConf(app.Spec.SparkConf, app.Namespace); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -30,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
 
 func TestSparkApplicationValidatorValidateCreate_NodeSelectorConflict(t *testing.T) {
@@ -323,5 +325,139 @@ func newSparkApplication() *v1beta2.SparkApplication {
 				Instances: ptr.To[int32](1),
 			},
 		},
+	}
+}
+
+var sparkConfSecurityVectors = []struct {
+	name      string
+	sparkConf map[string]string
+}{
+	{
+		name:      "driver service account override",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateDriverServiceAccountName: "cluster-admin"},
+	},
+	{
+		name:      "executor service account override",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateExecutorServiceAccountName: "cluster-admin"},
+	},
+	{
+		name:      "submission OAuth token file path",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateOAuthTokenFile: "/var/run/secrets/attacker/token"},
+	},
+	{
+		name:      "submission OAuth token injection",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateOAuthToken: "stolen-token"},
+	},
+	{
+		name:      "driver OAuth token file path",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateDriverOAuthTokenFile: "/var/run/secrets/attacker/token"},
+	},
+	{
+		name:      "driver OAuth token injection",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateDriverOAuthToken: "stolen-token"},
+	},
+	{
+		name:      "executor OAuth token file path",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateExecutorOAuthTokenFile: "/var/run/secrets/attacker/token"},
+	},
+	{
+		name:      "executor OAuth token injection",
+		sparkConf: map[string]string{common.SparkKubernetesAuthenticateExecutorOAuthToken: "stolen-token"},
+	},
+	{
+		name:      "namespace override",
+		sparkConf: map[string]string{common.SparkKubernetesNamespace: "kube-system"},
+	},
+	{
+		name:      "spark.master redirect",
+		sparkConf: map[string]string{common.SparkMaster: "k8s://https://attacker-cluster:443"},
+	},
+	{
+		name:      "spark.kubernetes.driver.master redirect",
+		sparkConf: map[string]string{common.SparkKubernetesDriverMaster: "k8s://https://attacker-cluster:443"},
+	},
+	{
+		name:      "container image override",
+		sparkConf: map[string]string{common.SparkKubernetesContainerImage: "attacker/malicious-image:latest"},
+	},
+	{
+		name:      "driver container image override",
+		sparkConf: map[string]string{common.SparkKubernetesDriverContainerImage: "attacker/malicious-image:latest"},
+	},
+	{
+		name:      "executor container image override",
+		sparkConf: map[string]string{common.SparkKubernetesExecutorContainerImage: "attacker/malicious-image:latest"},
+	},
+}
+
+func TestSparkApplicationValidatorSparkConf_SecurityVectorsRejected(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	for _, tt := range sparkConfSecurityVectors {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newSparkApplication()
+			app.Spec.SparkConf = tt.sparkConf
+
+			if _, err := validator.ValidateCreate(context.Background(), app); err == nil {
+				t.Fatalf("expected sparkConf to be rejected, but it was allowed")
+			}
+		})
+	}
+}
+
+func TestSparkApplicationValidatorSparkConf_UpdateRejected(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	oldApp := newSparkApplication()
+	newApp := newSparkApplication()
+	newApp.Spec.SparkConf = map[string]string{common.SparkMaster: "k8s://https://attacker-cluster:443"}
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err == nil {
+		t.Fatalf("expected sparkConf to be rejected on update, but it was allowed")
+	}
+}
+
+func TestSparkApplicationValidatorSparkConf_TypedError(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	app := newSparkApplication()
+	app.Spec.SparkConf = map[string]string{common.SparkMaster: "k8s://https://attacker-cluster:443"}
+
+	_, err := validator.ValidateCreate(context.Background(), app)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	var denied *SparkConfKeyDeniedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("expected SparkConfKeyDeniedError, got %T", err)
+	}
+	if denied.Key != common.SparkMaster {
+		t.Fatalf("expected key %q, got %q", common.SparkMaster, denied.Key)
+	}
+}
+
+func TestSparkApplicationValidatorSparkConf_BenignKeysPass(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	tests := []struct {
+		name      string
+		sparkConf map[string]string
+	}{
+		{name: "executor memory tuning", sparkConf: map[string]string{"spark.executor.memory": "4g"}},
+		{name: "shuffle partitions tuning", sparkConf: map[string]string{"spark.sql.shuffle.partitions": "200"}},
+		{name: "namespace matching app namespace", sparkConf: map[string]string{common.SparkKubernetesNamespace: "default"}},
+		{name: "arbitrary user-defined key", sparkConf: map[string]string{"spark.myapp.customSetting": "42"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newSparkApplication()
+			app.Spec.SparkConf = tt.sparkConf
+
+			if _, err := validator.ValidateCreate(context.Background(), app); err != nil {
+				t.Fatalf("expected benign sparkConf to be allowed, got error: %v", err)
+			}
+		})
 	}
 }

--- a/internal/webhook/sparkconf_validator.go
+++ b/internal/webhook/sparkconf_validator.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+)
+
+type SparkConfKeyDeniedError struct {
+	Key     string
+	Message string
+}
+
+func (e *SparkConfKeyDeniedError) Error() string {
+	return fmt.Sprintf("sparkConf key %q is not allowed: %s", e.Key, e.Message)
+}
+
+var deniedSparkConfKeys = map[string]string{
+	common.SparkKubernetesAuthenticateDriverServiceAccountName:   "configure the service account via the CRD spec instead",
+	common.SparkKubernetesAuthenticateExecutorServiceAccountName: "configure the service account via the CRD spec instead",
+	common.SparkKubernetesAuthenticateOAuthTokenFile:             "authentication credentials are managed by the operator",
+	common.SparkKubernetesAuthenticateOAuthToken:                 "authentication credentials are managed by the operator",
+	common.SparkKubernetesAuthenticateDriverOAuthTokenFile:       "authentication credentials are managed by the operator",
+	common.SparkKubernetesAuthenticateDriverOAuthToken:           "authentication credentials are managed by the operator",
+	common.SparkKubernetesAuthenticateExecutorOAuthTokenFile:     "authentication credentials are managed by the operator",
+	common.SparkKubernetesAuthenticateExecutorOAuthToken:         "authentication credentials are managed by the operator",
+	common.SparkMaster:                           "this value is managed by the operator",
+	common.SparkKubernetesDriverMaster:           "this value is managed by the operator",
+	common.SparkKubernetesContainerImage:         "use the image field on the CRD instead",
+	common.SparkKubernetesDriverContainerImage:   "use the image field on the CRD instead",
+	common.SparkKubernetesExecutorContainerImage: "use the image field on the CRD instead",
+}
+
+func validateSparkConf(sparkConf map[string]string, namespace string) error {
+	for key, value := range sparkConf {
+		if msg, denied := deniedSparkConfKeys[key]; denied {
+			return &SparkConfKeyDeniedError{Key: key, Message: msg}
+		}
+		if key == common.SparkKubernetesNamespace && value != namespace {
+			return &SparkConfKeyDeniedError{
+				Key:     key,
+				Message: fmt.Sprintf("must equal the application namespace %q, got %q", namespace, value),
+			}
+		}
+	}
+	return nil
+}

--- a/internal/webhook/sparkconnect_validator.go
+++ b/internal/webhook/sparkconnect_validator.go
@@ -161,6 +161,10 @@ func (v *SparkConnectValidator) validateSpec(sc *v1alpha1.SparkConnect) error {
 		return err
 	}
 
+	if err := validateSparkConf(sc.Spec.SparkConf, sc.Namespace); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/webhook/sparkconnect_validator_test.go
+++ b/internal/webhook/sparkconnect_validator_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
 
 func TestSparkConnectValidatorValidateCreate_Success(t *testing.T) {
@@ -359,6 +360,33 @@ func TestValidateMemoryString(t *testing.T) {
 				t.Errorf("validateMemoryString(%q) = error %v, wantError %v, got error: %v", tt.memory, hasError, tt.wantError, err)
 			}
 		})
+	}
+}
+
+func TestSparkConnectValidatorSparkConf_SecurityVectorsRejected(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	for _, tt := range sparkConfSecurityVectors {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newSparkConnect()
+			sc.Spec.SparkConf = tt.sparkConf
+
+			if _, err := validator.ValidateCreate(context.Background(), sc); err == nil {
+				t.Fatalf("expected sparkConf to be rejected, but it was allowed")
+			}
+		})
+	}
+}
+
+func TestSparkConnectValidatorSparkConf_UpdateRejected(t *testing.T) {
+	validator := newTestSparkConnectValidator(t)
+
+	oldSC := newSparkConnect()
+	newSC := newSparkConnect()
+	newSC.Spec.SparkConf = map[string]string{common.SparkMaster: "k8s://https://attacker-cluster:443"}
+
+	if _, err := validator.ValidateUpdate(context.Background(), oldSC, newSC); err == nil {
+		t.Fatalf("expected sparkConf to be rejected on update, but it was allowed")
 	}
 }
 

--- a/pkg/common/spark.go
+++ b/pkg/common/spark.go
@@ -51,9 +51,13 @@ const (
 	SparkUIProxyRedirectURI = "spark.ui.proxyRedirectUri"
 )
 
+// Spark core properties.
+const (
+	SparkMaster = "spark.master"
+)
+
 // Spark on Kubernetes properties.
 const (
-
 	// SparkKubernetesDriverMaster is the Spark configuration key for specifying the Kubernetes master the driver use
 	// to manage executor pods and other Kubernetes resources.
 	SparkKubernetesDriverMaster = "spark.kubernetes.driver.master"
@@ -81,6 +85,24 @@ const (
 
 	// account used by the executor pod.
 	SparkKubernetesAuthenticateExecutorServiceAccountName = "spark.kubernetes.authenticate.executor.serviceAccountName"
+
+	// SparkKubernetesAuthenticateOAuthTokenFile is the configuration property for the submission client's OAuth token file.
+	SparkKubernetesAuthenticateOAuthTokenFile = "spark.kubernetes.authenticate.oauthTokenFile"
+
+	// SparkKubernetesAuthenticateOAuthToken is the configuration property for the submission client's OAuth token.
+	SparkKubernetesAuthenticateOAuthToken = "spark.kubernetes.authenticate.oauthToken"
+
+	// SparkKubernetesAuthenticateDriverOAuthTokenFile is the configuration property for the driver pod's OAuth token file.
+	SparkKubernetesAuthenticateDriverOAuthTokenFile = "spark.kubernetes.authenticate.driver.oauthTokenFile"
+
+	// SparkKubernetesAuthenticateDriverOAuthToken is the configuration property for the driver pod's OAuth token.
+	SparkKubernetesAuthenticateDriverOAuthToken = "spark.kubernetes.authenticate.driver.oauthToken"
+
+	// SparkKubernetesAuthenticateExecutorOAuthTokenFile is the configuration property for the executor pod's OAuth token file.
+	SparkKubernetesAuthenticateExecutorOAuthTokenFile = "spark.kubernetes.authenticate.executor.oauthTokenFile"
+
+	// SparkKubernetesAuthenticateExecutorOAuthToken is the configuration property for the executor pod's OAuth token.
+	SparkKubernetesAuthenticateExecutorOAuthToken = "spark.kubernetes.authenticate.executor.oauthToken"
 
 	// SparkKubernetesDriverLabelPrefix is the Spark configuration key prefix for labels on the driver Pod.
 	SparkKubernetesDriverLabelTemplate = "spark.kubernetes.driver.label.%s"

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	clientretry "k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
@@ -492,6 +493,84 @@ var _ = Describe("Example SparkApplication", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bytes).NotTo(BeEmpty())
 			Expect(strings.Contains(string(bytes), "Pi is roughly 3")).To(BeTrue())
+		})
+	})
+
+	Context("sparkConf-key-authorization", func() {
+		ctx := context.Background()
+		mainFile := "local:///opt/spark/examples/jars/spark-examples.jar"
+
+		It("should reject a SparkApplication with a denied sparkConf key", func() {
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sparkconf-denied-key",
+					Namespace: "default",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Type:                v1beta2.SparkApplicationTypeScala,
+					SparkVersion:        "3.5.0",
+					Mode:                v1beta2.DeployModeCluster,
+					MainApplicationFile: &mainFile,
+					MainClass:           ptr.To("org.apache.spark.examples.SparkPi"),
+					Driver: v1beta2.DriverSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+					},
+					Executor: v1beta2.ExecutorSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+						Instances: ptr.To[int32](1),
+					},
+					SparkConf: map[string]string{
+						common.SparkKubernetesAuthenticateDriverServiceAccountName: "cluster-admin",
+					},
+				},
+			}
+
+			By("Creating SparkApplication with denied sparkConf key")
+			err := k8sClient.Create(ctx, app)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is not allowed"))
+		})
+
+		It("should accept a SparkApplication with safe sparkConf keys via dry-run", func() {
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sparkconf-safe-key",
+					Namespace: "default",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Type:                v1beta2.SparkApplicationTypeScala,
+					SparkVersion:        "3.5.0",
+					Mode:                v1beta2.DeployModeCluster,
+					MainApplicationFile: &mainFile,
+					MainClass:           ptr.To("org.apache.spark.examples.SparkPi"),
+					Driver: v1beta2.DriverSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+					},
+					Executor: v1beta2.ExecutorSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+						Instances: ptr.To[int32](1),
+					},
+					SparkConf: map[string]string{
+						"spark.executor.memory": "4g",
+					},
+				},
+			}
+
+			By("Creating SparkApplication with safe sparkConf via dry-run")
+			err := k8sClient.Create(ctx, app, client.DryRunAll)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://spark.kubeflow.org/en/latest/contributor-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

This backports #3043 to 2.5.2 to address a CVE.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
