### PR TITLE
ci: add gh-workflow-approve workflow for /ok-to-test on fork PRs

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,0 +1,86 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Approve Workflow Runs
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test') || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Check if author is a Kubeflow GitHub member
+        id: membership-check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const username = context.payload.pull_request.user.login;
+            const org = context.repo.owner;
+            try {
+              const res = await github.rest.orgs.checkMembershipForUser({
+                org,
+                username
+              });
+              core.setOutput("is_member", true);
+            } catch (error) {
+              if (error.status === 404) {
+                // User is not a member
+                core.setOutput("is_member", false);
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Approve Pending Workflow Runs
+        if: steps.membership-check.outputs.is_member == 'true' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          retries: 3
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+            }
+
+            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
+
+            core.info(`Found ${runs.length} workflow runs that need approval`)
+            for (const run of runs) {
+              core.info(`Approving workflow run ${run.id}`)
+              const request = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }
+              await github.rest.actions.approveWorkflowRun(request)
+            }


### PR DESCRIPTION
## Purpose of this PR

Fork PRs to spark-operator require manual approval before GitHub Actions runs (e.g. Integration Test). Today that typically needs a maintainer with write access. This PR adds the same `gh-workflow-approve` workflow used in [kubeflow/trainer](https://github.com/kubeflow/trainer/blob/master/.github/workflows/gh-workflow-approve.yaml), so kubeflow org members can trigger CI on external PRs by commenting `/ok-to-test` or applying the `ok-to-test` label — without write access on the repo.

**Proposed changes:**

- Add `.github/workflows/gh-workflow-approve.yaml` to auto-approve pending workflow runs on fork PRs

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

External contributors and reviewers with read-only access cannot run Integration Test on fork PRs until a maintainer approves workflows. This workflow lets trusted kubeflow org members (or anyone who gets the `ok-to-test` label applied) unblock CI, matching the pattern already used in other kubeflow projects.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.