### PR TITLE
fix: remove unused Provider.TLSConfig() method

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -19,7 +19,6 @@ package certificate
 import (
 	"context"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -203,29 +202,6 @@ func (cp *Provider) ServerCert() ([]byte, error) {
 		Bytes: cp.serverCert.Raw,
 	})
 	return data, nil
-}
-
-// TLSConfig returns the TLS configuration.
-func (cp *Provider) TLSConfig() (*tls.Config, error) {
-	keyPEMBlock, err := cp.ServerKey()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get server key: %v", err)
-	}
-
-	certPEMBlock, err := cp.ServerCert()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get server certificate: %v", err)
-	}
-
-	tlsCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate TLS certificate: %v", err)
-	}
-
-	cfg := &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-	}
-	return cfg, nil
 }
 
 // WriteFile saves the certificate and key to the given path.

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -74,11 +74,6 @@ var _ = Describe("Certificate Provider", func() {
 			Expect(serverCert).NotTo(BeEmpty())
 		})
 
-		It("Should generate new TLS config", func() {
-			cfg, err := cp.ServerCert()
-			Expect(err).To(BeNil())
-			Expect(cfg).NotTo(BeEmpty())
-		})
 	})
 
 	Context("The data of webhook secret is empty", func() {


### PR DESCRIPTION
## Purpose of this PR

Remove the unused `Provider.TLSConfig()` method from `pkg/certificate/certificate.go`.

**Proposed changes:**

- Remove `TLSConfig()` method that creates a bare `tls.Config` without honoring any TLS profile
- Remove the now-unused `crypto/tls` import

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

`TLSConfig()` was never called anywhere in the codebase. The webhook server uses file-based certs via controller-runtime's `CertDir`/`CertName`/`KeyName` options, not this method. The method creates a bare `tls.Config{Certificates: ...}` without setting `MinVersion`, `CipherSuites`, or `NextProtos`, which gets flagged by TLS compliance linters (tls-lint) as a hardcoded TLS config that doesn't honor the cluster security profile. Removing it eliminates the finding and reduces the certificate package's API surface.

Verified via `grep -rn '.TLSConfig()' --include='*.go'` across the entire repo: zero callers.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.